### PR TITLE
Default to newest init time

### DIFF
--- a/mslib/msui/_tests/test_wms_control.py
+++ b/mslib/msui/_tests/test_wms_control.py
@@ -367,6 +367,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert layer_a.get_vtime() == self.window.cbValidTime.currentText()
         assert layer_a.get_level() == layer_b.get_level()
         assert layer_a.get_vtime() == layer_b.get_vtime()
+        assert layer_a.get_itime() == layer_a.get_itimes()[-1]
         assert mockbox.critical.call_count == 0
 
 
@@ -643,14 +644,33 @@ class TestWMSControlWidgetSetupSimple(object):
         dimext_time_period = '<Dimension name="TIME" units="ISO8610"> </Dimension> ' \
             '<Extent name="TIME"> 2010-10-17T12:00:00Z/2010-11-18T00:00:00Z/P1M, ' \
             '2012-10-01T12:00:00Z,2012-10-17T12:00:00Z/2012-10-18T00:00:00Z/PT12H </Extent>'
+        dimext_inittime = """
+                <Dimension name="INIT_TIME" units="ISO8610"> </Dimension>
+                <Extent name="INIT_TIME"> 2010-10-17T12:00:00Z,2012-10-16T12:00:00Z,2012-10-17T12:00:00Z </Extent>"""
+
+        testxml = self.xml.format(
+            "", self.srs_base, dimext_time_period + dimext_inittime + self.dimext_elevation)
+        self.window.activate_wms(wc.MSSWebMapService(None, version='1.1.1', xml=testxml))
+        QtWidgets.QApplication.processEvents()
+        self.window.cbAutoUpdate.setCheckState(False)
+        self.window.cbInitTime.setCurrentIndex(0)
+        assert [self.window.cbValidTime.itemText(i) for i in range(self.window.cbValidTime.count())] == \
+            ['2010-10-17T12:00:00Z', '2010-11-17T12:00:00Z',
+             '2012-10-01T12:00:00Z',
+             '2012-10-17T12:00:00Z', '2012-10-18T00:00:00Z']
+        assert [self.window.cbInitTime.itemText(i) for i in range(self.window.cbInitTime.count())] == \
+            ['2010-10-17T12:00:00Z', '2012-10-16T12:00:00Z', '2012-10-17T12:00:00Z']
+
+    def test_valid_before_init(self):
+        dimext_time_period = '<Dimension name="TIME" units="ISO8610"> </Dimension> ' \
+            '<Extent name="TIME"> 2010-10-17T12:00:00Z,2012-10-17T12:00:00Z </Extent>' \
+
         testxml = self.xml.format(
             "", self.srs_base, dimext_time_period + self.dimext_inittime + self.dimext_elevation)
         self.window.activate_wms(wc.MSSWebMapService(None, version='1.1.1', xml=testxml))
         QtWidgets.QApplication.processEvents()
         assert [self.window.cbValidTime.itemText(i) for i in range(self.window.cbValidTime.count())] == \
-            ['2010-10-17T12:00:00Z', '2010-11-17T12:00:00Z',
-             '2012-10-01T12:00:00Z',
-             '2012-10-17T12:00:00Z', '2012-10-18T00:00:00Z']
+            ['2012-10-17T12:00:00Z']
         assert [self.window.cbInitTime.itemText(i) for i in range(self.window.cbInitTime.count())] == \
             ['2012-10-16T12:00:00Z', '2012-10-17T12:00:00Z']
 
@@ -677,6 +697,8 @@ class TestWMSControlWidgetSetupSimple(object):
             "", self.srs_base, dimext_time_format + self.dimext_inittime + self.dimext_elevation)
         self.window.activate_wms(wc.MSSWebMapService(None, version='1.1.1', xml=testxml))
         QtWidgets.QApplication.processEvents()
+        self.window.cbAutoUpdate.setCheckState(False)
+        self.window.cbInitTime.setCurrentIndex(0)
         assert [self.window.cbValidTime.itemText(i) for i in range(self.window.cbValidTime.count())] == \
             ['2012-10-17T00:00:00Z', '2012-10-18T00:00:00Z', '2012-10-19T00:00:00Z']
         assert [self.window.cbInitTime.itemText(i) for i in range(self.window.cbInitTime.count())] == \

