### PR TITLE
Allow GET requests to use query parameters

### DIFF
--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -184,7 +184,7 @@ def verify_user(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
-            user = User.verify_auth_token(request.form.get('token', False))
+            user = User.verify_auth_token(request.values.get('token', False))
         except TypeError:
             logging.debug("no token in request form")
             abort(404)
@@ -242,7 +242,7 @@ def get_auth_token():
 
 @APP.route('/test_authorized')
 def authorized():
-    token = request.form['token']
+    token = request.values['token']
     user = User.verify_auth_token(token)
     if user is not None:
         if mscolab_settings.USER_VERIFICATION:
@@ -317,8 +317,8 @@ def delete_user():
 @APP.route("/messages", methods=["GET"])
 @verify_user
 def messages():
-    timestamp = request.form.get("timestamp", "1970-01-01, 00:00:00")
-    p_id = request.form.get("p_id", None)
+    timestamp = request.values.get("timestamp", "1970-01-01, 00:00:00")
+    p_id = request.values.get("p_id", None)
     chat_messages = cm.get_messages(p_id, timestamp)
     return jsonify({"messages": chat_messages})
 
@@ -386,7 +386,7 @@ def create_project():
 @APP.route('/get_project_by_id', methods=['GET'])
 @verify_user
 def get_project_by_id():
-    p_id = request.form.get('p_id', None)
+    p_id = request.values.get('p_id', None)
     user = g.user
     result = fm.get_file(int(p_id), user)
     if result is False:
@@ -397,7 +397,7 @@ def get_project_by_id():
 @APP.route('/get_all_changes', methods=['GET'])
 @verify_user
 def get_all_changes():
-    p_id = request.form.get('p_id', None)
+    p_id = request.values.get('p_id', None)
     named_version = request.args.get('named_version')
     user = g.user
     result = fm.get_all_changes(int(p_id), user, named_version)
@@ -409,7 +409,7 @@ def get_all_changes():
 @APP.route('/get_change_content', methods=['GET'])
 @verify_user
 def get_change_content():
-    ch_id = int(request.form.get('ch_id', 0))
+    ch_id = int(request.values.get('ch_id', 0))
     result = fm.get_change_content(ch_id)
     if result is False:
         return "False"
@@ -433,7 +433,7 @@ def set_version_name():
 @APP.route('/authorized_users', methods=['GET'])
 @verify_user
 def authorized_users():
-    p_id = request.form.get('p_id', None)
+    p_id = request.values.get('p_id', None)
     return json.dumps({"users": fm.get_authorized_users(int(p_id))})
 
 
@@ -470,7 +470,7 @@ def update_project():
 @APP.route('/project_details', methods=["GET"])
 @verify_user
 def get_project_details():
-    p_id = request.form.get('p_id', None)
+    p_id = request.values.get('p_id', None)
     user = g.user
     return json.dumps(fm.get_project_details(int(p_id), user))
 
@@ -492,7 +492,7 @@ def undo_ftml():
 @APP.route("/users_without_permission", methods=["GET"])
 @verify_user
 def get_users_without_permission():
-    p_id = request.form.get('p_id', None)
+    p_id = request.values.get('p_id', None)
     u_id = g.user.id
     users = fm.fetch_users_without_permission(int(p_id), u_id)
     if users is False:
@@ -504,7 +504,7 @@ def get_users_without_permission():
 @APP.route("/users_with_permission", methods=["GET"])
 @verify_user
 def get_users_with_permission():
-    p_id = request.form.get('p_id', None)
+    p_id = request.values.get('p_id', None)
     u_id = g.user.id
     users = fm.fetch_users_with_permission(int(p_id), u_id)
     if users is False:

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -184,7 +184,7 @@ def verify_user(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
-            user = User.verify_auth_token(request.values.get('token', False))
+            user = User.verify_auth_token(request.args.get('token', request.form.get('token', False)))
         except TypeError:
             logging.debug("no token in request form")
             abort(404)
@@ -242,7 +242,7 @@ def get_auth_token():
 
 @APP.route('/test_authorized')
 def authorized():
-    token = request.values['token']
+    token = request.args.get('token', request.form.get('token'))
     user = User.verify_auth_token(token)
     if user is not None:
         if mscolab_settings.USER_VERIFICATION:
@@ -317,8 +317,8 @@ def delete_user():
 @APP.route("/messages", methods=["GET"])
 @verify_user
 def messages():
-    timestamp = request.values.get("timestamp", "1970-01-01, 00:00:00")
-    p_id = request.values.get("p_id", None)
+    timestamp = request.args.get("timestamp", request.form.get("timestamp", "1970-01-01, 00:00:00"))
+    p_id = request.args.get("p_id", request.form.get("p_id", None))
     chat_messages = cm.get_messages(p_id, timestamp)
     return jsonify({"messages": chat_messages})
 
@@ -386,7 +386,7 @@ def create_project():
 @APP.route('/get_project_by_id', methods=['GET'])
 @verify_user
 def get_project_by_id():
-    p_id = request.values.get('p_id', None)
+    p_id = request.args.get('p_id', request.form.get('p_id', None))
     user = g.user
     result = fm.get_file(int(p_id), user)
     if result is False:
@@ -397,7 +397,7 @@ def get_project_by_id():
 @APP.route('/get_all_changes', methods=['GET'])
 @verify_user
 def get_all_changes():
-    p_id = request.values.get('p_id', None)
+    p_id = request.args.get('p_id', request.form.get('p_id', None))
     named_version = request.args.get('named_version')
     user = g.user
     result = fm.get_all_changes(int(p_id), user, named_version)
@@ -409,7 +409,7 @@ def get_all_changes():
 @APP.route('/get_change_content', methods=['GET'])
 @verify_user
 def get_change_content():
-    ch_id = int(request.values.get('ch_id', 0))
+    ch_id = int(request.args.get('ch_id', request.form.get('ch_id', 0)))
     result = fm.get_change_content(ch_id)
     if result is False:
         return "False"
@@ -433,7 +433,7 @@ def set_version_name():
 @APP.route('/authorized_users', methods=['GET'])
 @verify_user
 def authorized_users():
-    p_id = request.values.get('p_id', None)
+    p_id = request.args.get('p_id', request.form.get('p_id', None))
     return json.dumps({"users": fm.get_authorized_users(int(p_id))})
 
 
@@ -470,7 +470,7 @@ def update_project():
 @APP.route('/project_details', methods=["GET"])
 @verify_user
 def get_project_details():
-    p_id = request.values.get('p_id', None)
+    p_id = request.args.get('p_id', request.form.get('p_id', None))
     user = g.user
     return json.dumps(fm.get_project_details(int(p_id), user))
 
@@ -492,7 +492,7 @@ def undo_ftml():
 @APP.route("/users_without_permission", methods=["GET"])
 @verify_user
 def get_users_without_permission():
-    p_id = request.values.get('p_id', None)
+    p_id = request.args.get('p_id', request.form.get('p_id', None))
     u_id = g.user.id
     users = fm.fetch_users_without_permission(int(p_id), u_id)
     if users is False:
@@ -504,7 +504,7 @@ def get_users_without_permission():
 @APP.route("/users_with_permission", methods=["GET"])
 @verify_user
 def get_users_with_permission():
-    p_id = request.values.get('p_id', None)
+    p_id = request.args.get('p_id', request.form.get('p_id', None))
     u_id = g.user.id
     users = fm.fetch_users_with_permission(int(p_id), u_id)
     if users is False:


### PR DESCRIPTION
fixes #1095 
GET requests normally don't have a body, as such it should have used `args`.
For backwards compatibility both should be allowed, and `args` should be preferred over `form`.
Werkzeug 2.0 removed the usability of `values` for GET requests.