### PR TITLE
Remove upper bound on flask-socketio version

### DIFF
--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -66,7 +66,7 @@ requirements:
     - flask-mail
     - flask-migrate
     - werkzeug >=2.2.3
-    - flask-socketio =5.1.0
+    - flask-socketio >=5.1.0
     - flask-sqlalchemy >=3.0.0
     - flask-cors
     - passlib


### PR DESCRIPTION
**Purpose of PR?**:

Part of #1942

**Does this PR introduce a breaking change?**

Not quite sure. The reason this version was pinned is #1356, but I cannot reproduce this issue even with flask-socketio=5.1.1.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

test suite passes

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->