### PR TITLE
new optional parameter for pytest --mss_settings / improving config_loader

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -40,6 +40,19 @@ import fs
 from mslib.mswms.demodata import DataFiles
 import mslib._tests.constants as constants
 
+
+def pytest_addoption(parser):
+    parser.addoption("--mss_settings", action="store")
+
+
+def pytest_generate_tests(metafunc):
+    option_value = metafunc.config.option.mss_settings
+    if option_value is not None:
+        mss_settings_file_fs = fs.open_fs(constants.MSS_CONFIG_PATH)
+        mss_settings_file_fs.writetext("mss_settings.json", option_value)
+        mss_settings_file_fs.close()
+
+
 if os.getenv("TESTS_VISIBLE") == "TRUE":
     Display = None
 else:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -213,15 +213,8 @@ facilitating collaboration on campaigns. To enable this feature apply
     "filepicker_default": "fs",
 
 to your configuration file. The allowed values are "qt" for QT-based dialogues, "fs" for
-fsfile_picker-based dialogues supporting remote locations, or "default" for the default
+fs_file_picker-based dialogues supporting remote locations, or "default" for the default
 dialogues. The default is currently identical to "qt", but may change in upcoming releases.
-The dialogues may also be configured more fine grained with the parameters of
-'filepicker_flightrack for saving and loading flight tracks,
-'filepicker_matplotlib' for saving figures, "filepicker_config" for loading json configuration
-files, "filepicker_performance" for loading performance data, "filepicker_satellitetrack" for 
-loading satellite track data, and "filepicker_trajectories" for loading data in the
-trajectory tool. Additionally, the dialogue type may be configured for each export/import plugin
-individually by a fourth, optional, parameter.
 
 data dir
 ~~~~~~~~

--- a/mslib/_tests/constants.py
+++ b/mslib/_tests/constants.py
@@ -47,7 +47,8 @@ if not ROOT_FS.exists("mss/testdata"):
 SERVER_CONFIG_FS = fs.open_fs(os.path.join(ROOT_DIR, "mss"))
 DATA_FS = fs.open_fs(os.path.join(ROOT_DIR, "mss/testdata"))
 
-os.environ["MSS_CONFIG_PATH"] = SERVER_CONFIG_FS.root_path
+MSS_CONFIG_PATH = SERVER_CONFIG_FS.root_path
+os.environ["MSS_CONFIG_PATH"] = MSS_CONFIG_PATH
 SERVER_CONFIG_FILE_PATH = os.path.join(SERVER_CONFIG_FS.root_path, SERVER_CONFIG_FILE)
 
 # we keep DATA_DIR until we move netCDF4 files to pyfilesystem2

--- a/mslib/_tests/test_utils.py
+++ b/mslib/_tests/test_utils.py
@@ -120,7 +120,7 @@ class TestConfigLoader(object):
         assert num_labels == 10
         # this overwrites the builtin default value
         num_labels = utils.config_loader(config_file=config_file, dataset="num_labels", default=11)
-        assert num_labels == 11
+        assert num_labels == 10
         with pytest.raises(KeyError):
             utils.config_loader(config_file=config_file, dataset="UNDEFINED")
         with pytest.raises(KeyError):
@@ -161,7 +161,7 @@ class TestConfigLoader(object):
         assert num_labels == 10
         # this overwrites the given value
         num_labels = utils.config_loader(config_file=config_file, dataset="num_labels", default=11)
-        assert num_labels == 11
+        assert num_labels == 10
         with pytest.raises(KeyError):
             utils.config_loader(config_file=config_file, dataset="UNDEFINED")
         with pytest.raises(KeyError):

--- a/mslib/_tests/test_utils.py
+++ b/mslib/_tests/test_utils.py
@@ -32,6 +32,7 @@ from mslib import utils
 import multidict
 import werkzeug
 from mslib._tests.constants import MSS_CONFIG_PATH
+from mslib._tests.utils import create_mss_settings_file
 
 
 class TestParseTime(object):
@@ -63,6 +64,9 @@ class TestConfigLoader(object):
     """
     tests config file for client
     """
+    def teardown(self):
+         if fs.open_fs(MSS_CONFIG_PATH).exists("mss_settings.json"):
+             fs.open_fs(MSS_CONFIG_PATH).remove("mss_settings.json")
 
     def test_default_config(self):
         data = utils.config_loader()
@@ -101,11 +105,9 @@ class TestConfigLoader(object):
 
     def test_existing_empty_config_file(self):
         """
-        pytest -k  test_existing_empty_config_file --mss_settings {}
-
         on a user defined empty mss_settings_json this test should return the default value for num_labels
-
         """
+        create_mss_settings_file('{ }')
         if not fs.open_fs(MSS_CONFIG_PATH).exists("mss_settings.json"):
             pytest.skip('undefined test mss_settings.json')
         with fs.open_fs(MSS_CONFIG_PATH) as file_dir:
@@ -126,10 +128,9 @@ class TestConfigLoader(object):
 
     def test_existing_config_file_different_parameters(self):
         """
-        pytest -k test_existing_config_file_different_parameters --mss_settings '{"num_interpolation_points": 201 }'
-
         on a user defined mss_settings_json without a defined num_labels this test should return its default value
         """
+        create_mss_settings_file('{"num_interpolation_points": 201 }')
         if not fs.open_fs(MSS_CONFIG_PATH).exists("mss_settings.json"):
             pytest.skip('undefined test mss_settings.json')
         with fs.open_fs(MSS_CONFIG_PATH) as file_dir:
@@ -147,11 +148,9 @@ class TestConfigLoader(object):
 
     def test_existing_config_file_defined_parameters(self):
         """
-        pytest -k test_existing_config_file_defined_parameters --mss_settings \
-        '{"num_interpolation_points": 201, "num_labels": 10 }'
-
         on a user defined mss_settings_json without a defined num_labels this test should return its default value
         """
