### PR TITLE
Fix a few bugs for get_capabilities and multilayering

### DIFF
--- a/mslib/_tests/utils.py
+++ b/mslib/_tests/utils.py
@@ -25,9 +25,11 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import time
 import fs
 import socket
 import multiprocessing
+from PyQt5 import QtTest
 from werkzeug.urls import url_join
 from mslib.mscolab.server import register_user
 from flask import json
@@ -203,3 +205,26 @@ def mscolab_start_server(all_ports, mscolab_settings=mscolab_settings):
 def create_mss_settings_file(content):
     with fs.open_fs(MSS_CONFIG_PATH) as file_dir:
         file_dir.writetext("mss_settings.json", content)
+
+
+def wait_until_signal(signal, timeout=5):
+    """
+    Blocks the calling thread until the signal emits or the timeout expires.
+    """
+    init_time = time.time()
+    finished = False
+
+    def done(*args):
+        nonlocal finished
+        finished = True
+
+    signal.connect(done)
+    while not finished and time.time() - init_time < timeout:
+        QtTest.QTest.qWait(100)
+
+    try:
+        signal.disconnect(done)
+    except TypeError:
+        pass
+    finally:
+        return finished

--- a/mslib/msui/_tests/test_sideview.py
+++ b/mslib/msui/_tests/test_sideview.py
@@ -36,6 +36,7 @@ from mslib.mswms.mswms import application
 from PyQt5 import QtWidgets, QtTest, QtCore, QtGui
 from mslib.msui import flighttrack as ft
 import mslib.msui.sideview as tv
+from mslib._tests.utils import wait_until_signal
 
 PORTS = list(range(8095, 8105))
 
@@ -170,8 +171,7 @@ class Test_SideViewWMS(object):
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        while self.wms_control.cpdlg.isVisible():
-            QtTest.QTest.qWait(100)
+        wait_until_signal(self.wms_control.cpdlg.canceled)
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     def test_server_getmap(self, mockbox):
@@ -181,7 +181,7 @@ class Test_SideViewWMS(object):
         self.query_server(f"http://127.0.0.1:{self.port}")
         QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(2000)
+        wait_until_signal(self.wms_control.image_displayed)
         assert mockbox.critical.call_count == 0
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")

--- a/mslib/msui/_tests/test_topview.py
+++ b/mslib/msui/_tests/test_topview.py
@@ -38,6 +38,7 @@ from mslib.mswms.mswms import application
 from PyQt5 import QtWidgets, QtCore, QtTest
 from mslib.msui import flighttrack as ft
 import mslib.msui.topview as tv
+from mslib._tests.utils import wait_until_signal
 
 PORTS = list(range(8084, 8094))
 
@@ -301,8 +302,7 @@ class Test_TopViewWMS(object):
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        while self.wms_control.cpdlg.isVisible():
-            QtTest.QTest.qWait(100)
+        wait_until_signal(self.wms_control.cpdlg.canceled)
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     def test_server_getmap(self, mockbox):
@@ -312,7 +312,7 @@ class Test_TopViewWMS(object):
         self.query_server(f"http://127.0.0.1:{self.port}")
         QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(2000)
+        wait_until_signal(self.wms_control.image_displayed)
         QtWidgets.QApplication.processEvents()
         self.window.mpl.canvas.redraw_map()
         assert mockbox.critical.call_count == 0

--- a/mslib/msui/_tests/test_wms_control.py
+++ b/mslib/msui/_tests/test_wms_control.py
@@ -36,6 +36,7 @@ from mslib.mswms.mswms import application
 from PyQt5 import QtWidgets, QtCore, QtTest
 from mslib.msui import flighttrack as ft
 import mslib.msui.wms_control as wc
+from mslib._tests.utils import wait_until_signal
 
 
 PORTS = list(range(8106, 8120))
