### PR TITLE
fixes #1014

### DIFF
--- a/docs/help.rst
+++ b/docs/help.rst
@@ -9,12 +9,12 @@ MSCOLAB
 
 .. raw:: html
 
-    <iframe width="560" height="315" src=http://www.youtube.com/embed/eDBnULXvo7M?rel=0" frameborder="0" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="http://www.youtube.com/embed/eDBnULXvo7M?rel=0" frameborder="0" allowfullscreen></iframe>
 
 KML Docking Widget
 ------------------
 
 .. raw:: html
 
-    <iframe width="560" height="315" src=http://www.youtube.com/embed/G4aPIRLBz9U?rel=0" frameborder="0" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="http://www.youtube.com/embed/G4aPIRLBz9U?rel=0" frameborder="0" allowfullscreen></iframe>
 


### PR DESCRIPTION
Added apostrophes to the links. Embedded links should be visible now.