+        create_mss_settings_file('{"num_interpolation_points": 201, "num_labels": 10 }')
         if not fs.open_fs(MSS_CONFIG_PATH).exists("mss_settings.json"):
             pytest.skip('undefined test mss_settings.json')
         with fs.open_fs(MSS_CONFIG_PATH) as file_dir:

--- a/mslib/_tests/test_utils.py
+++ b/mslib/_tests/test_utils.py
@@ -26,10 +26,12 @@
 """
 import pytest
 import os
+import fs
 import datetime
 from mslib import utils
 import multidict
 import werkzeug
+from mslib._tests.constants import MSS_CONFIG_PATH
 
 
 class TestParseTime(object):
@@ -95,6 +97,14 @@ class TestConfigLoader(object):
             config_file = os.path.join(utils_path, '../', 'docs', 'samples', 'config', 'mss',
                                        'not_existing_mss_settings.json.sample')
             _ = utils.config_loader(config_file=config_file)
+
+    def test_existing_empty_config_file(self):
+        if not fs.open_fs(MSS_CONFIG_PATH).exists("mss_settings.json"):
+            pytest.skip('undefined test mss_settings.json')
+        config_file = fs.path.join(MSS_CONFIG_PATH, "mss_settings.json")
+        data = utils.config_loader(config_file=config_file)
+        assert isinstance(data, dict)
+        assert data["num_labels"] == 10
 
 
 class TestGetDistance(object):

--- a/mslib/_tests/test_utils.py
+++ b/mslib/_tests/test_utils.py
@@ -78,16 +78,13 @@ class TestConfigLoader(object):
         data = utils.config_loader(dataset="num_labels")
         assert data == 10
         # defined value and not a default one
-        data = utils.config_loader(dataset="num_labels", default=5)
+        data = utils.config_loader(dataset="num_labels")
         assert data == 10
-        # default for non existing entry
-        data = utils.config_loader(dataset="foobar", default=5)
-        assert data == 5
 
     def test_default_config_wrong_file(self):
         # return default if no access to config file given
-        data = utils.config_loader(config_file="foo.json", default={"foo": "123"})
-        assert data == {"foo": "123"}
+        with pytest.raises(utils.FatalUserError):
+            data = utils.config_loader(config_file="foo.json")
 
     def test_sample_config_file(self):
         utils_path = os.path.dirname(os.path.abspath(utils.__file__))
@@ -97,8 +94,8 @@ class TestConfigLoader(object):
         with pytest.raises(KeyError):
             utils.config_loader(config_file=config_file, dataset="UNDEFINED")
         with pytest.raises(KeyError):
-            assert utils.config_loader(config_file=config_file, dataset="UNDEFINED", default=9)
-        with pytest.raises(IOError):
+            assert utils.config_loader(config_file=config_file, dataset="UNDEFINED")
+        with pytest.raises(utils.FatalUserError):
             config_file = os.path.join(utils_path, '../', 'docs', 'samples', 'config', 'mss',
                                        'not_existing_mss_settings.json.sample')
             _ = utils.config_loader(config_file=config_file)
@@ -119,12 +116,12 @@ class TestConfigLoader(object):
         num_labels = utils.config_loader(config_file=config_file, dataset="num_labels")
         assert num_labels == 10
         # this overwrites the builtin default value
-        num_labels = utils.config_loader(config_file=config_file, dataset="num_labels", default=11)
+        num_labels = utils.config_loader(config_file=config_file, dataset="num_labels")
         assert num_labels == 10
         with pytest.raises(KeyError):
             utils.config_loader(config_file=config_file, dataset="UNDEFINED")
         with pytest.raises(KeyError):
-            assert utils.config_loader(config_file=config_file, dataset="UNDEFINED", default=9)
+            assert utils.config_loader(config_file=config_file, dataset="UNDEFINED")
 
     def test_existing_config_file_different_parameters(self):
         """
@@ -144,7 +141,7 @@ class TestConfigLoader(object):
         with pytest.raises(KeyError):
             utils.config_loader(config_file=config_file, dataset="UNDEFINED")
         with pytest.raises(KeyError):
-            assert utils.config_loader(config_file=config_file, dataset="UNDEFINED", default=9)
+            assert utils.config_loader(config_file=config_file, dataset="UNDEFINED")
 
     def test_existing_config_file_defined_parameters(self):
         """
@@ -160,12 +157,12 @@ class TestConfigLoader(object):
         num_labels = utils.config_loader(config_file=config_file, dataset="num_labels")
         assert num_labels == 10
         # this overwrites the given value
-        num_labels = utils.config_loader(config_file=config_file, dataset="num_labels", default=11)
+        num_labels = utils.config_loader(config_file=config_file, dataset="num_labels")
         assert num_labels == 10
         with pytest.raises(KeyError):
             utils.config_loader(config_file=config_file, dataset="UNDEFINED")
         with pytest.raises(KeyError):
-            assert utils.config_loader(config_file=config_file, dataset="UNDEFINED", default=9)
+            assert utils.config_loader(config_file=config_file, dataset="UNDEFINED")
 
 class TestGetDistance(object):
     """

--- a/mslib/_tests/test_utils.py
+++ b/mslib/_tests/test_utils.py
@@ -123,11 +123,11 @@ class TestConfigLoader(object):
         with pytest.raises(KeyError):
             assert utils.config_loader(config_file=config_file, dataset="UNDEFINED")
 
-    def test_existing_config_file_different_parameters(self):
+    def  test_existing_config_file_different_parameters(self):
         """
         on a user defined mss_settings_json without a defined num_labels this test should return its default value
         """
