### PR TITLE
Server and client may crash if no coastline is visible in selected re…

### DIFF
--- a/mslib/msui/mpl_map.py
+++ b/mslib/msui/mpl_map.py
@@ -122,6 +122,7 @@ class MapCanvas(basemap.Basemap):
 
         # Set up the map appearance.
         if self.appearance["draw_coastlines"]:
+            self.map_coastlines = None
             if len(self.coastsegs) > 0 and len(self.coastsegs[0]) > 0:
                 self.map_coastlines = self.drawcoastlines(zorder=3)
             self.map_countries = self.drawcountries(zorder=3)
@@ -535,11 +536,14 @@ class MapCanvas(basemap.Basemap):
         """
         self.appearance["draw_coastlines"] = visible
         if visible and self.map_coastlines is None and self.map_countries is None:
-            self.map_coastlines = self.drawcoastlines(zorder=3)
+            self.map_coastlines = None
+            if len(self.coastsegs) > 0 and len(self.coastsegs[0]) > 0:
+                self.map_coastlines = self.drawcoastlines(zorder=3)
             self.map_countries = self.drawcountries(zorder=3)
             self.ax.figure.canvas.draw()
-        elif not visible and self.map_coastlines is not None and self.map_countries is not None:
-            self.map_coastlines.remove()
+        elif not visible and (self.map_coastlines is not None or self.map_countries is not None):
+            if self.map_coastlines is not None:
+                self.map_coastlines.remove()
             self.map_countries.remove()
             del self.cntrysegs
             self.map_coastlines = None

--- a/mslib/mswms/mpl_hsec.py
+++ b/mslib/mswms/mpl_hsec.py
@@ -350,7 +350,10 @@ class MPLBasemapHorizontalSectionStyle(AbstractHorizontalSectionStyle):
 
         if self._plot_countries:
             # Set up the map appearance.
-            bm.drawcoastlines(color='0.25')
+            try:
+                bm.drawcoastlines(color='0.25')
+            except ValueError as ex:
+                logging.error("Error in basemap/matplotlib call of drawcoastlines: %s", ex)
             bm.drawcountries(color='0.5')
             bm.drawmapboundary(fill_color='white')
 


### PR DESCRIPTION
…ctangle

This was partially captured already in the client, but could be provoked
by enabling/disabling visibility of coastlines in inopportune moments.
The server always crashed. The problem is now safely avoided/treated.

Fix #1410