### PR TITLE
Hotfix for #901

### DIFF
--- a/mslib/msui/editor.py
+++ b/mslib/msui/editor.py
@@ -52,8 +52,9 @@ class EditorMainWindow(QtWidgets.QMainWindow):
         self.editor = QtWidgets.QPlainTextEdit()
 
         # Load mss_settings.json (if already exists), change \\ to / so fs can work with it
-        self.path = constants.CACHED_CONFIG_FILE.replace("\\", "/")
+        self.path = constants.CACHED_CONFIG_FILE
         if self.path:
+            self.path = self.path.replace("\\", "/")
             dir_name, file_name = fs.path.split(self.path)
             with fs.open_fs(dir_name) as _fs:
                 if _fs.exists(file_name):

--- a/mslib/msui/editor.py
+++ b/mslib/msui/editor.py
@@ -51,8 +51,8 @@ class EditorMainWindow(QtWidgets.QMainWindow):
         # Could also use a QTextEdit and set self.editor.setAcceptRichText(False)
         self.editor = QtWidgets.QPlainTextEdit()
 
-        # Load mss_settings.json (if already exists)
-        self.path = constants.CACHED_CONFIG_FILE
+        # Load mss_settings.json (if already exists), change \\ to / so fs can work with it
+        self.path = constants.CACHED_CONFIG_FILE.replace("\\", "/")
         if self.path:
             dir_name, file_name = fs.path.split(self.path)
             with fs.open_fs(dir_name) as _fs:


### PR DESCRIPTION
Fixes #901 
in fs, \\ is an illegal character for `_fs.exists` and can't be used for splitting dirname and filename either.
Replacing \\ with / fixes this particular error, at this particular place.