### PR TITLE
Allow specification of file for linear defaultstyle

### DIFF
--- a/mslib/mswms/_tests/test_mss_plot_driver.py
+++ b/mslib/mswms/_tests/test_mss_plot_driver.py
@@ -174,6 +174,11 @@ class Test_LSec(object):
             img = self.plot(mpl_lsec_styles.LS_DefaultStyle(driver=self.lsec, variable=variable))
             assert img is not None
 
+    def test_LS_DefaultStyle_PL(self):
+        img = self.plot(mpl_lsec_styles.LS_DefaultStyle(driver=self.lsec, variable="air_potential_temperature",
+                                                        filetype="pl"))
+        assert img is not None
+
     def test_LS_RelativeHumdityStyle_01(self):
         img = self.plot(mpl_lsec_styles.LS_RelativeHumdityStyle_01(driver=self.lsec))
         assert img is not None

--- a/mslib/mswms/mpl_lsec_styles.py
+++ b/mslib/mswms/mpl_lsec_styles.py
@@ -36,10 +36,12 @@ class LS_DefaultStyle(AbstractLinearSectionStyle):
     """
     Style for single variables that require no further calculation
     """
-    def __init__(self, driver, variable="air_temperature"):
+    def __init__(self, driver, variable="air_temperature", filetype="ml"):
         super(AbstractLinearSectionStyle, self).__init__(driver=driver)
         self.variable = variable
-        self.required_datafields = [("ml", "air_pressure", "Pa"), ("ml", self.variable, None)]
+        self.required_datafields = [(filetype, self.variable, None)]
+        if filetype != "pl":
+            self.required_datafields.insert(0, (filetype, "air_pressure", "Pa"))
         abbreviation = "".join([text[0] for text in self.variable.split("_")])
         self.name = f"LS_{str.upper(abbreviation)}"
         self.title = f"{self.variable} Linear Plot"

--- a/mslib/mswms/mss_plot_driver.py
+++ b/mslib/mswms/mss_plot_driver.py
@@ -797,10 +797,10 @@ class LinearSectionDriver(VerticalSectionDriver):
             cross_section = utils.interpolate_vertsec(var_data, self.lat_data, lon_data, self.lats, self.lons)
             # Create vertical interpolation factors and indices for subsequent variables
             # TODO: Improve performance for this interpolation in general
-            if name == "air_pressure" or "air_pressure" not in self.data_vars and len(factors) == 0:
+            if len(factors) == 0:
                 for index_lonlat, alt in enumerate(self.alts):
-                    pressures = cross_section[:, index_lonlat] if "air_pressure" in self.data_vars \
-                        else self.vert_data[::-self.vert_order] * 100 if self.vert_units.lower() == "hpa" else 1
+                    pressures = cross_section[:, index_lonlat] if name == "air_pressure" \
+                        else self.vert_data[::-self.vert_order] * (100 if self.vert_units.lower() == "hpa" else 1)
                     closest = 0
                     direction = 1
                     for index_altitude, pressure in enumerate(pressures):

--- a/mslib/mswms/mss_plot_driver.py
+++ b/mslib/mswms/mss_plot_driver.py
@@ -773,10 +773,11 @@ class LinearSectionDriver(VerticalSectionDriver):
         lon_data = lon_data[lon_indices]
         factors = []
 
-        # Make sure air_pressure is the first to be evaluated
+        # Make sure air_pressure is the first to be evaluated if needed
         variables = list(self.data_vars)
-        if variables[0] != "air_pressure":
-            variables.insert(0, variables.pop(variables.index("air_pressure")))
+        if "air_pressure" in self.data_vars:
+            if variables[0] != "air_pressure":
+                variables.insert(0, variables.pop(variables.index("air_pressure")))
 
         for name in variables:
             var = self.data_vars[name]
@@ -796,9 +797,10 @@ class LinearSectionDriver(VerticalSectionDriver):
             cross_section = utils.interpolate_vertsec(var_data, self.lat_data, lon_data, self.lats, self.lons)
             # Create vertical interpolation factors and indices for subsequent variables
             # TODO: Improve performance for this interpolation in general
-            if name == "air_pressure":
+            if name == "air_pressure" or "air_pressure" not in self.data_vars and len(factors) == 0:
                 for index_lonlat, alt in enumerate(self.alts):
-                    pressures = cross_section[:, index_lonlat]
+                    pressures = cross_section[:, index_lonlat] if "air_pressure" in self.data_vars \
+                        else self.vert_data[::-self.vert_order] * 100 if self.vert_units.lower() == "hpa" else 1
                     closest = 0
                     direction = 1
                     for index_altitude, pressure in enumerate(pressures):
@@ -818,6 +820,7 @@ class LinearSectionDriver(VerticalSectionDriver):
                             [[closest, 1 - (abs(pressures[closest] - alt) / distance)],
                              [next_closest, 1 - (abs(pressures[next_closest] - alt) / distance)]])
 
+            # Interpolate with the previously calculated pressure indices and factors
             for index in range(len(self.alts)):
                 cur_factor = factors[index]
                 value = cross_section[cur_factor[0][0], index] * cur_factor[0][1] + \

--- a/mslib/mswms/wms.py
+++ b/mslib/mswms/wms.py
@@ -205,7 +205,9 @@ class WMSServer(object):
             mss_wms_settings.register_linear_layers = []
         for layer in mss_wms_settings.register_linear_layers:
             if len(layer) == 3:
-                self.register_lsec_layer(layer[2], layer[1], layer[0])
+                self.register_lsec_layer(layer[2], layer[1], layer_class=layer[0])
+            elif len(layer) == 4:
+                self.register_lsec_layer(layer[3], layer[1], layer[2], layer[0])
             else:
                 self.register_lsec_layer(layer[1], layer_class=layer[0])
 
@@ -262,7 +264,7 @@ class WMSServer(object):
                     raise ValueError("dataset '%s' not available", dataset)
             self.vsec_layer_registry[dataset][layer.name] = layer
 
-    def register_lsec_layer(self, datasets, variable=None, layer_class=None):
+    def register_lsec_layer(self, datasets, variable=None, filetype="ml", layer_class=None):
         """
         Register linear section layer in internal dict of layers.
 
@@ -274,7 +276,7 @@ class WMSServer(object):
         for dataset in datasets:
             try:
                 if variable:
-                    layer = layer_class(self.lsec_drivers[dataset], variable)
+                    layer = layer_class(self.lsec_drivers[dataset], variable, filetype)
                 else:
                     layer = layer_class(self.lsec_drivers[dataset])
             except KeyError as ex:

--- a/mslib/utils.py
+++ b/mslib/utils.py
@@ -83,6 +83,7 @@ UR.define("degreeW = -degrees")
 
 UR.define("fraction = [] = frac")
 UR.define("sigma = 1 fraction")
+UR.define("level = sigma")
 UR.define("percent = 1e-2 fraction")
 UR.define("permille = 1e-3 fraction")
 UR.define("ppm = 1e-6 fraction")


### PR DESCRIPTION
Makes the filetype for the linear defaultstyle choosable, so long as it contains an air_pressure field or is a pressure level file.
fixes #1027 