### PR TITLE
verifying if time.sleep() solves the _test_msui/test_mscolab timeouts

### DIFF
--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -684,6 +684,9 @@ class Test_Mscolab(object):
         self.connect_window.show()
         QtTest.QTest.mouseClick(self.connect_window.connectBtn, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
+        # socketio multiprocessing can reach a timeout
+        # idea from discussion
+        # https://stackoverflow.com/questions/67913861/python-multiprocessing-weird-behavior-when-not-using-time-sleep
         time.sleep(0.5 * random.random())
 
     def _login(self, emailid, password):

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -26,6 +26,9 @@
 """
 import sys
 import os
+import time
+import random
+
 import fs
 import fs.errors
 import fs.opener.errors
@@ -681,7 +684,7 @@ class Test_Mscolab(object):
         self.connect_window.show()
         QtTest.QTest.mouseClick(self.connect_window.connectBtn, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        QtTest.QTest.qWait(500)
+        time.sleep(0.5 * random.random())
 
     def _login(self, emailid, password):
         self.connect_window.loginEmailLe.setText(emailid)


### PR DESCRIPTION
closes #1685 