### PR TITLE
Remove redundant calls to "operations"

### DIFF
--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -508,7 +508,7 @@ class MSUIMscolab(QtCore.QObject):
         # User email
         self.email = None
         # Display all categories by default
-        self.selected_category = "ANY"
+        self.selected_category = "*ANY*"
         # Gravatar image path
         self.gravatar = None
 
@@ -1249,7 +1249,7 @@ class MSUIMscolab(QtCore.QObject):
             self.selected_category = self.ui.filterCategoryCb.currentText()
             if update_operations:
                 self.add_operations_to_ui()
-            if self.selected_category != "ANY":
+            if self.selected_category != "*ANY*":
                 items = [self.ui.listOperationsMSC.item(i) for i in range(self.ui.listOperationsMSC.count())]
                 row = 0
                 for item in items:
@@ -1257,6 +1257,8 @@ class MSUIMscolab(QtCore.QObject):
                         self.ui.listOperationsMSC.takeItem(row)
                     else:
                         row += 1
+            else:
+                self.add_operations_to_ui()
 
     def server_options_handler(self, index):
         selected_option = self.ui.serverOptionsCb.currentText()
@@ -1493,11 +1495,11 @@ class MSUIMscolab(QtCore.QObject):
                 operations = _json["operations"]
                 self.ui.filterCategoryCb.currentIndexChanged.disconnect(self.operation_category_handler)
                 self.ui.filterCategoryCb.clear()
-                categories = set(["ANY"])
+                categories = set(["*ANY*"])
                 for operation in operations:
                     categories.add(operation["category"])
-                categories.remove("ANY")
-                categories = ["ANY"] + sorted(categories)
+                categories.remove("*ANY*")
+                categories = ["*ANY*"] + sorted(categories)
                 category = config_loader(dataset="MSCOLAB_category")
                 self.ui.filterCategoryCb.addItems(categories)
                 if category in categories:

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -607,10 +607,9 @@ class MSUIMscolab(QtCore.QObject):
             self.ui.actionAddOperation.setEnabled(True)
 
             # Populate open operations list
-            self.add_operations_to_ui()
-
+            ops = self.add_operations_to_ui()
             # Show category list
-            self.show_categories_to_ui()
+            self.show_categories_to_ui(ops)
 
             self.ui.activeOperationDesc.setHidden(False)
             self.ui.actionChangeCategory.setEnabled(False)
@@ -870,6 +869,7 @@ class MSUIMscolab(QtCore.QObject):
                 self.error_dialog.showMessage('The path already exists')
 
     def get_recent_op_id(self):
