### PR TITLE
skipped test because of timeout on github

### DIFF
--- a/mslib/msui/_tests/test_mscolab.py
+++ b/mslib/msui/_tests/test_mscolab.py
@@ -404,6 +404,7 @@ class Test_Mscolab(object):
         wpdata_server = self.window.mscolab.waypoints_model.waypoint_data(0)
         assert wpdata_local.lat != wpdata_server.lat
 
+    @pytest.mark.skip("fails often on github on a timeout >60s")
     @mock.patch("mslib.msui.mscolab.QtWidgets.QErrorMessage.showMessage")
     @mock.patch("mslib.msui.mscolab.get_open_filename", return_value=os.path.join(sample_path, u"example.ftml"))
     def test_browse_add_operation(self, mockopen, mockmessage):


### PR DESCRIPTION
often github shows
```
ERROR mslib/msui/_tests/test_mscolab.py::Test_Mscolab::test_browse_add_operation
279
====== 415 passed, 24 skipped, 504 warnings, 1 error in 609.79s (0:10:09) ======
280
Error: The action has timed out.
```
disabling until we know how to solve this
