### PR TITLE
Install with mamba, check development.txt

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,18 +18,22 @@ jobs:
     steps:
     - uses: actions/checkout@v2
         
-    - name: Update dependencies if changed
+    - name: Reinstall dependencies if changed
       run: |
-        cmp -s /meta.yaml localbuild/meta.yaml || (echo Dependencies differ \
+        cmp -s /meta.yaml localbuild/meta.yaml && cmp -s /development.txt requirements.d/development.txt || (echo Dependencies differ \
         && cat localbuild/meta.yaml \
         | sed -n '/^requirements:/,/^test:/p' \
         | sed -e "s/.*- //" \
         | sed -e "s/menuinst.*//" \
         | sed -e "s/.*://" > reqs.txt \
+        && source /opt/conda/bin/activate mssenv \
         && conda config --add channels conda-forge \
         && conda config --add channels defaults \
-        && conda install -n mssenv --file reqs.txt --force-reinstall)
-
+        && conda install --revision 0 \
+        && conda install mamba \
+        && mamba install --file reqs.txt \
+        && mamba install --file requirements.d/development.txt)
+        
     - name: Run tests
       timeout-minutes: 25
       run: |


### PR DESCRIPTION
This PR makes sure the packages get removed and reinstalled when either the local meta.yaml or development.txt differ from the image. 
There is no simple way to remove all packages of a specific file, so instead all mssenv packages are removed and installed again either way.
This will add roughly 2.5 minutes to the total testing should differences arise. This could be optimised in the future by only removing either development.txt or meta.yaml packages.

This fixes #682 and fixes #669