### PR TITLE
Make linear default layer names unique

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,8 +30,8 @@ jobs:
         && conda config --add channels conda-forge \
         && conda config --set channel_priority strict \
         && conda install --revision 0 \
-        && conda install mamba \
-        && mamba install pyvirtualdisplay \
+        && conda install mamba python=3.9.12 \
+        && mamba install pyvirtualdisplay python=3.9.12 \
         && mamba install --file reqs.txt \
         && mamba install --file requirements.d/development.txt)
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,8 @@ jobs:
         && conda install mamba python=3.9 \
         && mamba install pyvirtualdisplay python=3.9 \
         && mamba install --file reqs.txt \
-        && mamba install --file requirements.d/development.txt)
+        && mamba install --file requirements.d/development.txt \
+        && mamba install -c conda-forge gsl)
 
     - name: Run tests
       timeout-minutes: 25

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
         && source /opt/conda/bin/activate mssenv \
         && conda config --add channels conda-forge \
         && conda install --revision 0 \
-        && conda install mamba python \
+        && conda install mamba python=3.9 \
         && mamba install pyvirtualdisplay python \
         && mamba install --file reqs.txt \
         && mamba install --file requirements.d/development.txt)

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
         && conda config --add channels conda-forge \
         && conda install --revision 0 \
         && conda install mamba python=3.9 \
-        && mamba install pyvirtualdisplay python \
+        && mamba install pyvirtualdisplay python=3.9 \
         && mamba install --file reqs.txt \
         && mamba install --file requirements.d/development.txt)
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,12 +28,13 @@ jobs:
         | sed -e "s/.*://" > reqs.txt \
         && source /opt/conda/bin/activate mssenv \
         && conda config --add channels conda-forge \
+        && conda config --set channel_priority strict \
         && conda install --revision 0 \
         && conda install mamba python=3.9 \
         && mamba install pyvirtualdisplay python=3.9 \
         && mamba install --file reqs.txt \
         && mamba install --file requirements.d/development.txt \
-        && mamba install -c conda-forge gsl)
+        && mamba install -c conda-forge gsl=2.7.0)
 
     - name: Run tests
       timeout-minutes: 25

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
         && conda config --add channels conda-forge \
         && conda config --set channel_priority strict \
         && conda install --revision 0 \
-        && conda install mamba \
+        && conda install mamba python=3.9.12 \
         && mamba install pyvirtualdisplay python=3.9.12 \
         && mamba install --file reqs.txt \
         && mamba install --file requirements.d/development.txt)

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,8 +30,8 @@ jobs:
         && conda config --add channels conda-forge \
         && conda config --set channel_priority strict \
         && conda install --revision 0 \
-        && conda install mamba python=3.9.12 \
-        && mamba install pyvirtualdisplay python=3.9.12 \
+        && conda install mamba \
+        && mamba install pyvirtualdisplay \
         && mamba install --file reqs.txt \
         && mamba install --file requirements.d/development.txt)
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,11 +30,10 @@ jobs:
         && conda config --add channels conda-forge \
         && conda config --set channel_priority strict \
         && conda install --revision 0 \
-        && conda install mamba python=3.9 \
-        && mamba install pyvirtualdisplay python=3.9 \
+        && conda install mamba \
+        && mamba install pyvirtualdisplay \
         && mamba install --file reqs.txt \
-        && mamba install --file requirements.d/development.txt \
-        && mamba install -c conda-forge gsl=2.7.0)
+        && mamba install --file requirements.d/development.txt)
 
     - name: Run tests
       timeout-minutes: 25

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
         && conda config --set channel_priority strict \
         && conda install --revision 0 \
         && conda install mamba \
-        && mamba install pyvirtualdisplay \
+        && mamba install pyvirtualdisplay python=3.9.12 \
         && mamba install --file reqs.txt \
         && mamba install --file requirements.d/development.txt)
 

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - python =3.9
+    - python
     - pip
     - future
     - menuinst  # [win]

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - chameleon
     - execnet
     - fastkml  =0.11
-    - gsl
     - isodate
     - lxml
     - netcdf4

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - chameleon
     - execnet
     - fastkml  =0.11
+    - gsl =2.7.0
     - isodate
     - lxml
     - netcdf4

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - python
+    - python =3.9
     - pip
     - future
     - menuinst  # [win]

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - python =3.9
+    - python
     - pip
     - future
     - menuinst  # [win]
@@ -32,7 +32,7 @@ requirements:
     - chameleon
     - execnet
     - fastkml  =0.11
-    - gsl =2.7.0
+    - gsl
     - isodate
     - lxml
     - netcdf4

--- a/mslib/mswms/mpl_lsec_styles.py
+++ b/mslib/mswms/mpl_lsec_styles.py
@@ -43,8 +43,7 @@ class LS_DefaultStyle(AbstractLinearSectionStyle):
         self.required_datafields = [(filetype, self.variable, None)]
         if filetype != "pl":
             self.required_datafields.insert(0, (filetype, "air_pressure", "Pa"))
-        abbreviation = "".join([text[0] for text in self.variable.split("_")])
-        self.name = f"LS_{str.upper(abbreviation)}"
+        self.name = f"LS_Default_{variable}"
         self.title = f"{self.variable} Linear Plot"
 
 

--- a/mslib/mswms/wms.py
+++ b/mslib/mswms/wms.py
@@ -452,6 +452,9 @@ class WMSServer(object):
                     self.hsec_layer_registry[dataset] = {}
                 else:
                     raise ValueError("dataset '%s' not available", dataset)
+            if layer.name in self.hsec_layer_registry[dataset]:
+                raise ValueError(f"new layer is already registered? dataset={dataset} layer.name={layer.name} "
+                                 f"new={layer} old={self.hsec_layer_registry[dataset][layer.name]}")
             self.hsec_layer_registry[dataset][layer.name] = layer
 
     def register_vsec_layer(self, datasets, layer_class):
@@ -477,6 +480,9 @@ class WMSServer(object):
                     self.vsec_layer_registry[dataset] = {}
                 else:
                     raise ValueError("dataset '%s' not available", dataset)
+            if layer.name in self.vsec_layer_registry[dataset]:
+                raise ValueError(f"new layer is already registered? dataset={dataset} layer.name={layer.name} "
+                                 f"new={layer} old={self.vsec_layer_registry[dataset][layer.name]}")
             self.vsec_layer_registry[dataset][layer.name] = layer
 
     def register_lsec_layer(self, datasets, variable=None, filetype="ml", layer_class=None):
@@ -505,6 +511,9 @@ class WMSServer(object):
                     self.lsec_layer_registry[dataset] = {}
                 else:
                     raise ValueError("dataset '%s' not available", dataset)
+            if layer.name in self.lsec_layer_registry[dataset]:
+                raise ValueError(f"new layer is already registered? dataset={dataset} layer.name={layer.name} "
+                                 f"new={layer} old={self.lsec_layer_registry[dataset][layer.name]}")
             self.lsec_layer_registry[dataset][layer.name] = layer
 
     def create_service_exception(self, code=None, text="", version="1.3.0"):


### PR DESCRIPTION
Currently, similar variables result in layers of same name, which
overwrirte each other in registration.

Fix #1415