### PR TITLE
Don't trigger multilayer click if favourite

### DIFF
--- a/mslib/msui/multilayers.py
+++ b/mslib/msui/multilayers.py
@@ -62,9 +62,10 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
         self.settings = load_settings_qsettings("multilayers",
                                                 {"favourites": [], "saved_styles": {}, "saved_colors": {}})
         self.synced_reference = Layer(None, None, None, is_empty=True)
+        self.skip_clicked_event = False
         self.listLayers.itemChanged.connect(self.multilayer_changed)
-        self.listLayers.itemClicked.connect(self.multilayer_clicked)
         self.listLayers.itemClicked.connect(self.check_icon_clicked)
+        self.listLayers.itemClicked.connect(self.multilayer_clicked)
         self.listLayers.itemDoubleClicked.connect(self.multilayer_doubleclicked)
         self.listLayers.setVisible(True)
 
@@ -142,6 +143,7 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
                 icon_start += checkbox_width + 6
             position = self.listLayers.viewport().mapFromGlobal(QtGui.QCursor().pos())
             if icon_start <= position.x() <= icon_start + icon_width:
+                self.skip_clicked_event = True
                 self.threads += 1
                 item.favourite_triggered()
                 if self.filter_favourite:
@@ -379,6 +381,10 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
         Gets called whenever the user clicks on a layer in the multilayer list
         Makes sure the dock widget updates its data depending on the users selection
         """
+        if self.skip_clicked_event:
+            self.skip_clicked_event = False
+            return
+
         if not isinstance(item, Layer):
             index = self.cbWMS_URL.findText(item.text(0))
             if index != -1 and index != self.cbWMS_URL.currentIndex():


### PR DESCRIPTION
Fixes #1188 
Trigger favourite check before multilayer click, if the user did change the favourite status skip the multilayer click event once.