### PR TITLE
Fix pyproj 3.1.0 error

### DIFF
--- a/mslib/msui/mpl_map.py
+++ b/mslib/msui/mpl_map.py
@@ -561,7 +561,9 @@ class MapCanvas(basemap.Basemap):
             # projection, gc.npts() returns lons that connect lon1 and lat2, not lon1 and
             # lon2 ... I cannot figure out why, maybe this is an issue in certain versions
             # of pyproj?? (mr, 16Oct2012)
-            lonlats = gc.npts(lons[i], lats[i], lons[i + 1], lats[i + 1], npoints)
+            lonlats = []
+            if npoints > 0:
+                lonlats = gc.npts(lons[i], lats[i], lons[i + 1], lats[i + 1], npoints)
             # The cylindrical projection of matplotlib is not periodic, that means that
             # -170 longitude and 190 longitude are not identical. The gc projection however
             # assumes identity and maps all longitudes to -180 to 180. This is no issue for


### PR DESCRIPTION
A [recent update in pyproj](https://github.com/pyproj4/pyproj/commit/e0b9453d29e7c9475467268d6838dac8503ab145#diff-884caf2af6e10fc8e0b305d38b427edc7b43d9ed3ec739aed1be2de94049ab7dR279) now throws an error when trying to determine 0 points between A and B, which is the case when trying to draw a path between the same waypoints, where previously it returned an empty list.
This fix calls gc.npts only if npoints is bigger than 0 to avoid this error.
Fixes #1032 