### PR TITLE
chore: Ignore deprecation warnings from pkg_resources

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,8 @@
 log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 timeout = 60
+filterwarnings =
+    # These namespaces are declared in a way not conformant with PEP420. Not much we can do about that here, we should keep an eye on when this is fixed in our dependencies though.
+    ignore:Deprecated call to `pkg_resources.declare_namespace\('(xstatic|xstatic\.pkg|mpl_toolkits|mpl_toolkits\.basemap_data|sphinxcontrib|zope|fs|fs\.opener)'\)`\.:DeprecationWarning
+    # pkg_resources is explicitly used in fs (PyFilesystem2). Ignore the deprecation warning here.
+    ignore:pkg_resources is deprecated as an API.:DeprecationWarning


### PR DESCRIPTION
**Purpose of PR?**:

Ignore deprecation warnings for namespace packages that are not conformant with PEP420, e.g. due to using `pkg_resources.declare_namespace`. Related to #1919, I think we should keep that issue open until this is actually fixed in our dependencies and we can remove the warning filters again, though.

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

pytest, checking that the deprecation warnings do not show up.

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [x] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->