### PR TITLE
Remove usage of werkzeug.urls.url_encode

### DIFF
--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -303,7 +303,7 @@ class FileManager:
             operation_data = operation_file.read()
         return operation_data
 
-    def get_all_changes(self, op_id, user, named_version=None):
+    def get_all_changes(self, op_id, user, named_version=False):
         """
         op_id: operation-id
         user: user of this request
@@ -314,17 +314,17 @@ class FileManager:
         perm = Permission.query.filter_by(u_id=user.id, op_id=op_id).first()
         if perm is None:
             return False
-        # Get all changes
-        if named_version is None:
-            changes = Change.query.\
-                filter_by(op_id=op_id)\
-                .order_by(Change.created_at.desc())\
-                .all()
         # Get only named versions
-        else:
+        if named_version:
             changes = Change.query\
                 .filter(Change.op_id == op_id)\
                 .filter(~Change.version_name.is_(None))\
+                .order_by(Change.created_at.desc())\
+                .all()
+        # Get all changes
+        else:
+            changes = Change.query\
+                .filter_by(op_id=op_id)\
                 .order_by(Change.created_at.desc())\
                 .all()
 

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -422,7 +422,7 @@ def get_operation_by_id():
 @verify_user
 def get_all_changes():
     op_id = request.args.get('op_id', request.form.get('op_id', None))
-    named_version = request.args.get('named_version')
+    named_version = request.args.get('named_version') == "True"
     user = g.user
     result = fm.get_all_changes(int(op_id), user, named_version)
     if result is False:

--- a/mslib/msui/mscolab_version_history.py
+++ b/mslib/msui/mscolab_version_history.py
@@ -133,7 +133,7 @@ class MSColabVersionHistory(QtWidgets.QMainWindow, ui.Ui_MscolabVersionHistory):
                 "token": self.token,
                 "op_id": self.op_id
             }
-            named_version_only = None
+            named_version_only = False
             if self.versionFilterCB.currentIndex() == 0:
                 named_version_only = True
             query_string = urlencode({"named_version": named_version_only})

--- a/mslib/msui/mscolab_version_history.py
+++ b/mslib/msui/mscolab_version_history.py
@@ -29,8 +29,7 @@ from datetime import datetime
 import json
 
 import requests
-from urllib.parse import urljoin
-from werkzeug.urls import url_encode
+from urllib.parse import urljoin, urlencode
 
 from mslib.utils.verify_user_token import verify_user_token
 from mslib.msui.flighttrack import WaypointsTableModel
@@ -137,7 +136,7 @@ class MSColabVersionHistory(QtWidgets.QMainWindow, ui.Ui_MscolabVersionHistory):
             named_version_only = None
             if self.versionFilterCB.currentIndex() == 0:
                 named_version_only = True
-            query_string = url_encode({"named_version": named_version_only})
+            query_string = urlencode({"named_version": named_version_only})
             url_path = f'get_all_changes?{query_string}'
             url = urljoin(self.mscolab_server_url, url_path)
             r = requests.get(url, data=data, timeout=(2, 10))


### PR DESCRIPTION
Replaces it with `urllib.parse.urlencode`. Fixes #1910.