### PR TITLE
Switch to OpenAIP google cloud storage

### DIFF
--- a/mslib/msui/airdata_dockwidget.py
+++ b/mslib/msui/airdata_dockwidget.py
@@ -58,8 +58,8 @@ class AirdataDockwidget(QtWidgets.QWidget, ui.Ui_AirdataDockwidget):
                                                                           self.cbAirspaces.currentData()]))
         self.btApply.clicked.connect(self.redraw_map)
 
-        self.cbAirspaces.currentTextChanged.connect(self.adjust_ui)
-        self.cbAirportType.currentTextChanged.connect(self.adjust_ui)
+        self.cbAirspaces.currentTextChanged.connect(self.adjust_ui_airspaces)
+        self.cbAirportType.currentTextChanged.connect(self.adjust_ui_airports)
 
         self.cbDrawAirports.setChecked(settings["draw_airports"])
         self.cbDrawAirspaces.setChecked(settings["draw_airspaces"])
@@ -77,19 +77,23 @@ class AirdataDockwidget(QtWidgets.QWidget, ui.Ui_AirdataDockwidget):
         self.sbFrom.setValue(settings["filter_from"])
         self.sbTo.setValue(settings["filter_to"])
 
-    def adjust_ui(self):
+    def adjust_ui_airspaces(self):
         """
-        Disables and unchecks, or vice versa, UI elements depending on the current user selection
+        Disables and unchecks, or vice versa, airspace UI elements depending on the current user selection
+        """
+        airspaces_enabled = len(self.cbAirspaces.currentData()) > 0
+        self.cbDrawAirspaces.setChecked(airspaces_enabled)
+        self.cbDrawAirspaces.setEnabled(airspaces_enabled)
+        self.btDownloadAsp.setEnabled(airspaces_enabled)
+
+    def adjust_ui_airports(self):
+        """
+        Disables and unchecks, or vice versa, airport UI elements depending on the current user selection
         """
         airports_enabled = len(self.cbAirportType.currentData()) > 0
         self.cbDrawAirports.setChecked(airports_enabled)
         self.cbDrawAirports.setEnabled(airports_enabled)
         self.btDownload.setEnabled(airports_enabled)
-
-        airspaces_enabled = len(self.cbAirspaces.currentData()) > 0
-        self.cbDrawAirspaces.setChecked(airspaces_enabled)
-        self.cbDrawAirspaces.setEnabled(airspaces_enabled)
-        self.btDownloadAsp.setEnabled(airspaces_enabled)
 
     def redraw_map(self):
         if self.view.map is not None:

--- a/mslib/msui/airdata_dockwidget.py
+++ b/mslib/msui/airdata_dockwidget.py
@@ -28,7 +28,7 @@ import pycountry
 from mslib.msui.mss_qt import ui_airdata_dockwidget as ui
 from PyQt5 import QtWidgets, QtCore
 from mslib.utils.config import save_settings_qsettings, load_settings_qsettings
-from mslib.utils.airdata import _airspace_cache, update_airspace, get_airports
+from mslib.utils.airdata import get_available_airspaces, update_airspace, get_airports
 
 
 class AirdataDockwidget(QtWidgets.QWidget, ui.Ui_AirdataDockwidget):
@@ -41,7 +41,7 @@ class AirdataDockwidget(QtWidgets.QWidget, ui.Ui_AirdataDockwidget):
         code_to_name = {country.alpha_2.lower(): country.name for country in pycountry.countries}
         self.cbAirspaces.addItems([f"{code_to_name.get(airspace[0].split('_')[0], 'Unknown')} "
                                    f"{airspace[0].split('_')[0]}"
-                                   for airspace in _airspace_cache])
+                                   for airspace in get_available_airspaces()])
         self.cbAirportType.addItems(["small_airport", "medium_airport", "large_airport", "heliport", "balloonport",
                                      "seaplane_base", "closed"])
 

--- a/mslib/msui/airdata_dockwidget.py
+++ b/mslib/msui/airdata_dockwidget.py
@@ -44,6 +44,8 @@ class AirdataDockwidget(QtWidgets.QWidget, ui.Ui_AirdataDockwidget):
                                    for airspace in get_available_airspaces()])
         self.cbAirportType.addItems(["small_airport", "medium_airport", "large_airport", "heliport", "balloonport",
                                      "seaplane_base", "closed"])
+        self.cbAirportType.empty_text = "Click here to select airports..."
+        self.cbAirspaces.empty_text = "Click here to select airspaces..."
 
         self.settings_tag = "airdatadock"
         settings = load_settings_qsettings(self.settings_tag, {"draw_airports": False, "draw_airspaces": False,
@@ -56,8 +58,12 @@ class AirdataDockwidget(QtWidgets.QWidget, ui.Ui_AirdataDockwidget):
                                                                           self.cbAirspaces.currentData()]))
         self.btApply.clicked.connect(self.redraw_map)
 
+        self.cbAirspaces.currentTextChanged.connect(self.adjust_ui)
+        self.cbAirportType.currentTextChanged.connect(self.adjust_ui)
+
         self.cbDrawAirports.setChecked(settings["draw_airports"])
         self.cbDrawAirspaces.setChecked(settings["draw_airspaces"])
+
         for airspace in settings["airspaces"]:
             i = self.cbAirspaces.findText(airspace)
             if i != -1:
@@ -70,6 +76,20 @@ class AirdataDockwidget(QtWidgets.QWidget, ui.Ui_AirdataDockwidget):
         self.cbFilterAirspaces.setChecked(settings["filter_airspaces"])
         self.sbFrom.setValue(settings["filter_from"])
         self.sbTo.setValue(settings["filter_to"])
