### PR TITLE
fix crash when getting credentials from keyring

### DIFF
--- a/mslib/utils/auth.py
+++ b/mslib/utils/auth.py
@@ -64,7 +64,7 @@ def get_password_from_keyring(service_name=NAME, username=""):
                 return None
             else:
                 return cred.password
-        except keyring.errors.KeyringLocked as ex:
+        except (keyring.errors.KeyringLocked, keyring.errors.InitError) as ex:
             logging.warn(ex)
             return None
 


### PR DESCRIPTION
I ran into an issue when trying to connect to mscolab. See: 
[Screencast from 13.07.2023 14:03:03.webm](https://github.com/Open-MSS/MSS/assets/9308656/e329d81b-764f-49d1-b2d9-56ec680eed43)

~This bug was probably introduced in #1731.~

This patch catches the exception instead of crashing the app. I am not sure what other side-effects this might have though.

Fixes #1816 