@@ -101,8 +102,7 @@ class WMSControlWidgetSetup(object):
         QtTest.QTest.qWait(2000)  # time for the server to start up
         QtTest.QTest.mouseClick(self.window.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        while self.window.cpdlg.isVisible():
-            QtTest.QTest.qWait(100)
+        wait_until_signal(self.window.cpdlg.canceled)
 
 
 @pytest.mark.skipif(os.name == "nt",
@@ -163,7 +163,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtTest.QTest.qWait(20)
         QtTest.QTest.keyClick(self.window.pdlg, QtCore.Qt.Key_Enter)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(2000)
+        wait_until_signal(self.window.image_displayed)
 
         assert self.view.draw_image.call_count == 0
         assert self.view.draw_legend.call_count == 0
@@ -179,7 +179,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
 
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(5000)
+        wait_until_signal(self.window.image_displayed)
 
         assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
@@ -196,10 +196,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
 
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(1000)
-        QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(6000)
-        QtWidgets.QApplication.processEvents()
+        wait_until_signal(self.window.image_displayed)
 
         # assert mockbox.critical.call_count == 0
 
@@ -212,9 +209,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(1000)
-        QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(1000)
+        wait_until_signal(self.window.image_displayed)
 
         assert mockbox.critical.call_count == 0
 
@@ -235,8 +230,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseClick(self.window.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        while self.window.cpdlg.isVisible():
-            QtTest.QTest.qWait(100)
+        wait_until_signal(self.window.cpdlg.canceled)
         assert mockbox.critical.call_count == 1
         assert self.view.draw_image.call_count == 0
         assert self.view.draw_legend.call_count == 0
@@ -247,13 +241,12 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseClick(self.window.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        while self.window.cpdlg.isVisible():
-            QtTest.QTest.qWait(100)
+        wait_until_signal(self.window.cpdlg.canceled)
         assert mockbox.critical.call_count == 0
 
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(1000)
+        wait_until_signal(self.window.image_displayed)
 
         assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
@@ -300,7 +293,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         # Check drawing not causing errors
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(6000)
+        wait_until_signal(self.window.image_displayed)
 
         assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
@@ -336,7 +329,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         # Check drawing not causing errors
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(6000)
+        wait_until_signal(self.window.image_displayed)
 
         assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
@@ -389,7 +382,7 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         self.query_server(f"http://127.0.0.1:{self.port}")
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(5000)
+        wait_until_signal(self.window.image_displayed)
 
         assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
@@ -406,6 +399,7 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         server.child(0).draw()
+        wait_until_signal(self.window.image_displayed)
 
         assert mockbox.critical.call_count == 0
 

--- a/mslib/msui/multilayers.py
+++ b/mslib/msui/multilayers.py
@@ -94,7 +94,7 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
         """
         Checks if the mouse is pointing at the favourite icon and handles the event accordingly
         """
-        if layer.childCount() == 0:
+        if isinstance(layer, Layer):
             position = self.listLayers.viewport().mapFromGlobal(QtGui.QCursor().pos())
             if (self.cbMultilayering.isChecked() and 64 <= position.x() <= 80) or \
                (not self.cbMultilayering.isChecked() and 44 <= position.x() <= 60):
@@ -155,7 +155,7 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
                     wms_hits += 1
                 else:
                     widget.setHidden(True)
-            if wms_hits == 0:
+            if wms_hits == 0 and len(filter_string) > 0:
                 header.setHidden(True)
             else:
                 header.setHidden(False)
@@ -234,9 +234,9 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
                 priority.setCurrentIndex(self.layers_priority.index(layer))
                 priority.currentIndexChanged.connect(self.priority_changed)
 
-    def add_multilayer(self, name, wms):
+    def add_wms(self, wms):
         """
-        Adds a layer to the multilayer list, with the wms url as a parent
+        Adds a wms to the multilayer list
         """
         if wms.url not in self.layers:
             header = QtWidgets.QTreeWidgetItem(self.listLayers)
@@ -247,6 +247,10 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
             self.layers[wms.url]["wms"] = wms
             header.setExpanded(True)
 
+    def add_multilayer(self, name, wms):
+        """
+        Adds a layer to the multilayer list, with the wms url as a parent
+        """
         if name not in self.layers[wms.url]:
             layerobj = self.dock_widget.get_layer_object(wms, name.split(" | ")[-1])
             widget = Layer(self.layers[wms.url]["header"], self, layerobj, name=name)
@@ -280,7 +284,10 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
         Gets called whenever the user clicks on a layer in the multilayer list
         Makes sure the dock widget updates its data depending on the users selection
         """
-        if item.childCount() > 0:
+        if not isinstance(item, Layer):
+            index = self.cbWMS_URL.findText(item.text(0))
+            if index != -1 and index != self.cbWMS_URL.currentIndex():
+                self.cbWMS_URL.setCurrentIndex(index)
             return
 
         self.threads += 1

--- a/mslib/msui/wms_control.py
+++ b/mslib/msui/wms_control.py
@@ -390,6 +390,7 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
     fetch = QtCore.pyqtSignal([list], name="fetch")
     signal_disable_cbs = QtCore.Signal(name="disable_cbs")
     signal_enable_cbs = QtCore.Signal(name="enable_cbs")
+    image_displayed = QtCore.pyqtSignal()
 
     def __init__(self, parent=None, default_WMS=None, wms_cache=None, view=None):
         """
@@ -613,27 +614,27 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
                         self.cpdlg.close()
                         return
                 else:
-                    self.cpdlg.close()
                     logging.error("cannot load capabilities document.. "
                                   "no layers can be used in this view.")
                     QtWidgets.QMessageBox.critical(
                         self.multilayers, self.tr("Web Map Service"),
                         self.tr(f"ERROR: We cannot load the capability document!\n\n{type(ex)}\n{ex}"))
+                    self.cpdlg.close()
             except Exception as ex:
-                self.cpdlg.close()
                 logging.error("cannot load capabilities document.. "
                               "no layers can be used in this view.")
                 QtWidgets.QMessageBox.critical(
                     self.multilayers, self.tr("Web Map Service"),
                     self.tr(f"ERROR: We cannot load the capability document!\n\n{type(ex)}\n{ex}"))
+                self.cpdlg.close()
 
         try:
             str(base_url)
         except UnicodeEncodeError:
-            self.cpdlg.close()
             logging.error("got a unicode url?!: '%s'", base_url)
             QtWidgets.QMessageBox.critical(self.multilayers, self.tr("Web Map Service"),
                                            self.tr("ERROR: We cannot parse unicode URLs!"))
+            self.cpdlg.close()
 
         self.capabilities_worker = Worker.create(lambda: MSSWebMapService(base_url, version=version,
                                                                           username=username, password=password),
@@ -703,7 +704,6 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
 
         def on_failure(e):
             try:
-                self.cpdlg.close()
                 raise e
             except (requests.exceptions.TooManyRedirects,
                     requests.exceptions.ConnectionError,
@@ -715,6 +715,8 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
                 QtWidgets.QMessageBox.critical(
                     self.multilayers, self.tr("Web Map Service"),
                     self.tr(f"ERROR: We cannot load the capability document!\n\\n{type(ex)}\n{ex}"))
+            finally:
+                self.cpdlg.close()
 
         self.display_capabilities_dialog()
         self.capabilities_worker = Worker.create(lambda: requests.get(base_url, params=params),
@@ -1334,6 +1336,7 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
         self.display_retrieved_image(img, legend_img, layer, style, init_time, valid_time, complete_level)
         # this is for cases where 'remove' button is clicked, then 'retrieve' is clicked
         self.signal_disable_cbs.emit()
+        self.image_displayed.emit()
 
     def get_map(self, layers=None):
         """Prototypical stub for getMap() function. Needs to be reimplemented


### PR DESCRIPTION
fixes #781 and fixes #777 
- No longer throw an error when viewing an empty WMS Servers capabilites
- Don't filter out layerless WMS Servers in the Layer List
- Catch timeout exceptions again during GetCapabilities
- No longer allow retrieval on no selected layers for Multilayering
- For GetMap and GetCapabilities; Replace fixed qWaits with dynamic ones, awaiting signals