### PR TITLE
Config_editor dialog changed. Fixes #627

### DIFF
--- a/mslib/msui/editor.py
+++ b/mslib/msui/editor.py
@@ -50,6 +50,10 @@ class EditorMainWindow(QtWidgets.QMainWindow):
         # Could also use a QTextEdit and set self.editor.setAcceptRichText(False)
         self.editor = QtWidgets.QPlainTextEdit()
 
+        # Load existing mss_settings.json
+        readMe = open(MSS_CONFIG_PATH + "/mss_settings.json", 'r').read()
+        self.editor.insertPlainText(readMe)
+
         # Setup the QTextEdit editor configuration
         fixedfont = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont)
         fixedfont.setPointSize(12)

--- a/mslib/msui/editor.py
+++ b/mslib/msui/editor.py
@@ -214,7 +214,6 @@ class EditorMainWindow(QtWidgets.QMainWindow):
         self.editor.setLineWrapMode(1 if self.editor.lineWrapMode() == 0 else 0)
 
     def closeEvent(self, event):
-        # self.dialog_critical("If you changed the mss_settings.json please restart the gui")
         ret = QtWidgets.QMessageBox.critical(
             self, self.tr("Do you want to save the changes?"),
             self.tr("If you changed the mss_settings.json please restart the gui"),
@@ -222,7 +221,6 @@ class EditorMainWindow(QtWidgets.QMainWindow):
 
         if ret == QtWidgets.QMessageBox.Save:
             self.file_save()
-            print("File saved")
             event.accept()
         else:
             event.accept()

--- a/mslib/msui/editor.py
+++ b/mslib/msui/editor.py
@@ -210,4 +210,15 @@ class EditorMainWindow(QtWidgets.QMainWindow):
         self.editor.setLineWrapMode(1 if self.editor.lineWrapMode() == 0 else 0)
 
     def closeEvent(self, event):
-        self.dialog_critical("If you changed the mss_settings.json please restart the gui")
+        # self.dialog_critical("If you changed the mss_settings.json please restart the gui")
+        ret = QtWidgets.QMessageBox.critical(
+            self, self.tr("Do you want to save the changes?"),
+            self.tr("If you changed the mss_settings.json please restart the gui"),
+            QtWidgets.QMessageBox.Save | QtWidgets.QMessageBox.Ignore, QtWidgets.QMessageBox.Save)
+
+        if ret == QtWidgets.QMessageBox.Save:
+            self.file_save()
+            print("File saved")
+            event.accept()
+        else:
+            event.accept()

--- a/mslib/msui/mss_pyui.py
+++ b/mslib/msui/mss_pyui.py
@@ -414,6 +414,8 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
             # cleanup mscolab window
             if self.mscolab_window is not None:
                 self.mscolab_window.close()
+            if self.config_editor is not None:
+                self.config_editor.close()
             event.accept()
         else:
             event.ignore()
@@ -529,12 +531,7 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
         Returns:
 
         """
-        ret = QtWidgets.QMessageBox.warning(
-            self, self.tr("Mission Support System"),
-            self.tr("Opening a config file will reset application. Continue?"),
-            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
-        if ret == QtWidgets.QMessageBox.Yes:
-            self.config_editor = editor.EditorMainWindow(parent=self)
+        self.config_editor = editor.EditorMainWindow(parent=self)
 
     def open_flight_track(self):
         """Slot for the 'Open Flight Track' menu entry. Opens a QFileDialog and


### PR DESCRIPTION
New dialog box to check save/ignore on config_editor closing. If main window is closed before config_editor is closed, it asks if the config_editor contents should be saved/ignored. 