-        create_mss_settings_file('{"num_interpolation_points": 201 }')
+        create_mss_settings_file('{"num_interpolation_points": 20 }')
         if not fs.open_fs(MSS_CONFIG_PATH).exists("mss_settings.json"):
             pytest.skip('undefined test mss_settings.json')
         with fs.open_fs(MSS_CONFIG_PATH) as file_dir:
@@ -138,6 +138,10 @@ class TestConfigLoader(object):
         assert data["num_labels"] == 10
         num_labels = utils.config_loader(config_file=config_file, dataset="num_labels")
         assert num_labels == 10
+        num_interpolation_points = utils.config_loader(config_file=config_file, dataset="num_interpolation_points")
+        assert num_interpolation_points == 20
+        data = utils.config_loader(config_file=config_file)
+        assert data["num_interpolation_points"] == 20
         with pytest.raises(KeyError):
             utils.config_loader(config_file=config_file, dataset="UNDEFINED")
         with pytest.raises(KeyError):

--- a/mslib/_tests/test_utils.py
+++ b/mslib/_tests/test_utils.py
@@ -99,11 +99,35 @@ class TestConfigLoader(object):
             _ = utils.config_loader(config_file=config_file)
 
     def test_existing_empty_config_file(self):
+        """
+        pytest -k  test_existing_empty_config_file --mss_settings {}
+
+        on a user defined empty mss_settings_json this test should return the default value for num_labels
+
+        """
         if not fs.open_fs(MSS_CONFIG_PATH).exists("mss_settings.json"):
             pytest.skip('undefined test mss_settings.json')
         config_file = fs.path.join(MSS_CONFIG_PATH, "mss_settings.json")
         data = utils.config_loader(config_file=config_file)
         assert isinstance(data, dict)
+        assert len(data) == 0
+        assert data["num_labels"] == 10
+
+    def test_existing_config_file_different_parameters(self):
+        """
+        pytest -k test_existing_config_file_different_parameters --mss_settings '{"num_interpolation_points": 201 }'
+
+        on a user defined mss_settings_json without a defined num_labels this test should return its default value
+        """
+        if not fs.open_fs(MSS_CONFIG_PATH).exists("mss_settings.json"):
+            pytest.skip('undefined test mss_settings.json')
+        with fs.open_fs(MSS_CONFIG_PATH) as file_dir:
+            file_content = file_dir.readtext("mss_settings.json")
+        assert "num_labels" not in file_content
+        config_file = fs.path.join(MSS_CONFIG_PATH, "mss_settings.json")
+        data = utils.config_loader(config_file=config_file)
+        assert isinstance(data, dict)
+        assert len(data) > 0
         assert data["num_labels"] == 10
 
 

--- a/mslib/_tests/utils.py
+++ b/mslib/_tests/utils.py
@@ -25,9 +25,11 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import fs
 from werkzeug.urls import url_join
 from mslib.mscolab.server import register_user
 from flask import json
+from mslib._tests.constants import MSS_CONFIG_PATH
 
 
 def callback_ok_image(status, response_headers):
@@ -149,3 +151,8 @@ def mscolab_get_project_id(app, msc_url, email, password, username, path):
     for p in response['projects']:
         if p['path'] == path:
             return p['p_id']
+
+
+def create_mss_settings_file(content):
+    with fs.open_fs(MSS_CONFIG_PATH) as file_dir:
+        file_dir.writetext("mss_settings.json", content)

--- a/mslib/msui/__init__.py
+++ b/mslib/msui/__init__.py
@@ -108,8 +108,16 @@ class MissionSupportSystemDefaultConfig(object):
         "http://localhost:8083",
     ]
 
+    MSCOLAB_mailid = ""
+    MSCOLAB_password = ""
+    MSC_login = {}
+
     # timeout of Url request
     WMS_request_timeout = 30
+
+    WMS_preload = []
+
+    WMS_login = {}
 
     # WMS image cache settings:
     wms_cache = os.path.join(tempfile.gettempdir(), "msui_wms_cache")
@@ -166,3 +174,7 @@ class MissionSupportSystemDefaultConfig(object):
     # ToDo refactor to rename this to data_dir/mss_data_dir
     # mss dir
     mss_dir = "~/mss"
+
+
+    export_plugins = {}
+    import_plugins = {}

--- a/mslib/msui/__init__.py
+++ b/mslib/msui/__init__.py
@@ -108,8 +108,13 @@ class MissionSupportSystemDefaultConfig(object):
         "http://localhost:8083",
     ]
 
+    # mail address to sign in
     MSCOLAB_mailid = ""
+
+    # password to sign in
     MSCOLAB_password = ""
+
+    # dictionary of MSC servers {"http://www.your-mscolab-server.de" : ("youruser", "yourpassword")]
     MSC_login = {}
 
     # timeout of Url request
@@ -117,6 +122,7 @@ class MissionSupportSystemDefaultConfig(object):
 
     WMS_preload = []
 
+    # dictionary of WMS servers {"http://www.your-wms-server.de" : ("youruser", "yourpassword")]
     WMS_login = {}
 
     # WMS image cache settings:
@@ -124,6 +130,7 @@ class MissionSupportSystemDefaultConfig(object):
 
     # Maximum size of the cache in bytes.
     wms_cache_max_size_bytes = 20 * 1024 * 1024
+
     # Maximum age of a cached file in seconds.
     wms_cache_max_age_seconds = 5 * 86400
 
@@ -175,6 +182,8 @@ class MissionSupportSystemDefaultConfig(object):
     # mss dir
     mss_dir = "~/mss"
 
-
+    # dictionary for export plugins, e.g.  {"Text": ["txt", "mslib.plugins.io.text", "save_to_txt"] }
     export_plugins = {}
+
+    # dictionary for import plugins, e.g. { "FliteStar": ["txt", "mslib.plugins.io.flitestar", "load_from_flitestar"] }
     import_plugins = {}

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -97,7 +97,7 @@ class Waypoint(object):
 
     def __init__(self, lat=0, lon=0, flightlevel=0, location="", comments=""):
         self.location = location
