### PR TITLE
Fix syntax error for sqlite sqlalchemy

### DIFF
--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -72,8 +72,8 @@ requirements:
     - xstatic-bootstrap
     - pyperclip
     - geos <3.9.0
-    - sqlalchemy < 1.4.0
-    - sqlite < 3.35.1
+    - sqlalchemy <1.4.0
+    - sqlite <3.35.1
 
 test:
   imports:


### PR DESCRIPTION
The space after < is wrong syntax for meta.yaml.
After this is merged, stable should be merged into develop too, to stop our develop docker image from failing.