### PR TITLE
Fix not all windows closing

### DIFF
--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -644,7 +644,7 @@ class MSSMscolabWindow(QtWidgets.QMainWindow, ui.Ui_MSSMscolabWindow):
         self.listProjects.itemActivated.connect(self.set_active_pid)
 
     def force_close_view_windows(self):
-        for window in self.active_windows:
+        for window in self.active_windows[:]:
             window.handle_force_close()
         self.active_windows = []
 


### PR DESCRIPTION
Removing an item of a list while iterating over it with a foreach is usually yucky.
Iterating over a copy of the list solves the issue.
fixes #879 