-        locations = config_loader(dataset='locations', default=mss_default.locations)
+        locations = config_loader(dataset='locations')
         if location in locations:
             self.lat, self.lon = locations[location]
         else:
@@ -662,7 +662,7 @@ class WaypointDelegate(QtWidgets.QItemDelegate):
         """
         if index.column() == LOCATION:
             combobox = QtWidgets.QComboBox(parent)
-            locations = config_loader(dataset='locations', default=mss_default.locations)
+            locations = config_loader(dataset='locations')
             adds = list(locations.keys())
             if self.parent() is not None:
                 for loc in [wp.location for wp in self.parent().waypoints_model.all_waypoint_data() if
@@ -693,7 +693,7 @@ class WaypointDelegate(QtWidgets.QItemDelegate):
         """
         if index.column() == LOCATION:
             loc = editor.currentText()
-            locations = config_loader(dataset='locations', default=mss_default.locations)
+            locations = config_loader(dataset='locations')
             if loc in locations:
                 lat, lon = locations[loc]
                 # Don't update distances and flight performance twice, hence

--- a/mslib/msui/hexagon_dockwidget.py
+++ b/mslib/msui/hexagon_dockwidget.py
@@ -95,8 +95,7 @@ class HexagonControlWidget(QtWidgets.QWidget, ui.Ui_HexagonDockWidget):
         index = table_view.currentIndex()
         if not index.isValid():
             row = 0
-            flightlevel = config_loader(dataset="new_flighttrack_flightlevel",
-                                        default=mss_default.new_flighttrack_flightlevel)
+            flightlevel = config_loader(dataset="new_flighttrack_flightlevel")
         else:
             row = index.row() + 1
             flightlevel = waypoints_model.waypoint_data(row - 1).flightlevel

--- a/mslib/msui/mpl_qtwidget.py
+++ b/mslib/msui/mpl_qtwidget.py
@@ -51,7 +51,7 @@ from PyQt5 import QtCore, QtWidgets, QtGui
 from mslib.utils import convert_pressure_to_vertical_axis_measure
 
 PIL_IMAGE_ORIGIN = "upper"
-LAST_SAVE_DIRECTORY = config_loader(dataset="data_dir", default=mss_default.data_dir)
+LAST_SAVE_DIRECTORY = config_loader(dataset="data_dir")
 
 matplotlib.rcParams['savefig.directory'] = LAST_SAVE_DIRECTORY
 
@@ -168,10 +168,7 @@ save_figure_original = NavigationToolbar2QT.save_figure
 
 
 def save_figure(self, *args):
-    picker_default = config_loader(dataset="filepicker_default",
-                                   default=mss_default.filepicker_default)
-    picker_type = config_loader(dataset="filepicker_matplotlib",
-                                default=picker_default)
+    picker_type = config_loader(dataset="filepicker_default")
     if picker_type in ["default", "qt"]:
         save_figure_original(self, *args)
     elif picker_type == "fs":
@@ -451,7 +448,7 @@ class MplSideViewCanvas(MplCanvas):
         model -- WaypointsTableModel defining the vertical section.
         """
         if numlabels is None:
-            numlabels = config_loader(dataset='num_labels', default=mss_default.num_labels)
+            numlabels = config_loader(dataset='num_labels')
         super(MplSideViewCanvas, self).__init__()
 
         # Default settings.
@@ -504,8 +501,7 @@ class MplSideViewCanvas(MplCanvas):
             # itself to the change() signals of the flight track data model.
             self.waypoints_interactor = mpl_pi.VPathInteractor(
                 self.ax, self.waypoints_model,
-                numintpoints=config_loader(dataset="num_interpolation_points",
-                                           default=mss_default.num_interpolation_points),
+                numintpoints=config_loader(dataset="num_interpolation_points"),
                 redraw_xaxis=self.redraw_xaxis, clear_figure=self.clear_figure
             )
 

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -144,11 +144,11 @@ class MSSMscolabWindow(QtWidgets.QMainWindow, ui.Ui_MSSMscolabWindow):
         self.url.setModel(MSCOLAB_URL_LIST)
         # fill value of mscolab url from config
         default_MSCOLAB = config_loader(
-            dataset="default_MSCOLAB", default=mss_default.default_MSCOLAB)
+            dataset="default_MSCOLAB")
         add_mscolab_urls(self.url, default_MSCOLAB)
 
-        self.emailid.setText(config_loader(dataset="MSCOLAB_mailid", default=""))
-        self.password.setText(config_loader(dataset="MSCOLAB_password", default=""))
+        self.emailid.setText(config_loader(dataset="MSCOLAB_mailid"))
+        self.password.setText(config_loader(dataset="MSCOLAB_password"))
 
         # fill value of mscolab url if found in QSettings storage
         self.settings = \
@@ -355,7 +355,7 @@ class MSSMscolabWindow(QtWidgets.QMainWindow, ui.Ui_MSSMscolabWindow):
         self.user_diag.show()
 
     def add_user(self):
-        for key, value in config_loader(dataset="MSC_login", default={}).items():
+        for key, value in config_loader(dataset="MSC_login").items():
             if key not in constants.MSC_LOGIN_CACHE:
                 constants.MSC_LOGIN_CACHE[key] = value
         auth = constants.MSC_LOGIN_CACHE.get(self.mscolab_server_url, (None, None))
@@ -522,7 +522,7 @@ class MSSMscolabWindow(QtWidgets.QMainWindow, ui.Ui_MSSMscolabWindow):
         self.reload_view_windows()
 
     def authorize(self):
-        for key, value in config_loader(dataset="MSC_login", default={}).items():
+        for key, value in config_loader(dataset="MSC_login").items():
             if key not in constants.MSC_LOGIN_CACHE:
                 constants.MSC_LOGIN_CACHE[key] = value
         auth = constants.MSC_LOGIN_CACHE.get(self.mscolab_server_url, (None, None))

--- a/mslib/msui/mscolab_admin_window.py
+++ b/mslib/msui/mscolab_admin_window.py
@@ -39,7 +39,7 @@ class MSColabAdminWindow(QtWidgets.QMainWindow, ui.Ui_MscolabAdminWindow):
     viewCloses = QtCore.pyqtSignal(name="viewCloses")
 
     def __init__(self, token, p_id, user, project_name, projects, conn, parent=None,
-                 mscolab_server_url=config_loader(dataset="default_MSCOLAB", default=mss_default.default_MSCOLAB)):
+                 mscolab_server_url=config_loader(dataset="default_MSCOLAB")):
         """
         token: access token
         p_id: project id

