### PR TITLE
fixed mscolab permission upgrade, #853

### DIFF
--- a/mslib/mscolab/_tests/test_files_api.py
+++ b/mslib/mscolab/_tests/test_files_api.py
@@ -186,21 +186,21 @@ class Test_Files(object):
         with self.app.app_context():
             p_id = get_recent_pid(self.fm, self.user)
             assert p_id == 4
-        data = {
-            "token": self.token,
-            "p_id": p_id,
-            "selected_userids": json.dumps([12, 13]),
-            "selected_access_level": "viewer"
-        }
-        url = url_join(self.url, 'modify_bulk_permissions')
-        r = requests.post(url, data=data).json()
-        assert r["success"] is True
-        data["p_id"] = self.undefined_p_id
-        r = requests.post(url, data=data).json()
-        assert r["success"] is False
-        data["p_id"] = self.no_perm_p_id
-        r = requests.post(url, data=data).json()
-        assert r["success"] is False
+            data = {
+                "token": self.token,
+                "p_id": p_id,
+                "selected_userids": json.dumps([12, 13]),
+                "selected_access_level": "viewer"
+            }
+            url = url_join(self.url, 'modify_bulk_permissions')
+            r = requests.post(url, data=data).json()
+            assert r["success"] is True
+            data["p_id"] = self.undefined_p_id
+            r = requests.post(url, data=data).json()
+            assert r["success"] is False
+            data["p_id"] = self.no_perm_p_id
+            r = requests.post(url, data=data).json()
+            assert r["success"] is False
 
     def test_delete_bulk_permissions(self):
         with self.app.app_context():

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -436,7 +436,7 @@ def modify_bulk_permissions():
     success = fm.modify_bulk_permission(p_id, user, u_ids, new_access_level)
     if success:
         for u_id in u_ids:
-            sockio.sm.emit_new_permission(u_id=u_id, p_id=p_id)
+            sockio.sm.emit_update_permission(u_id, p_id, access_level=new_access_level)
         sockio.sm.emit_project_permissions_updated(user.id, p_id)
         return jsonify({"success": True, "message": "User permissions successfully updated!"})
 

--- a/mslib/mscolab/sockets_manager.py
+++ b/mslib/mscolab/sockets_manager.py
@@ -225,8 +225,7 @@ class SocketsManager(object):
         if access_level is None:
             perm = Permission.query.filter_by(u_id=u_id, p_id=p_id).first()
             access_level = perm.access_level
-            logging.debug("access_level by database query"
-                          "")
+            logging.debug("access_level by database query")
 
         socketio.emit('update-permission', json.dumps({"p_id": p_id,
                                                        "u_id": u_id,

--- a/mslib/mscolab/sockets_manager.py
+++ b/mslib/mscolab/sockets_manager.py
@@ -218,14 +218,19 @@ class SocketsManager(object):
         """
         socketio.emit('new-permission', json.dumps({"p_id": p_id, "u_id": u_id}), room=str(p_id))
 
-    def emit_update_permission(self, u_id, p_id):
+    def emit_update_permission(self, u_id, p_id, access_level=None):
         """
         to refresh permissions in msui
         """
-        perm = Permission.query.filter_by(u_id=u_id, p_id=p_id).first()
+        if access_level is None:
+            perm = Permission.query.filter_by(u_id=u_id, p_id=p_id).first()
+            access_level = perm.access_level
+            logging.debug("access_level by database query"
+                          "")
+
         socketio.emit('update-permission', json.dumps({"p_id": p_id,
                                                        "u_id": u_id,
-                                                       "access_level": perm.access_level}), room=str(p_id))
+                                                       "access_level": access_level}), room=str(p_id))
 
     def emit_revoke_permission(self, u_id, p_id):
         socketio.emit("revoke-permission", json.dumps({"p_id": p_id, "u_id": u_id}), room=str(p_id))


### PR DESCRIPTION
in the server code a line reverted from 3db9e60708657dae4c414ad95ad702259a0e6b26
because of SQLite objects created in a thread can only be used in that
same thread also the API for submitting the access_level extended.