### PR TITLE
Use old operation name as default for new name in rename_operation_ha…

### DIFF
--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -1162,6 +1162,7 @@ class MSUIMscolab(QtCore.QObject):
                     f"You're about to rename the operation - '{self.active_operation_name}' "
                     f"Enter new operation name: "
                 ),
+                text=f"{self.active_operation_name}",
             )
             if ok:
                 data = {


### PR DESCRIPTION
Use old operation name as default for new name in rename_operation_handler

**Purpose of PR?**:

Fixes #1921

**Checklist:**
- [x] Bug fix. Fixes #1921
- [x] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests
