### PR TITLE
Rerun failed tests up to 5 times before complete fail

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,7 +39,12 @@ jobs:
       run: |
         source /opt/conda/bin/activate mssenv \
         && cd $GITHUB_WORKSPACE \
-        && pytest --cov=mslib mslib
+        && pytest --cov=mslib mslib \
+        || (for i in {1..5} \
+          ; do pytest mslib --last-failed --lfnf=none \
+          && break \
+        ; done)
+
         
     - name: coveralls
       if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/xdist_testing.yml
+++ b/.github/workflows/xdist_testing.yml
@@ -41,6 +41,6 @@ jobs:
         && cd $GITHUB_WORKSPACE \
         && pytest -n 6 --dist loadscope --max-worker-restart 0 mslib \
         || (for i in {1..5} \
-          ; do pytest mslib --last-failed --lfnf=none \
+          ; do pytest -n 6 --dist loadscope --max-worker-restart 0 mslib --last-failed --lfnf=none \
           && break \
         ; done)

--- a/.github/workflows/xdist_testing.yml
+++ b/.github/workflows/xdist_testing.yml
@@ -39,4 +39,8 @@ jobs:
       run: |
         source /opt/conda/bin/activate mssenv \
         && cd $GITHUB_WORKSPACE \
-        && pytest -n 6 --dist loadscope --max-worker-restart 0 mslib
+        && pytest -n 6 --dist loadscope --max-worker-restart 0 mslib \
+        || (for i in {1..5} \
+          ; do pytest mslib --last-failed --lfnf=none \
+          && break \
+        ; done)


### PR DESCRIPTION
Band aid fix for all the random failing tests on GitHub.
If tests fail, give them 5 more chances to pass before declaring the action failed.
Does not get rid of the occasional xdist hang up.