### PR TITLE
Fix mamba failing installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installing `MSS` from the `conda-forge` channel can be achieved by adding `conda
 
 Once the `conda-forge` channel has been enabled, `mss` can be installed with:
 
-    $ conda create -n mssenv python=3
+    $ conda create -n mssenv python=3.8
     $ conda activate mssenv
     $ conda install mamba
     $ mamba install mss


### PR DESCRIPTION
This fixes mamba failing to install mss, because there is currently no 3.9 build, discussed here: Open-MSS/MSS#613

Note: `mamba install mss python=3.8` caused other issues on my system (menuinst package missing), 
so `conda create -n mssenv python=3.8` was used instead.