### PR TITLE
enable boa build and documentation

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -449,13 +449,25 @@ As developer you should copy this directory and adjust the source path, build nu
 using a local meta.yaml recipe::
 
   $ cd yourlocalbuild
-  $ conda build .
-  $ conda create -n mssbuildtest mamba
-  $ conda activate mssbuildtest
-  $ mamba install --use-local mss
+  $ mamba build .
+  $ mamba create -n mssbuildtest
+  $ mamba activate mssbuildtest
+  $ mamba install -c local mss
 
 
 Take care on removing alpha builds, or increase the build number for a new version.
+
+
+Alternative local build by boa
+------------------------------
+
+`boa <https://boa-build.readthedocs.io/en/latest/>`_ is a new faster option to build conda packages.
+We need first to convert the existing description to a recipe.yaml::
+
+  $ cd yourlocalbuild
+  $ boa convert meta.yaml > recipe.yaml
+  $ boa build .
+  $ mamba install -c local mss
 
 
 Creating a new release

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - setuptools
     - pip
     - menuinst  # [win]
+    - future
   run:
     - python
     - defusedxml

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -23,3 +23,4 @@ pytest-reverse
 eventlet>0.30.2
 dnspython>=2.0.0, <2.3.0
 gsl==2.7.0
+boa


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2000 

**Does this PR introduce a breaking change?**
it enables us to build much faster. After a while of testing we could for example change our docker build for testing environments.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
tried the docs example

