### PR TITLE
Reimplemented parts of matplotlibs history mechanism for TopViews

### DIFF
--- a/mslib/msui/mpl_qtwidget.py
+++ b/mslib/msui/mpl_qtwidget.py
@@ -273,6 +273,7 @@ class NavigationToolbar(NavigationToolbar2QT):
         self.setIconSize(QtCore.QSize(24, 24))
         self.layout().setSpacing(12)
         self.canvas = canvas
+        self.no_push_history = False
 
     def _icon(self, name, *args):
         """
@@ -299,6 +300,34 @@ class NavigationToolbar(NavigationToolbar2QT):
                 self.canvas.waypoints_interactor.button_release_move_callback(event)
             elif self.mode == _Mode.DELETE_WP:
                 self.canvas.waypoints_interactor.button_release_delete_callback(event)
+
+    def clear_history(self):
+        self._nav_stack.clear()
+        self.push_current()
+        self.set_history_buttons()
+
+    def push_current(self):
+        """Push the current view limits and position onto the stack."""
+        if self.sideview:
+            super(NavigationToolbar, self).push_current()
+        elif self.no_push_history:
+            pass
+        else:
+            self._nav_stack.push(self.canvas.map.kwargs.copy())
+            self.set_history_buttons()
+
+    def _update_view(self):
+        """
+        Update the viewlim and position from the view and position stack for
+        each axes.
+        """
+        if self.sideview:
+            super(NavigationToolbar, self)._update_view()
+        else:
+            nav_info = self._nav_stack()
+            if nav_info is None:
+                return
+            self.canvas.redraw_map(nav_info)
 
     def insert_wp(self, *args):
         """
@@ -346,12 +375,18 @@ class NavigationToolbar(NavigationToolbar2QT):
         self._update_buttons_checked()
 
     def release_zoom(self, event):
+        self.no_push_history = True
         super(NavigationToolbar, self).release_zoom(event)
+        self.no_push_history = False
         self.canvas.redraw_map()
+        self.push_current()
 
     def release_pan(self, event):
+        self.no_push_history = True
         super(NavigationToolbar, self).release_pan(event)
+        self.no_push_history = False
         self.canvas.redraw_map()
+        self.push_current()
 
     def mouse_move(self, event):
         """
@@ -1130,11 +1165,3 @@ class MplTopViewWidget(MplNavBarWidget):
         for action in actions:
             if action.text() in ["Subplots", "Customize"]:
                 action.setEnabled(False)
-            elif action.text() in ["Home", "Back", "Forward"]:
-                action.triggered.connect(self.historyEvent)
-
-    def historyEvent(self):
-        """Slot to react to clicks on one of the history buttons in the
-           navigation toolbar. Redraws the image.
-        """
-        self.canvas.redraw_map()

--- a/mslib/msui/topview.py
+++ b/mslib/msui/topview.py
@@ -224,6 +224,7 @@ class MSSTopViewWindow(MSSMplViewWindow, ui.Ui_TopViewWindow):
         # Automatically enable or disable roundtrip when data changes
         self.waypoints_model.dataChanged.connect(self.update_roundtrip_enabled)
         self.update_roundtrip_enabled()
+        self.mpl.navbar.push_current()
 
     def update_predefined_maps(self, extra=None):
         self.cbChangeMapSection.clear()
@@ -296,6 +297,7 @@ class MSSTopViewWindow(MSSMplViewWindow, ui.Ui_TopViewWindow):
 
         logging.debug("switching to map section '%s' - '%s'", current_map_key, kwargs)
         self.mpl.canvas.redraw_map(kwargs)
+        self.mpl.navbar.clear_history()
 
     def setIdentifier(self, identifier):
         super(MSSTopViewWindow, self).setIdentifier(identifier)


### PR DESCRIPTION
Works now also for stereographic projections and projection changes.

Fix issue #919