### PR TITLE
Fix mamba installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Installing `MSS` from the `conda-forge` channel can be achieved by adding `conda
 
 Once the `conda-forge` channel has been enabled, `mss` can be installed with:
 
-    $ conda create -n mssenv mamba
+    $ conda create -n mssenv python=3.9
     $ conda activate mssenv
+    $ conda install mamba
     $ mamba install mss
 
 It is possible to list all versions of `mss` available on your platform with:


### PR DESCRIPTION
Fixes mamba failing to install MSS. 

While installing MSS, the following error appears:
```
Encountered problems while solving.
Problem: nothing provides basemap 1.0.7 needed by mss-1.2.1-py27_0
```
This occurs because Mamba keeps python 3.10 unless explicitly mentioned, and currently we don't have a python 3.10 release.
Related: #613