--- a/mslib/msui/multilayers.py
+++ b/mslib/msui/multilayers.py
@@ -539,7 +539,7 @@ class Layer(QtWidgets.QTreeWidgetItem):
         if len(init_time_names) > 0:
             self.itime_name = init_time_names[0]
             values = self.extents[self.itime_name]["values"]
-            self.allowed_init_times = self.parent.dock_widget.parse_time_extent(values)
+            self.allowed_init_times = sorted(self.parent.dock_widget.parse_time_extent(values))
             self.itimes = [_time.isoformat() + "Z" for _time in self.allowed_init_times]
             if len(self.allowed_init_times) == 0:
                 msg = "cannot determine init time format"
@@ -548,7 +548,7 @@ class Layer(QtWidgets.QTreeWidgetItem):
                     self.parent.dock_widget, self.parent.dock_widget.tr("Web Map Service"),
                     self.parent.dock_widget.tr("ERROR: {}".format(msg)))
             else:
-                self.itime = self.itimes[0]
+                self.itime = self.itimes[-1]
 
     def _parse_vtimes(self):
         """

--- a/mslib/msui/multilayers.py
+++ b/mslib/msui/multilayers.py
@@ -639,7 +639,7 @@ class Layer(QtWidgets.QTreeWidgetItem):
             if self.get_vtime() < itime:
                 valid_vtime = next((vtime for vtime in self.get_vtimes() if vtime >= itime), None)
                 if valid_vtime:
-                    self.set_vtime()
+                    self.set_vtime(valid_vtime)
                     self.parent.carry_parameters["vtime"] = self.get_vtime()
             self.parent.needs_repopulate.emit()
 

--- a/mslib/msui/wms_control.py
+++ b/mslib/msui/wms_control.py
@@ -869,6 +869,8 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
 
         crs = layer.get_allowed_crs()
         levels, itimes, vtimes = layer.get_levels(), layer.get_itimes(), layer.get_vtimes()
+        if vtimes and itimes:
+            vtimes = vtimes[next((i for i, vtime in enumerate(vtimes) if vtime >= layer.get_itime()), 0):]
 
         if levels:
             self.cbLevel.addItems(levels)
@@ -1044,7 +1046,10 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
             if pydt in self.multilayers.get_current_layer().allowed_valid_times:
                 index = self.cbValidTime.findText(pydt.isoformat() + "Z")
                 # setCurrentIndex also sets the date/time edit via signal.
-                self.cbValidTime.setCurrentIndex(index)
+                if index > -1:
+                    self.cbValidTime.setCurrentIndex(index)
+                else:
+                    valid_time_available = False
             else:
                 valid_time_available = False
         font = self.dteValidTime.font()
@@ -1064,6 +1069,7 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
 
         if self.multilayers.threads == 0 and not self.layerChangeInProgress:
             self.multilayers.get_current_layer().set_itime(self.cbInitTime.currentText())
+            self.multilayers.carry_parameters["itime"] = self.cbInitTime.currentText()
 
         self.auto_update()
         return init_time == "" or init_time is not None
@@ -1079,6 +1085,7 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
 
         if self.multilayers.threads == 0 and not self.layerChangeInProgress:
             self.multilayers.get_current_layer().set_vtime(self.cbValidTime.currentText())
+            self.multilayers.carry_parameters["vtime"] = self.cbValidTime.currentText()
 
         self.auto_update()
         return valid_time == "" or valid_time is not None
@@ -1086,6 +1093,7 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
     def level_changed(self):
         if self.multilayers.threads == 0 and not self.layerChangeInProgress:
             self.multilayers.get_current_layer().set_level(self.cbLevel.currentText())
+            self.multilayers.carry_parameters["level"] = self.cbLevel.currentText()
         self.auto_update()
 
     def enable_level_elements(self, enable):


### PR DESCRIPTION
Fixes #824 
1. When a layer gets constructed, default to its newest initialisation time.
2. Improve carry-over logic. 
    Only carry over parameters that have been explicitly changed by the user, otherwise keep the default.
    Save carry-over parameters as to not lose them after a layer didn't support them.
3. Filter valid times to only show times after the selected init time