--- a/mslib/msui/mscolab_project.py
+++ b/mslib/msui/mscolab_project.py
@@ -70,7 +70,7 @@ class MSColabProjectWindow(QtWidgets.QMainWindow, ui.Ui_MscolabProject):
     reloadWindows = QtCore.pyqtSignal(name="reloadWindows")
 
     def __init__(self, token, p_id, user, project_name, access_level, conn, parent=None,
-                 mscolab_server_url=config_loader(dataset="default_MSCOLAB", default=mss_default.default_MSCOLAB)):
+                 mscolab_server_url=config_loader(dataset="default_MSCOLAB")):
         """
         token: access_token
         p_id: project id

--- a/mslib/msui/mscolab_version_history.py
+++ b/mslib/msui/mscolab_version_history.py
@@ -47,7 +47,7 @@ class MSColabVersionHistory(QtWidgets.QMainWindow, ui.Ui_MscolabVersionHistory):
     reloadWindows = QtCore.pyqtSignal(name="reloadWindows")
 
     def __init__(self, token, p_id, user, project_name, conn, parent=None,
-                 mscolab_server_url=config_loader(dataset="default_MSCOLAB", default=mss_default.default_MSCOLAB)):
+                 mscolab_server_url=config_loader(dataset="default_MSCOLAB")):
         """
         token: access_token
         p_id: project id

--- a/mslib/msui/mss_pyui.py
+++ b/mslib/msui/mss_pyui.py
@@ -170,7 +170,7 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
         # Reference to the flight track that is currently displayed in the
         # views.
         self.active_flight_track = None
-        self.last_save_directory = config_loader(dataset="data_dir", default=mss_default.data_dir)
+        self.last_save_directory = config_loader(dataset="data_dir")
         self.mscolab_window = None
         self.config_editor = None
 
@@ -206,13 +206,13 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
         # Views.
         self.listViews.itemActivated.connect(self.activate_sub_window)
 
-        self.add_import_filter("CSV", "csv", load_from_csv, pickertag="filepicker_flightrack")
-        self.add_export_filter("CSV", "csv", save_to_csv, pickertag="filepicker_flightrack")
+        self.add_import_filter("CSV", "csv", load_from_csv, pickertag="filepicker_default")
+        self.add_export_filter("CSV", "csv", save_to_csv, pickertag="filepicker_default")
 
         self._imported_plugins, self._exported_plugins = {}, {}
         self.add_plugins()
 
-        preload_urls = config_loader(dataset="WMS_preload", default=[])
+        preload_urls = config_loader(dataset="WMS_preload")
         self.preload_wms(preload_urls)
 
         # Status Bar
@@ -234,7 +234,7 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
             pdlg.setValue(i)
             QtWidgets.QApplication.processEvents()
             # initialize login cache from config file, but do not overwrite existing keys
-            for key, value in config_loader(dataset="WMS_login", default={}).items():
+            for key, value in config_loader(dataset="WMS_login").items():
                 if key not in constants.WMS_LOGIN_CACHE:
                     constants.WMS_LOGIN_CACHE[key] = value
             username, password = constants.WMS_LOGIN_CACHE.get(base_url, (None, None))
@@ -256,9 +256,9 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
 
     def add_plugins(self):
         picker_default = config_loader(
-            dataset="filepicker_default", default=mss_default.filepicker_default)
+            dataset="filepicker_default")
 
-        self._imported_plugins = config_loader(dataset="import_plugins", default={})
+        self._imported_plugins = config_loader(dataset="import_plugins")
         for name in self._imported_plugins:
             extension, module, function = self._imported_plugins[name][:3]
             picker_type = picker_default
@@ -285,7 +285,7 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
                         self._imported_plugins, type(ex), ex)))
                 continue
 
-        self._exported_plugins = config_loader(dataset="export_plugins", default={})
+        self._exported_plugins = config_loader(dataset="export_plugins")
         for name in self._exported_plugins:
             extension, module, function = self._exported_plugins[name][:3]
             picker_type = picker_default
@@ -425,7 +425,7 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
            a new instance of the view and adds a QActiveViewsListWidgetItem to
            the list of open views (self.listViews).
         """
-        layout = config_loader(dataset="layout", default=mss_default.layout)
+        layout = config_loader(dataset="layout")
         view_window = None
         if self.sender() == self.actionTopView:
             # Top view.
@@ -495,9 +495,8 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
         """
         if template is None:
             template = []
-            waypoints = config_loader(dataset="new_flighttrack_template", default=mss_default.new_flighttrack_template)
-            default_flightlevel = config_loader(dataset="new_flighttrack_flightlevel",
-                                                default=mss_default.new_flighttrack_flightlevel)
+            waypoints = config_loader(dataset="new_flighttrack_template")
+            default_flightlevel = config_loader(dataset="new_flighttrack_flightlevel")
             for wp in waypoints:
                 template.append(ft.Waypoint(flightlevel=default_flightlevel, location=wp))
             if len(template) < 2:
