### PR TITLE
Editing mscolab Url must be blocked on connect #637

### DIFF
--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -164,7 +164,6 @@ class MSSMscolabWindow(QtWidgets.QMainWindow, ui.Ui_MSSMscolabWindow):
         self.addUser.setEnabled(False)
         self.connectMscolab.setEnabled(True)
         self.url.setEnabled(True)
-        self.url.setEditable(True)
         # set mscolab_server_url to None
         self.mscolab_server_url = None
 
@@ -188,7 +187,6 @@ class MSSMscolabWindow(QtWidgets.QMainWindow, ui.Ui_MSSMscolabWindow):
                 # enable and disable right buttons
                 self.loginButton.setEnabled(True)
                 self.addUser.setEnabled(True)
-                self.url.setEditable(False)
                 self.url.setEnabled(False)
                 self.disconnectMscolab.setEnabled(True)
                 self.connectMscolab.setEnabled(False)

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -163,6 +163,8 @@ class MSSMscolabWindow(QtWidgets.QMainWindow, ui.Ui_MSSMscolabWindow):
         self.loginButton.setEnabled(False)
         self.addUser.setEnabled(False)
         self.connectMscolab.setEnabled(True)
+        self.url.setEnabled(True)
+        self.url.setEditable(True)
         # set mscolab_server_url to None
         self.mscolab_server_url = None
 
@@ -186,6 +188,8 @@ class MSSMscolabWindow(QtWidgets.QMainWindow, ui.Ui_MSSMscolabWindow):
                 # enable and disable right buttons
                 self.loginButton.setEnabled(True)
                 self.addUser.setEnabled(True)
+                self.url.setEditable(False)
+                self.url.setEnabled(False)
                 self.disconnectMscolab.setEnabled(True)
                 self.connectMscolab.setEnabled(False)
                 if self.mscolab_server_url not in self.settings["server_settings"].keys():


### PR DESCRIPTION
Disabled editing of the mscolab url on connecting, also disabled drop down. Enabled it again on clicking disconnect.