### PR TITLE
Switch syntax of removing vertical lines to that used everywhere else

### DIFF
--- a/mslib/msui/mpl_qtwidget.py
+++ b/mslib/msui/mpl_qtwidget.py
@@ -502,12 +502,12 @@ class SideViewPlotter(ViewPlotter):
 
     def draw_vertical_lines(self, highlight, lats, lons):
         # Remove all vertical lines
-        for line in self.vertical_lines[:]:
+        for line in self.vertical_lines:
             try:
-                self.ax.lines.remove(line)
+                line.remove()
             except ValueError as e:
                 logging.debug("Vertical line was somehow already removed:\n%s", e)
-            self.vertical_lines.remove(line)
+        self.vertical_lines = []
 
         # Add vertical lines
         if self.settings["draw_verticals"]:
@@ -653,7 +653,7 @@ class LinearViewPlotter(ViewPlotter):
         # Remove all vertical lines
         for line in self.vertical_lines:
             try:
-                self.ax.lines.remove(line)
+                line.remove()
             except ValueError as e:
                 logging.debug("Vertical line was somehow already removed:\n%s", e)
         self.vertical_lines = []


### PR DESCRIPTION
The old way of doing it seems to not work any more on more recent versions of matplotlib.

Fix #1714