### PR TITLE
Disable auto-update for testing

### DIFF
--- a/mslib/msui/_tests/test_wms_control.py
+++ b/mslib/msui/_tests/test_wms_control.py
@@ -261,6 +261,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         self.query_server(f"http://127.0.0.1:{self.port}")
         server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
                                                               QtCore.Qt.MatchFixedString)[0]
+        self.window.cbAutoUpdate.setCheckState(False)
         assert server is not None
         assert "header" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
         assert "wms" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
@@ -308,6 +309,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         self.query_server(f"http://127.0.0.1:{self.port}")
         server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
                                                               QtCore.Qt.MatchFixedString)[0]
+        self.window.cbAutoUpdate.setCheckState(False)
         assert server is not None
         assert "header" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
         assert "wms" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
@@ -344,6 +346,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         self.query_server(f"http://127.0.0.1:{self.port}")
         server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
                                                               QtCore.Qt.MatchFixedString)[0]
+        self.window.cbAutoUpdate.setCheckState(False)
         server.setExpanded(True)
         self.window.multilayers.cbMultilayering.setChecked(True)
         layer_a = server.child(0)


### PR DESCRIPTION
fixes #854 
The recent changes to develop, allowing Auto-Update to be triggered on layer changes, caused some multilayering tests to fail or succeed relying on race conditions.
This fix disables Auto-Update for the tests and reverts to the old behaviour.

This change has not been implemented in stable yet so no fix is needed there.