### PR TITLE
Fixed level selection.

### DIFF
--- a/mslib/mswms/gallery_builder.py
+++ b/mslib/mswms/gallery_builder.py
@@ -270,7 +270,10 @@ function changeImages(from_filter=false){
         return;
     }
 
-    var value = document.getElementById("level-select").value;
+    var value = document.getElementById("level-select").value
+                .replace(" ", "")
+                .replaceAll(" ", "_")
+                .replaceAll("-", "_");
     value = value != "" ? value : "None";
     var vtime = document.getElementById("time-select").value
                 .replaceAll(" ", "_").replaceAll(":", "_").replaceAll("-", "_");
@@ -285,7 +288,7 @@ function changeImages(from_filter=false){
     images = document.getElementsByName("gallery-image");
     for(var i = 0; i < images.length; i++){
         var image = images[i];
-        var tmpLevel = value.replaceAll(" ", "");
+        var tmpLevel = value;
         var new_location = image.src.replace(image.src.split("-").pop(), `${tmpLevel}it${itime}vt${vtime}.png`);
         var parentNode = hrefs.length == images.length ? image.parentNode.parentNode : image.parentNode;
 

--- a/mslib/mswms/wms.py
+++ b/mslib/mswms/wms.py
@@ -380,6 +380,9 @@ class WMSServer(object):
                                                       itime=str(itime), vtime=str(vtime), simple_naming=simple_naming)
                                             if level:
                                                 add_levels([f"{level} {vert_units}"], vert_units)
+                                            else:
+                                                add_levels(["None None"], "None")
+
                                             add_times(itime, [vtime])
                                         continue
 


### PR DESCRIPTION
Works now with units containing spaces and "-" signs. Has an additional
"None" selection for level that reveals layers without levels.

Fix #1348