### PR TITLE
reload operation list after deleting an operation

### DIFF
--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -897,6 +897,7 @@ class MSSMscolab(QtCore.QObject):
                     try:
                         res = requests.post(url, data=data)
                         res.raise_for_status()
+                        self.reload_operations()
                     except requests.exceptions.RequestException as e:
                         logging.debug(e)
                         show_popup(self.ui, "Error", "Some error occurred! Could not delete operation.")


### PR DESCRIPTION
this keeps the used category when it stills exists. When it is gone we switch to a full list by category ANY.