### PR TITLE
Close on doubleclick, auto update on layer change

### DIFF
--- a/mslib/msui/multilayers.py
+++ b/mslib/msui/multilayers.py
@@ -54,6 +54,7 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
         self.listLayers.itemChanged.connect(self.multilayer_changed)
         self.listLayers.itemClicked.connect(self.multilayer_clicked)
         self.listLayers.itemClicked.connect(self.check_icon_clicked)
+        self.listLayers.itemDoubleClicked.connect(self.multilayer_doubleclicked)
         self.listLayers.setVisible(True)
 
         self.leMultiFilter.setVisible(True)
@@ -343,7 +344,13 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
         if index != -1 and index != self.cbWMS_URL.currentIndex():
             self.cbWMS_URL.setCurrentIndex(index)
         self.needs_repopulate.emit()
+        if not self.cbMultilayering.isChecked():
+            self.dock_widget.auto_update()
         self.threads -= 1
+
+    def multilayer_doubleclicked(self, item, column):
+        if isinstance(item, Layer):
+            self.hide()
 
     def multilayer_changed(self, item):
         """
@@ -366,6 +373,8 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
             elif not (item.itimes or item.vtimes or item.levels):
                 item.is_active_unsynced = True
             self.update_checkboxes()
+            self.needs_repopulate.emit()
+            self.dock_widget.auto_update()
         elif item.checkState(0) == 0 and self.listLayers.itemWidget(item, 2):
             if item in self.layers_priority:
                 self.listLayers.removeItemWidget(item, 2)
@@ -375,6 +384,8 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
             item.is_active_unsynced = False
             self.reload_sync()
             self.update_checkboxes()
+            self.needs_repopulate.emit()
+            self.dock_widget.auto_update()
 
     def priority_changed(self, new_index):
         """

--- a/mslib/msui/multilayers.py
+++ b/mslib/msui/multilayers.py
@@ -338,14 +338,15 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
             if self.current_layer.get_vtime() in item.get_vtimes():
                 item.set_vtime(self.current_layer.get_vtime())
 
-        self.current_layer = item
-        self.listLayers.setCurrentItem(item)
-        index = self.cbWMS_URL.findText(item.get_wms().url)
-        if index != -1 and index != self.cbWMS_URL.currentIndex():
-            self.cbWMS_URL.setCurrentIndex(index)
-        self.needs_repopulate.emit()
-        if not self.cbMultilayering.isChecked():
-            self.dock_widget.auto_update()
+        if self.current_layer != item:
+            self.current_layer = item
+            self.listLayers.setCurrentItem(item)
+            index = self.cbWMS_URL.findText(item.get_wms().url)
+            if index != -1 and index != self.cbWMS_URL.currentIndex():
+                self.cbWMS_URL.setCurrentIndex(index)
+            self.needs_repopulate.emit()
+            if not self.cbMultilayering.isChecked():
+                self.dock_widget.auto_update()
         self.threads -= 1
 
     def multilayer_doubleclicked(self, item, column):

--- a/mslib/msui/wms_control.py
+++ b/mslib/msui/wms_control.py
@@ -499,13 +499,14 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
         self.pdlg = QtWidgets.QProgressDialog(
             "retrieving image...", "Cancel", 0, 10, parent=self.parent())
         self.pdlg.close()
+        self.pdlg.canceled.connect(lambda: self.parent().setEnabled(True))
 
         # Progress dialog to inform the user about ongoing capability requests.
         self.capabilities_worker = Worker(None)
         self.cpdlg = QtWidgets.QProgressDialog(
             "retrieving wms capabilities...", "Cancel", 0, 10, parent=self.multilayers)
-        self.cpdlg.canceled.connect(self.stop_capabilities_retrieval)
         self.cpdlg.close()
+        self.cpdlg.canceled.connect(self.stop_capabilities_retrieval)
 
         self.thread_prefetch = QtCore.QThread()  # no parent!
         self.thread_prefetch.start()
@@ -657,7 +658,9 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
         logging.debug("showing progress dialog")
         self.pdlg.reset()
         self.pdlg.setValue(5)
-        self.pdlg.setModal(True)
+        self.parent().setEnabled(False)
+        self.multilayers.setEnabled(True)
+        self.pdlg.setEnabled(True)
         self.pdlg.show()
 
     def display_capabilities_dialog(self):


### PR DESCRIPTION
Fixes #816 
Double clicking on a layer now closes the layer window.
Switching layers now triggers auto-updating of the map.