### PR TITLE
Add simple testing action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,35 @@
+name: Pytest MSS
+
+on: [ push, pull_request ]
+
+jobs:
+  Test-MSS:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory, action
+        echo $CONDA/bin >> $GITHUB_PATH
+
+    - name: Setup Conda
+      run: |
+        conda config --add channels conda-forge
+        conda config --add channels defaults
+        conda create -n mssenv python=3
+
+    - name: Install MSS
+      run: |
+        source ${CONDA}/bin/activate mssenv
+        conda install mamba
+        mamba install --only-deps mss
+        conda install --file requirements.d/development.txt
+
+    - name: Test with pytest
+      run: |
+        source ${CONDA}/bin/activate mssenv
+        xvfb-run pytest mslib


### PR DESCRIPTION
Tests the code on each push and pull request. This partly covers what was talked about in this issue Open-MSS/MSS#619
If any test fails, this action will fail. This also doesn't cover flake8 as that is covered in a parallel other action.

Building the environment takes about 1:30 to 2 minutes, testing the code takes about 14 minutes.
So in total this action takes around 16 minutes to complete.
The environment building time might be slightly reduced by using docker images.