### PR TITLE
Close windows and timeout after 60 seconds

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -29,6 +29,7 @@ import importlib
 import importlib.machinery
 import os
 import sys
+import mock
 from PyQt5 import QtWidgets
 # Disable pyc files
 sys.dont_write_bytecode = True
@@ -158,7 +159,10 @@ def close_open_windows(request):
     """
     Closes all windows after every test
     """
-    yield
+    # Mock every MessageBox widget in the test suite to avoid unwanted freezes on unhandled error popups etc.
+    with mock.patch("PyQt5.QtWidgets.QMessageBox.question"), mock.patch("PyQt5.QtWidgets.QMessageBox.information"), \
+            mock.patch("PyQt5.QtWidgets.QMessageBox.critical"), mock.patch("PyQt5.QtWidgets.QMessageBox.warning"):
+        yield
 
     # Try to close all remaining widgets after each test
     for qobject in set(QtWidgets.QApplication.topLevelWindows() + QtWidgets.QApplication.topLevelWidgets()):

--- a/conftest.py
+++ b/conftest.py
@@ -29,6 +29,7 @@ import importlib
 import importlib.machinery
 import os
 import sys
+from PyQt5 import QtWidgets
 # Disable pyc files
 sys.dont_write_bytecode = True
 
@@ -150,6 +151,22 @@ importlib.machinery.SourceFileLoader('mss_wms_settings', constants.SERVER_CONFIG
 sys.path.insert(0, constants.SERVER_CONFIG_FS.root_path)
 importlib.machinery.SourceFileLoader('mscolab_settings', path).load_module()
 sys.path.insert(0, parent_path)
+
+
+@pytest.fixture(autouse=True)
+def close_open_windows(request):
+    """
+    Closes all windows after every test
+    """
+    yield
+
+    # Try to close all remaining widgets after each test
+    for qobject in set(QtWidgets.QApplication.topLevelWindows() + QtWidgets.QApplication.topLevelWidgets()):
+        try:
+            qobject.destroy()
+        # Some objects deny permission, pass in that case
+        except RuntimeError:
+            pass
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
+timeout = 60

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -11,6 +11,7 @@ pytest-pep8
 pytest-flake8
 pytest-xdist
 pytest-cov
+pytest-timeout
 sphinx
 sphinx_rtd_theme
 gitpython


### PR DESCRIPTION
Fixes #1080 and hopefully a fix for #1093
After each test loop through all open windows and widgets and destroy them.
Fail a test that takes more than a minute to hopefully circumvent freezing tests.
Mock all messageboxes to avoid unexpected modal error popups never returning to pytest.