### PR TITLE
Allow multirow deletion

### DIFF
--- a/mslib/msui/hexagon_dockwidget.py
+++ b/mslib/msui/hexagon_dockwidget.py
@@ -67,11 +67,22 @@ class HexagonControlWidget(QtWidgets.QWidget, ui.Ui_HexagonDockWidget):
         super(HexagonControlWidget, self).__init__(parent)
         self.setupUi(self)
         self.view = view
+        if self.view:
+            self.view.tableWayPoints.selectionModel().selectionChanged.connect(self.on_selection_changed)
+            self.on_selection_changed(None)
 
         self.dsbHexgaonRadius.setValue(200)
 
         self.pbAddHexagon.clicked.connect(self._add_hexagon)
         self.pbRemoveHexagon.clicked.connect(self._remove_hexagon)
+
+    def on_selection_changed(self, index):
+        """
+        Disables add and remove when multiple rows are selected
+        """
+        enable = len(self.view.tableWayPoints.selectionModel().selectedRows()) <= 1
+        self.pbAddHexagon.setEnabled(enable)
+        self.pbRemoveHexagon.setEnabled(enable)
 
     def _get_parameters(self):
         return {

--- a/mslib/msui/qt5/ui_tableview_window.py
+++ b/mslib/msui/qt5/ui_tableview_window.py
@@ -2,11 +2,13 @@
 
 # Form implementation generated from reading ui file 'mslib/msui/ui/ui_tableview_window.ui'
 #
-# Created by: PyQt5 UI code generator 5.9.2
+# Created by: PyQt5 UI code generator 5.12.3
 #
 # WARNING! All changes made in this file will be lost!
 
+
 from PyQt5 import QtCore, QtGui, QtWidgets
+
 
 class Ui_TableViewWindow(object):
     def setupUi(self, TableViewWindow):
@@ -26,7 +28,7 @@ class Ui_TableViewWindow(object):
         self.tableWayPoints.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
         self.tableWayPoints.setDefaultDropAction(QtCore.Qt.CopyAction)
         self.tableWayPoints.setAlternatingRowColors(True)
-        self.tableWayPoints.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.tableWayPoints.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.tableWayPoints.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
         self.tableWayPoints.setObjectName("tableWayPoints")
         self.verticalLayout.addWidget(self.tableWayPoints)
@@ -85,4 +87,3 @@ class Ui_TableViewWindow(object):
         self.btRoundtrip.setText(_translate("TableViewWindow", "make roundtrip"))
         self.actionCloseWindow.setText(_translate("TableViewWindow", "Close Window"))
         self.actionCloseWindow.setShortcut(_translate("TableViewWindow", "Ctrl+W"))
-

--- a/mslib/msui/tableview.py
+++ b/mslib/msui/tableview.py
@@ -189,7 +189,6 @@ class MSSTableViewWindow(MSSViewWindow, ui.Ui_TableViewWindow):
         # tableView.edit(index)
         tableView.resizeRowsToContents()
 
-
     def confirm_delete_waypoint(self, rows):
         """
         Open a QMessageBox and ask the user if he really wants to

--- a/mslib/msui/tableview.py
+++ b/mslib/msui/tableview.py
@@ -81,6 +81,7 @@ class MSSTableViewWindow(MSSViewWindow, ui.Ui_TableViewWindow):
         self.btDeleteWayPoint.clicked.connect(self.removeWayPoint)
         self.btInvertDirection.clicked.connect(self.invertDirection)
         self.btRoundtrip.clicked.connect(self.make_roundtrip)
+        self.tableWayPoints.selectionModel().selectionChanged.connect(self.on_selection_changed)
 
         # Tool opener.
         self.cbTools.currentIndexChanged.connect(self.openTool)
@@ -95,6 +96,14 @@ class MSSTableViewWindow(MSSViewWindow, ui.Ui_TableViewWindow):
         self.waypoints_model.save_settings()
         self.resizeColumns()
         self.tableWayPoints.viewport().repaint()
+
+    def on_selection_changed(self, index):
+        """
+        Disables insert and clone when multiple rows are selected
+        """
+        enable = len(self.tableWayPoints.selectionModel().selectedRows()) <= 1
+        self.btCloneWaypoint.setEnabled(enable)
+        self.btAddWayPointToFlightTrack.setEnabled(enable)
 
     def openTool(self, index):
         """Slot that handles requests to open tool windows.
@@ -175,9 +184,9 @@ class MSSTableViewWindow(MSSViewWindow, ui.Ui_TableViewWindow):
         # tableView.edit(index)
         tableView.resizeRowsToContents()
 
-    def confirm_delete_waypoint(self, row):
+    def confirm_delete_waypoint(self, rows):
         """Open a QMessageBox and ask the user if he really wants to
-           delete the waypoint at index <row>.
+           delete the waypoints at rows.
 
         Returns TRUE if the user confirms the deletion.
 
@@ -185,30 +194,33 @@ class MSSTableViewWindow(MSSViewWindow, ui.Ui_TableViewWindow):
         is not possible. In this case the user is informed correspondingly.
         """
         wps = self.waypoints_model.all_waypoint_data()
-        if len(wps) < 3:
+        if len(wps) - len(rows) < 2:
             QtWidgets.QMessageBox.warning(
                 None, "Remove waypoint",
                 "Cannot remove waypoint, the flight track needs to consist of at least two points.")
             return False
         else:
-            waypoint = wps[row]
+            waypoints = [wps[row] for row in rows]
+            text = "\n".join(
+                [f"Remove waypoint at {waypoint.lat:.2f}/{waypoint.lon:.2f}, flightlevel {waypoint.flightlevel:.2f}?"
+                    for waypoint in waypoints])
+
             return QtWidgets.QMessageBox.question(
-                None, "Remove waypoint",
-                f"Remove waypoint at {waypoint.lat:.2f}/{waypoint.lon:.2f}, flightlevel {waypoint.flightlevel:.2f}?",
+                None, "Remove waypoint", text,
                 QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No) == QtWidgets.QMessageBox.Yes
 
     def removeWayPoint(self):
         """Handler for button <btDeleteWayPoint>. Deletes the currently selected
-           waypoint.
+           waypoints.
         """
         tableView = self.tableWayPoints
-        index = tableView.currentIndex()
-        if not index.isValid():
-            return
-        row = index.row()
+        indices = tableView.selectionModel().selectedRows()
+        rows = [index.row() for index in indices]
         # Let the user confirm the deletion.
-        if self.confirm_delete_waypoint(row):
-            self.waypoints_model.removeRows(row)
+        if len(rows) > 0:
+            if self.confirm_delete_waypoint(rows):
+                for row in sorted(rows, reverse=True):
+                    self.waypoints_model.removeRows(row)
 
     def make_roundtrip(self):
         """

--- a/mslib/msui/ui/ui_tableview_window.ui
+++ b/mslib/msui/ui/ui_tableview_window.ui
@@ -42,7 +42,7 @@
        <bool>true</bool>
       </property>
       <property name="selectionMode">
-       <enum>QAbstractItemView::SingleSelection</enum>
+       <enum>QAbstractItemView::ExtendedSelection</enum>
       </property>
       <property name="selectionBehavior">
        <enum>QAbstractItemView::SelectRows</enum>


### PR DESCRIPTION
Allows the selection of multiple rows by holding the ctrl key in the TableView, and simultaneous deletion.
Fixes #800 