@@ -539,7 +538,7 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
         """
         filename = get_open_filename(
             self, "Open Flight Track", self.last_save_directory, "Flight Track Files (*.ftml)",
-            pickertag="filepicker_flightrack")
+            pickertag="filepicker_default")
         if filename is not None:
             try:
                 if filename.endswith('.ftml'):
@@ -603,7 +602,7 @@ class MSSMainWindow(QtWidgets.QMainWindow, ui.Ui_MSSMainWindow):
         """
         default_filename = os.path.join(self.last_save_directory, self.active_flight_track.name + ".ftml")
         filename = get_save_filename(
-            self, "Save Flight Track", default_filename, "Flight Track (*.ftml)", pickertag="filepicker_flightrack")
+            self, "Save Flight Track", default_filename, "Flight Track (*.ftml)", pickertag="filepicker_default")
         logging.debug("filename : '%s'", filename)
         if filename:
             self.last_save_directory = fs.path.dirname(filename)

--- a/mslib/msui/mss_qt.py
+++ b/mslib/msui/mss_qt.py
@@ -63,12 +63,12 @@ def get_existing_directory_qt(*args):
 
 
 def get_pickertype(tag, typ):
-    default = config_loader(dataset="filepicker_default", default=mss_default.filepicker_default)
+    default = config_loader(dataset="filepicker_default")
     if typ is None:
         if tag is None:
             typ = default
         else:
-            typ = config_loader(dataset=tag, default=default)
+            typ = config_loader(dataset=tag)
     return typ
 
 

