### PR TITLE
Fix conda-forge missing in channels

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,6 +26,8 @@ jobs:
         | sed -e "s/.*- //" \
         | sed -e "s/menuinst.*//" \
         | sed -e "s/.*://" > reqs.txt \
+        && conda config --add channels conda-forge \
+        && conda config --add channels defaults \
         && conda install -n mssenv --file reqs.txt --force-reinstall)
 
     - name: Run tests


### PR DESCRIPTION
For some reason conda-forge is missing when using the testing container in GitHub Actions.
To work correctly, the channels need to be added again.