+        logging.debug('get_recent_op_id')
         if verify_user_token(self.mscolab_server_url, self.token):
             """
             get most recent operation's op_id
@@ -1243,12 +1243,13 @@ class MSUIMscolab(QtCore.QObject):
         self.waypoints_model.dataChanged.connect(self.handle_waypoints_changed)
         self.reload_view_windows()
 
-    def operation_category_handler(self):
+    def operation_category_handler(self, update_operations=True):
         # only after_login
         if self.mscolab_server_url is not None:
             self.selected_category = self.ui.filterCategoryCb.currentText()
-            if self.selected_category != "ANY":
+            if update_operations:
                 self.add_operations_to_ui()
+            if self.selected_category != "ANY":
                 items = [self.ui.listOperationsMSC.item(i) for i in range(self.ui.listOperationsMSC.count())]
                 row = 0
                 for item in items:
@@ -1256,8 +1257,6 @@ class MSUIMscolab(QtCore.QObject):
                         self.ui.listOperationsMSC.takeItem(row)
                     else:
                         row += 1
-            else:
-                self.add_operations_to_ui()
 
     def server_options_handler(self, index):
         selected_option = self.ui.serverOptionsCb.currentText()
@@ -1316,6 +1315,7 @@ class MSUIMscolab(QtCore.QObject):
         """
         get most recent operation
         """
+        logging.debug('get_recent_operation')
         if verify_user_token(self.mscolab_server_url, self.token):
             data = {
                 "token": self.token
@@ -1466,6 +1466,7 @@ class MSUIMscolab(QtCore.QObject):
 
     @QtCore.pyqtSlot(int)
     def handle_operation_deleted(self, op_id):
+        logging.debug('handle_operation_deleted')
         old_operation_name = self.active_operation_name
         old_active_id = self.active_op_id
         operation_name = self.delete_operation_from_list(op_id)
@@ -1473,19 +1474,24 @@ class MSUIMscolab(QtCore.QObject):
             operation_name = old_operation_name
         show_popup(self.ui, "Success", f'Operation "{operation_name}" was deleted!', icon=1)
 
-    def show_categories_to_ui(self):
+    def show_categories_to_ui(self, ops=None):
         """
         adds the list of operation categories to the UI
         """
-        if verify_user_token(self.mscolab_server_url, self.token):
-            data = {
-                "token": self.token
-            }
-            r = requests.get(f'{self.mscolab_server_url}/operations', data=data,
-                             timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+        logging.debug('show_categories_to_ui')
+        if verify_user_token(self.mscolab_server_url, self.token) or ops:
+            if ops is not None:
+                r = ops
+            else:
+                data = {
+                    "token": self.token
+                }
+                r = requests.get(f'{self.mscolab_server_url}/operations', data=data,
+                                 timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.text != "False":
                 _json = json.loads(r.text)
                 operations = _json["operations"]
+                self.ui.filterCategoryCb.currentIndexChanged.disconnect(self.operation_category_handler)
                 self.ui.filterCategoryCb.clear()
                 categories = set(["ANY"])
                 for operation in operations:
@@ -1497,9 +1503,12 @@ class MSUIMscolab(QtCore.QObject):
                 if category in categories:
                     index = categories.index(category)
                     self.ui.filterCategoryCb.setCurrentIndex(index)
+                self.operation_category_handler(update_operations=False)
+                self.ui.filterCategoryCb.currentIndexChanged.connect(self.operation_category_handler)
 
     def add_operations_to_ui(self):
         logging.debug('add_operations_to_ui')
+        r = None
         if verify_user_token(self.mscolab_server_url, self.token):
             data = {
                 "token": self.token
@@ -1551,6 +1560,7 @@ class MSUIMscolab(QtCore.QObject):
         else:
             show_popup(self.ui, "Error", "Your Connection is expired. New Login required!")
             self.logout()
+        return r
 
     def show_operation_options_in_inactivated_state(self, access_level):
         self.ui.actionUnarchiveOperation.setEnabled(False)
@@ -1780,9 +1790,9 @@ class MSUIMscolab(QtCore.QObject):
             self.waypoints_model.dataChanged.connect(self.handle_waypoints_changed)
 
     def reload_operations(self):
-        self.add_operations_to_ui()
+        ops = self.add_operations_to_ui()
         selected_category = self.ui.filterCategoryCb.currentText()
-        self.show_categories_to_ui()
+        self.show_categories_to_ui(ops)
         index = self.ui.filterCategoryCb.findText(selected_category, QtCore.Qt.MatchFixedString)
         if index >= 0:
             self.ui.filterCategoryCb.setCurrentIndex(index)

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -580,7 +580,7 @@ class Test_Mscolab(object):
                             range(self.window.mscolab.ui.listOperationsMSC.count())]
         assert ["flight5678"] == operation_pathes
 
-    def test_get_recent_op_id(self, mockbox, mockpatch):
+    def test_get_recent_op_id(self):
         self._connect_to_mscolab()
         self._create_user("anton", "anton@something.org", "something")
         QtTest.QTest.qWait(100)

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -560,7 +560,27 @@ class Test_Mscolab(object):
         assert self.window.mscolab.active_op_id is not None
         assert self.window.mscolab.active_operation_category == "new_category"
 
-    def test_get_recent_op_id(self):
+    @mock.patch("PyQt5.QtWidgets.QMessageBox.information")
+    def test_any_special_category(self, mockpatch):
+        self._connect_to_mscolab()
+        self._create_user("something", "something@something.org", "something")
+        self._create_operation("flight1234", "Description flight1234")
+        QtTest.QTest.qWait(0)
+        self._create_operation("flight5678", "Description flight5678", category="furtherexample")
+        # all operations of two defined categories are found
+        assert self.window.mscolab.selected_category == "*ANY*"
+        operation_pathes = [self.window.mscolab.ui.listOperationsMSC.item(i).operation_path for i in
+                            range(self.window.mscolab.ui.listOperationsMSC.count())]
+        assert ["flight1234", "flight5678"] == operation_pathes
+        self.window.mscolab.ui.filterCategoryCb.setCurrentIndex(2)
+        QtWidgets.QApplication.processEvents()
+        # only operation of furtherexample are found
+        assert self.window.mscolab.selected_category == "furtherexample"
+        operation_pathes = [self.window.mscolab.ui.listOperationsMSC.item(i).operation_path for i in
+                            range(self.window.mscolab.ui.listOperationsMSC.count())]
+        assert ["flight5678"] == operation_pathes
+
+    def test_get_recent_op_id(self, mockbox, mockpatch):
         self._connect_to_mscolab()
         self._create_user("anton", "anton@something.org", "something")
         QtTest.QTest.qWait(100)
@@ -720,14 +740,14 @@ class Test_Mscolab(object):
         read_config_file(path=config_file)
 
     @mock.patch("mslib.msui.mscolab.QtWidgets.QErrorMessage.showMessage")
-    def _create_operation(self, path, description, mockbox):
+    def _create_operation(self, path, description, mockbox, category="example"):
         self.window.actionAddOperation.trigger()
         QtWidgets.QApplication.processEvents()
         self.window.mscolab.add_proj_dialog.path.setText(str(path))
         QtWidgets.QApplication.processEvents()
         self.window.mscolab.add_proj_dialog.description.setText(str(description))
         QtWidgets.QApplication.processEvents()
-        self.window.mscolab.add_proj_dialog.category.setText("example")
+        self.window.mscolab.add_proj_dialog.category.setText(category)
         QtWidgets.QApplication.processEvents()
         okWidget = self.window.mscolab.add_proj_dialog.buttonBox.button(
             self.window.mscolab.add_proj_dialog.buttonBox.Ok)


### PR DESCRIPTION
Pass on previous results to subsequent functions, disable unnecessary request triggers.

Fix #1940
