### PR TITLE
Fix sql versions

### DIFF
--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -72,6 +72,8 @@ requirements:
     - xstatic-bootstrap
     - pyperclip
     - geos <3.9.0
+    - sqlalchemy < 1.4.0
+    - sqlite < 3.35.1
 
 test:
   imports:


### PR DESCRIPTION
The new versions sqlalchemy 1.4.0 and sqlite 3.35.1 are causing all tests to fail.
Fixing the versions to something before fixes that for the time being.