### PR TITLE
Spelling-Correction-Commit

### DIFF
--- a/mslib/msui/topview.py
+++ b/mslib/msui/topview.py
@@ -276,7 +276,7 @@ class MSUITopViewWindow(MSUIMplViewWindow, ui.Ui_TopViewWindow):
         are connected).
         """
         toolitems = ["(select to open control)", "Web Map Service", "Satellite Tracks", "Remote Sensing", "KML Overlay",
-                     "Airports/Airspaces", "Multiple FLightpath"]
+                     "Airports/Airspaces", "Multiple Flightpath"]
         self.cbTools.clear()
         self.cbTools.addItems(toolitems)
 


### PR DESCRIPTION
According to issue there was a spelling mistake in TopView.py file, it has now been corrected from "Multiple FLightpath" to "Multiple Flightpath".