--- a/mslib/msui/performance_settings.py
+++ b/mslib/msui/performance_settings.py
@@ -90,7 +90,7 @@ class MSS_PerformanceSettingsDialog(QtWidgets.QDialog, ui_ps.Ui_PerformanceSetti
         """
         filename = get_open_filename(
             self, "Open Aircraft Performance JSON File", constants.MSS_CONFIG_PATH,
-            "Performance File (*.json)", pickertag="filepicker_performance")
+            "Performance File (*.json)", pickertag="filepicker_default")
         if filename is not None:
             try:
                 performance = config_loader(config_file=filename)

--- a/mslib/msui/satellite_dockwidget.py
+++ b/mslib/msui/satellite_dockwidget.py
@@ -136,7 +136,7 @@ class SatelliteControlWidget(QtWidgets.QWidget, ui.Ui_SatelliteDockWidget):
         filename = get_open_filename(
             self, "Open NASA satellite overpass prediction",
             os.path.join(os.path.dirname(self.leFile.text())), "All Files (*)",
-            pickertag="filepicker_satellitetrack")
+            pickertag="filepicker_default")
         if not filename:
             return
         self.leFile.setText(filename)

--- a/mslib/msui/sideview.py
+++ b/mslib/msui/sideview.py
@@ -289,12 +289,10 @@ class MSSSideViewWindow(MSSMplViewWindow, ui.Ui_SideViewWindow):
                 # Open a WMS control widget.
                 title = "Web Service Plot Control"
                 widget = wms.VSecWMSControlWidget(
-                    default_WMS=config_loader(dataset="default_VSEC_WMS",
-                                              default=mss_default.default_VSEC_WMS),
+                    default_WMS=config_loader(dataset="default_VSEC_WMS"),
                     waypoints_model=self.waypoints_model,
                     view=self.mpl.canvas,
-                    wms_cache=config_loader(dataset="wms_cache",
-                                            default=mss_default.wms_cache))
+                    wms_cache=config_loader(dataset="wms_cache"))
                 self.mpl.canvas.waypoints_interactor.signal_get_vsec.connect(widget.call_get_vsec)
             else:
                 raise IndexError("invalid control index")

--- a/mslib/msui/topview.py
+++ b/mslib/msui/topview.py
@@ -224,7 +224,7 @@ class MSSTopViewWindow(MSSMplViewWindow, ui.Ui_TopViewWindow):
     def update_predefined_maps(self, extra=None):
         self.cbChangeMapSection.clear()
         predefined_map_sections = config_loader(
-            dataset="predefined_map_sections", default=mss_default.predefined_map_sections)
+            dataset="predefined_map_sections")
         self.cbChangeMapSection.addItems(sorted(predefined_map_sections.keys()))
         if extra is not None and len(extra) > 0:
             self.cbChangeMapSection.insertSeparator(self.cbChangeMapSection.count())
@@ -239,9 +239,9 @@ class MSSTopViewWindow(MSSMplViewWindow, ui.Ui_TopViewWindow):
                 # Create a new WMSDockWidget.
                 title = "Web Map Service (Top View)"
                 widget = wc.HSecWMSControlWidget(
-                    default_WMS=config_loader(dataset="default_WMS", default=mss_default.default_WMS),
+                    default_WMS=config_loader(dataset="default_WMS"),
                     view=self.mpl.canvas,
-                    wms_cache=config_loader(dataset="wms_cache", default=mss_default.wms_cache))
+                    wms_cache=config_loader(dataset="wms_cache"))
                 widget.signal_disable_cbs.connect(self.disable_cbs)
                 widget.signal_enable_cbs.connect(self.enable_cbs)
             elif index == SATELLITE:
@@ -273,7 +273,7 @@ class MSSTopViewWindow(MSSMplViewWindow, ui.Ui_TopViewWindow):
         # Get the initial projection parameters from the tables in mss_settings.
         current_map_key = self.cbChangeMapSection.currentText()
         predefined_map_sections = config_loader(
-            dataset="predefined_map_sections", default=mss_default.predefined_map_sections)
+            dataset="predefined_map_sections")
         current_map = predefined_map_sections.get(
             current_map_key, {"CRS": current_map_key, "map": {}})
         proj_params = get_projection_params(current_map["CRS"])

--- a/mslib/msui/wms_control.py
+++ b/mslib/msui/wms_control.py
@@ -195,7 +195,7 @@ class MSSWebMapService(mslib.ogcwms.WebMapService):
         # owslib.wms.ServiceException. However, openURL only checks for mime
         # types text/xml and application/xml. application/vnd.ogc.se_xml is
         # not considered. For some reason, the check below doesn't work, though..
-        proxies = config_loader(dataset="proxies", default=mss_default.proxies)
+        proxies = config_loader(dataset="proxies")
 
         u = openURL(base_url, data, method,
                     username=self.username, password=self.password, proxies=proxies)
@@ -547,7 +547,7 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
         """
         wms = None
         # initialize login cache fomr config file, but do not overwrite existing keys
-        for key, value in config_loader(dataset="WMS_login", default={}).items():
+        for key, value in config_loader(dataset="WMS_login").items():
             if key not in constants.WMS_LOGIN_CACHE:
                 constants.WMS_LOGIN_CACHE[key] = value
         username, password = constants.WMS_LOGIN_CACHE.get(base_url, (None, None))
@@ -1377,7 +1377,7 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
             # If caching is enabled, get the URL and check the image cache
             # directory for the suitable image file.
             if self.caching_enabled():
-                prefetch_config = config_loader(dataset="wms_prefetch", default=mss_default.wms_prefetch)
+                prefetch_config = config_loader(dataset="wms_prefetch")
                 prefetch_entries = ["validtime_fwd", "validtime_bck", "level_up", "level_down"]
                 for _x in prefetch_entries:
                     if _x in prefetch_config:
@@ -1497,10 +1497,8 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
         try:
             for f, fsize, fage in files:
                 cum_size_bytes += fsize
-                if (cum_size_bytes > config_loader(dataset="wms_cache_max_size_bytes",
-                                                   default=mss_default.wms_cache_max_size_bytes) or
-                        fage > config_loader(dataset="wms_cache_max_age_seconds",
-                                             default=mss_default.wms_cache_max_age_seconds)):
+                if (cum_size_bytes > config_loader(dataset="wms_cache_max_size_bytes") or
+                        fage > config_loader(dataset="wms_cache_max_age_seconds")):
                     os.remove(f)
                     removed_files += 1
         except (IOError, OSError) as ex:

--- a/mslib/ogcwms.py
+++ b/mslib/ogcwms.py
@@ -77,7 +77,7 @@ from mslib.utils import config_loader
 
 def openURL(url_base, data=None, method='Get', cookies=None,
             username=None, password=None,
-            timeout=config_loader(dataset="WMS_request_timeout", default=mss_default.WMS_request_timeout),
+            timeout=config_loader(dataset="WMS_request_timeout"),
             headers=None, proxies=None):
     # (mss) added proxies
     # (mss) timeout default of 30secs set by the config_loader
@@ -329,7 +329,7 @@ class WebMapService(object):
             request['time'] = str(time)
 
         data = urlencode(request)
-        proxies = config_loader(dataset="proxies", default=mss_default.proxies)
+        proxies = config_loader(dataset="proxies")
         u = openURL(base_url, data, method, username=self.username, password=self.password, proxies=proxies)
 
         # check for service exceptions, and return
@@ -602,7 +602,7 @@ class WMSCapabilitiesReader(object):
         """
         getcaprequest = self.capabilities_url(service_url)
 
-        proxies = config_loader(dataset="proxies", default=mss_default.proxies)
+        proxies = config_loader(dataset="proxies")
 
         # now split it up again to use the generic openURL function...
         spliturl = getcaprequest.split('?')

--- a/mslib/utils.py
+++ b/mslib/utils.py
@@ -28,13 +28,13 @@
 
 import datetime
 import isodate
-from fs import open_fs, errors
 import json
 import logging
 import netCDF4 as nc
 import numpy as np
 import os
 import pint
+from fs import open_fs, errors
 from scipy.interpolate import interp1d
 from scipy.ndimage import map_coordinates
 
@@ -86,93 +86,46 @@ class FatalUserError(Exception):
         logging.debug("%s", error_string)
 
 
-def config_loader(config_file=None, dataset=None, default=None):
+def config_loader(config_file=None, dataset=None):
     """
     Function for loading json config data
 
     Args:
         config_file: json file, parameters for initializing mss,
         dataset: section to pull from json file
-        default: values to return if dataset was requested and don't exist or config_file is not given
 
     Returns: a dictionary
 
     """
-    # ToDo Refactor this soon
-    if config_file is None:
-        config_file = constants.CACHED_CONFIG_FILE
-    if config_file is None:
-        logging.info(
-            'Default MSS configuration in place, no user settings, see http://mss.rtfd.io/en/stable/usage.html')
-        default_config = dict(MissionSupportSystemDefaultConfig.__dict__)
+    default_config = dict(MissionSupportSystemDefaultConfig.__dict__)
+    if config_file is None and dataset is None:
+        return default_config
+    if dataset is not None and dataset not in default_config:
+        raise KeyError(f"requested dataset '{dataset}' not in defaults or config_file")
+    if config_file is None and dataset is not None:
+        return default_config[dataset]
+    if config_file is not None:
+        _dirname, _name = os.path.split(config_file)
+        _fs = open_fs(_dirname)
+        try:
+            with _fs.open(_name, 'r') as source:
+                data = json.load(source)
+        except errors.ResourceNotFound:
+            error_message = f"MSS config File '{config_file}' not found"
+            raise FatalUserError(error_message)
+        except ValueError as ex:
+            error_message = f"MSS config File '{config_file}' has a syntax error:\n\n'{ex}'"
+            raise FatalUserError(error_message)
+        if len(data) == 0 and dataset is None:
+            return default_config
+        if len(data) == 0 and dataset is not None:
+            return default_config[dataset]
+        if dataset in data:
+            return data[dataset]
+        if dataset is not None and dataset not in data:
+            return default_config[dataset]
         if dataset is None:
             return default_config
-        else:
-            try:
-                return default_config[dataset]
-            except KeyError:
-                logging.debug("'%s' Key(s) are not defined!", dataset)
-                return default
-    _dirname, _name = os.path.split(config_file)
-    _fs = open_fs(_dirname)
-    try:
-        with _fs.open(_name, 'r') as source:
-            data = json.load(source)
-            if len(data) == 0:
-                # user defined empty dictionary, fallback to defaults
-                default_config = dict(MissionSupportSystemDefaultConfig.__dict__)
-                if dataset is not None:
-                    if dataset not in default_config:
-                        raise KeyError("requested dataset not in defaults or config_file")
-                    if dataset in default_config and default is not None:
-                        return default_config[dataset]
-                else:
-                     return default_config
-            else:
-                default_config = dict(MissionSupportSystemDefaultConfig.__dict__)
-                for key in data:
-                    try:
-                        default_config[key] = data[key]
-                    except KeyError:
-                        logging.debug("'%s' Key(s) are not defined!", key)
-                if dataset is not None:
-                    if dataset in default_config and default is None:
-                        return default_config[dataset]
-                    if dataset in default_config and default is not None:
-                        if dataset in data:
-                            return data[dataset]
-                        return default
-                    if dataset not in default_config:
-                        raise KeyError("requested dataset not in defaults or config_file")
-                return default_config
-
-
-    except (AttributeError, IOError, TypeError, errors.ResourceNotFound) as ex:
-        logging.error("MSS config File error '%s' - '%s' - '%s'", config_file, type(ex), ex)
-        if default is not None:
-            return default
-        raise IOError("MSS config File not found")
-    except ValueError as ex:
-        error_message = f"MSS config File '{config_file}' has a syntax error:\n\n'{ex}'"
-        raise FatalUserError(error_message)
-    if dataset:
-        try:
-            return data[dataset]
-        except KeyError:
-            logging.debug("Config File used: '%s'", config_file)
-            logging.debug("Key not defined in config_file! '%s'", dataset)
-            if default is not None:
-                return default
-            default_config = dict(MissionSupportSystemDefaultConfig.__dict__)
-            try:
-                return default_config[dataset]
-            except KeyError:
-                logging.debug("Key not defined in config_file! '%s' and not in defaults", dataset)
-                raise KeyError("requested dataset not in defaults or config_file")
-            raise KeyError("default value for key not set")
-
-    return data
-
 
 def get_distance(coord0, coord1):
     """
@@ -196,7 +149,7 @@ def find_location(lat, lon, tolerance=5):
     :param tolerance: maximum distance between location and coordinates in km
     :return: None or lat/lon, name
     """
-    locations = config_loader(dataset='locations', default=MissionSupportSystemDefaultConfig.locations)
+    locations = config_loader(dataset='locations')
     distances = sorted([(get_distance((lat, lon), (loc_lat, loc_lon)), loc)
                         for loc, (loc_lat, loc_lon) in locations.items()])
     if len(distances) > 0 and distances[0][0] <= tolerance:

--- a/mslib/utils.py
+++ b/mslib/utils.py
@@ -123,23 +123,28 @@ def config_loader(config_file=None, dataset=None):
 
     """
     default_config = dict(MissionSupportSystemDefaultConfig.__dict__)
-    if config_file is None and dataset is None:
-        return default_config
     if dataset is not None and dataset not in default_config:
         raise KeyError(f"requested dataset '{dataset}' not in defaults or config_file")
-    if config_file is None and dataset is not None:
-        return default_config[dataset]
+    if config_file is None:
+        if dataset is None:
+            return default_config
+        else:
+            return default_config[dataset]
     user_config = read_config_file(config_file)
-    if len(user_config) == 0 and dataset is None:
+    if dataset is not None:
+        if dataset not in user_config:
+            return default_config[dataset]
+        else:
+            return user_config[dataset]
+    else:
+        for key in user_config:
+            default_config[key] = user_config[key]
         return default_config
-    if len(user_config) == 0 and dataset is not None:
-        return default_config[dataset]
-    if dataset in user_config:
-        return user_config[dataset]
-    if dataset is not None and dataset not in user_config:
-        return default_config[dataset]
-    if dataset is None:
-        return default_config
+    if len(user_config) == 0:
+        if dataset is None:
+            return default_config
+        else:
+            return default_config[dataset]
 
 
 def get_distance(coord0, coord1):

--- a/mslib/utils.py
+++ b/mslib/utils.py
@@ -125,7 +125,7 @@ def config_loader(config_file=None, dataset=None, default=None):
                     if dataset not in default_config:
                         raise KeyError("requested dataset not in defaults or config_file")
                     if dataset in default_config and default is not None:
-                        return default
+                        return default_config[dataset]
                 else:
                      return default_config
             else:
@@ -139,6 +139,8 @@ def config_loader(config_file=None, dataset=None, default=None):
                     if dataset in default_config and default is None:
                         return default_config[dataset]
                     if dataset in default_config and default is not None:
+                        if dataset in data:
+                            return data[dataset]
                         return default
                     if dataset not in default_config:
                         raise KeyError("requested dataset not in defaults or config_file")


### PR DESCRIPTION
by this parameter pytest can use a mss_settings.json
saved in the test tmp directory
example:
pytest -k test_existing_empty_config_file --mss_settings '{ }'
pytest -k test_existing_config_file_different_parameters --mss_settings '{"num_interpolation_points": 201 }'

After we agreed to this kind of configuration we can pick tests which can be verified by an individual "mss_settings.json" for tests. I guess we will do this by another test action. 
