### PR TITLE
renamed endpoint for mscolab authentification

### DIFF
--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -203,7 +203,7 @@ def home():
     return render_template("/index.html")
 
 
-@APP.route("/status")
+@APP.route("/status_auth")
 @conditional_decorator(auth.login_required, mscolab_settings.__dict__.get('enable_basic_http_authentication', False))
 def hello():
     return "Mscolab server"

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -218,7 +218,7 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
             s = requests.Session()
             s.auth = auth
             s.headers.update({'x-test': 'true'})
-            r = s.get(urljoin(url, 'status'), timeout=(2, 10))
+            r = s.get(urljoin(url, 'status_auth'), timeout=(2, 10))
             if r.status_code == 401:
                 self.set_status("Error", 'Server authentication data were incorrect.')
             elif r.status_code == 200:

--- a/tests/_test_mscolab/test_server.py
+++ b/tests/_test_mscolab/test_server.py
@@ -78,7 +78,7 @@ class Test_Server(TestCase):
 
     def test_hello(self):
         with self.app.test_client() as test_client:
-            response = test_client.get('/status')
+            response = test_client.get('/status_auth')
             assert response.status_code == 200
             assert b"Mscolab server" in response.data
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -182,7 +182,7 @@ def mscolab_check_free_port(all_ports, port):
 
 
 def mscolab_ping_server(port):
-    url = f"http://127.0.0.1:{port}/status"
+    url = f"http://127.0.0.1:{port}/status_auth"
     try:
         r = requests.get(url, timeout=(2, 10))
         if r.text == "Mscolab server":


### PR DESCRIPTION
With this change, we can "patch" the mscolab server to serve both 8.x and 9.x but do not need to. This can actually remain in develop, but we can remove it as well. I think it is better this way.