### PR TITLE
Add more default WMS servers and examples

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -248,11 +248,13 @@ With setting the option "filepicker_default": "default" you can only access loca
 Example WMS Server
 ++++++++++++++++++
 
-Some public accessible WMS Servers
+Some publicly accessible WMS Servers
 
  * http://osmwms.itc-halle.de/maps/osmfree
  * http://ows.terrestris.de/osm/service
- * https://firms.modaps.eosdis.nasa.gov/wms
+ * http://eumetview.eumetsat.int/geoserver/wms
+ * https://apps.ecmwf.int/wms/?token=public
+ * https://maps.dwd.de/geoserver/wms
 
 
 .. include:: kml_guide.rst

--- a/mslib/utils/config.py
+++ b/mslib/utils/config.py
@@ -107,7 +107,9 @@ class MissionSupportSystemDefaultConfig(object):
 
     # URLs of default WMS servers.
     default_WMS = [
-        "http://localhost:8081/"
+        "http://localhost:8081/",
+        "http://eumetview.eumetsat.int/geoserver/wms",
+        "https://apps.ecmwf.int/wms/?token=public"
     ]
 
     default_VSEC_WMS = [


### PR DESCRIPTION
Adds some more example WMS servers into the documentation and into the default list in MSS.
All verified to work for now.
Fixes #350 