+
+    def adjust_ui(self):
+        """
+        Disables and unchecks, or vice versa, UI elements depending on the current user selection
+        """
+        airports_enabled = len(self.cbAirportType.currentData()) > 0
+        self.cbDrawAirports.setChecked(airports_enabled)
+        self.cbDrawAirports.setEnabled(airports_enabled)
+        self.btDownload.setEnabled(airports_enabled)
+
+        airspaces_enabled = len(self.cbAirspaces.currentData()) > 0
+        self.cbDrawAirspaces.setChecked(airspaces_enabled)
+        self.cbDrawAirspaces.setEnabled(airspaces_enabled)
+        self.btDownloadAsp.setEnabled(airspaces_enabled)
 
     def redraw_map(self):
         if self.view.map is not None:

--- a/mslib/msui/mpl_map.py
+++ b/mslib/msui/mpl_map.py
@@ -348,7 +348,7 @@ class MapCanvas(basemap.Basemap):
         """
         Sets airports to visible or not visible
         """
-        if (reload or not value) and self.airports:
+        if (reload or not value or len(port_type) == 0) and self.airports:
             if OURAIRPORTS_NOTICE in self.crs_text.get_text():
                 self.crs_text.set_text(self.crs_text.get_text().replace(f"{OURAIRPORTS_NOTICE}\n", ""))
             self.airports.remove()
@@ -356,14 +356,14 @@ class MapCanvas(basemap.Basemap):
             self.airports = None
             self.airtext = None
             self.ax.figure.canvas.mpl_disconnect(self.airports_event)
-        if value:
+        if value and len(port_type) > 0:
             self.draw_airports(port_type)
 
     def set_draw_airspaces(self, value, airspaces=[], range_km=None, reload=True):
         """
         Sets airspaces to visible or not visible
         """
-        if (reload or not value) and self.airspaces:
+        if (reload or not value or len(airspaces) == 0) and self.airspaces:
             if OPENAIP_NOTICE in self.crs_text.get_text():
                 self.crs_text.set_text(self.crs_text.get_text().replace(f"{OPENAIP_NOTICE}\n", ""))
             self.airspaces.remove()
@@ -371,7 +371,7 @@ class MapCanvas(basemap.Basemap):
             self.airspaces = None
             self.airspacetext = None
             self.ax.figure.canvas.mpl_disconnect(self.airspace_event)
-        if value:
+        if value and len(airspaces) > 0:
             country_codes = [airspace.split(" ")[-1] for airspace in airspaces]
             self.draw_airspaces(country_codes, range_km)
 

--- a/mslib/msui/mpl_map.py
+++ b/mslib/msui/mpl_map.py
@@ -382,7 +382,7 @@ class MapCanvas(basemap.Basemap):
         if not self.airspaces:
             airspaces = copy.deepcopy(get_airspaces(countries))
             if not airspaces:
-                logging.error("Tried to draw airspaces without .aip files.")
+                logging.error("Tried to draw airspaces without asp files.")
                 return
 
             for i, airspace in enumerate(airspaces):

--- a/mslib/msui/mss_qt.py
+++ b/mslib/msui/mss_qt.py
@@ -276,6 +276,8 @@ class CheckableComboBox(QtWidgets.QComboBox):
         # Prevent popup from closing when clicking on an item
         self.view().viewport().installEventFilter(self)
 
+        self.empty_text = ""
+
     def resizeEvent(self, event):
         # Recompute text to elide as needed
         self.updateText()
@@ -326,6 +328,9 @@ class CheckableComboBox(QtWidgets.QComboBox):
             if self.model().item(i).checkState() == QtCore.Qt.Checked:
                 texts.append(self.model().item(i).text())
         text = ", ".join(texts)
+        if len(text) == 0:
+            text = self.empty_text
+
         self.lineEdit().setText(text)
 
     def addItem(self, text, data=None):

--- a/mslib/utils/airdata.py
+++ b/mslib/utils/airdata.py
@@ -28,6 +28,7 @@
 
 import csv
 import defusedxml.ElementTree as etree
+import humanfriendly
 import os
 import requests
 import re as regex
@@ -93,8 +94,8 @@ def get_airports(force_download=False):
 
     if (force_download or is_outdated or not file_exists) \
             and QtWidgets.QMessageBox.question(None, "Allow download", f"You selected airports to be "
-                                               f"{'drawn' if not force_download else 'downloaded (~10MB)'}." +
-                                               ("\nThe airports file first needs to be downloaded or updated (~10MB)."
+                                               f"{'drawn' if not force_download else 'downloaded (~10 MB)'}." +
+                                               ("\nThe airports file first needs to be downloaded or updated (~10 MB)."
                                                 if not force_download else "") + "\nIs now a good time?",
                                                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No) \
             == QtWidgets.QMessageBox.Yes:
@@ -141,8 +142,8 @@ def update_airspace(force_download=False, countries=["de"]):
         if (force_download or is_outdated or not file_exists) \
                 and QtWidgets.QMessageBox.question(
                     None, "Allow download",
-                    f"The selected {country} airspace needs to be downloaded ({round(int(data[-1]) / (1024**2), 3)}MB)"
-                    f"\nIs now a good time?",
+                    f"The selected {country} airspace needs to be downloaded "
+                    f"({humanfriendly.format_size(int(data[-1]))})\nIs now a good time?",
                     QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No) \
                 == QtWidgets.QMessageBox.Yes:
             download_progress(location, url)


### PR DESCRIPTION
OpenAIP now has a storage bucket through which airspace files can be downloaded.
The google cloud storage library and the OpenAIP API require authentication, so the google cloud storage API is used instead.