### PR TITLE
Fix error on empty coastsegs on land

### DIFF
--- a/mslib/msui/_tests/test_mpl_map.py
+++ b/mslib/msui/_tests/test_mpl_map.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+
+    mslib.msui._tests.test_mpl_map
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    This module is used to test the functionality of mpl_map.py
+
+    This file is part of mss.
+
+    :copyright: Copyright 2021 May Bär
+    :copyright: Copyright 2021 by the mss team, see AUTHORS.
+    :license: APACHE-2.0, see LICENSE for details.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+from matplotlib import pyplot as plt
+from mslib.msui.mpl_map import MapCanvas
+
+
+class Test_MapCanvas:
+    def setup(self):
+        kwargs = {'resolution': 'l', 'area_thresh': 1000.0, 'ax': plt.gca(), 'llcrnrlon': -15.0, 'llcrnrlat': 35.0,
+                  'urcrnrlon': 30.0, 'urcrnrlat': 65.0, 'epsg': '4326'}
+        self.map = MapCanvas(**kwargs)
+
+    def test_no_coastsegs(self):
+        """
+        Assert rendering areas without a coastline does not cause an error
+        """
+        # On land
+        self.map.ax.set_xlim([2, 3])
+        self.map.ax.set_ylim([48, 49])
+        self.map.update_with_coordinate_change()
+
+        # On water
+        self.map.ax.set_xlim([1, 2])
+        self.map.ax.set_ylim([62, 63])
+        self.map.update_with_coordinate_change()

--- a/mslib/msui/mpl_map.py
+++ b/mslib/msui/mpl_map.py
@@ -104,7 +104,8 @@ class MapCanvas(basemap.Basemap):
 
         # Set up the map appearance.
         if self.appearance["draw_coastlines"]:
-            self.map_coastlines = self.drawcoastlines(zorder=3)
+            if len(self.coastsegs) > 0 and len(self.coastsegs[0]) > 0:
+                self.map_coastlines = self.drawcoastlines(zorder=3)
             self.map_countries = self.drawcountries(zorder=3)
         else:
             self.map_coastlines = None
@@ -425,7 +426,7 @@ class MapCanvas(basemap.Basemap):
         grat_vis = self.appearance["draw_graticule"]
         self.set_graticule_visible(False)
         self.appearance["draw_graticule"] = grat_vis
-        if self.map_coastlines is not None:
+        if self.map_coastlines is not None and (len(self.coastsegs) > 0 and len(self.coastsegs[0]) > 0):
             self.map_coastlines.remove()
 
         if self.image is not None:


### PR DESCRIPTION
Basemap is erroring when drawing a coastline that looks like [[]] instead of [], which happens when zoomed in on land without coastsegs, not however on water.
This additional check will prevent this from happening.
fixes #609