### PR TITLE
Pin xmlschema, werkzeug

### DIFF
--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -92,6 +92,7 @@ requirements:
     - email_validator
     - keyring
     - dbus-python
+    - xmlschema <=2.5.0
 
 test:
   imports:

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -65,7 +65,7 @@ requirements:
     - flask-httpauth
     - flask-mail
     - flask-migrate
-    - werkzeug >=2.2.3
+    - werkzeug >=2.2.3,<3.0.0
     - flask-socketio =5.1.0
     - flask-sqlalchemy >=3.0.0
     - flask-cors

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -92,7 +92,6 @@ requirements:
     - email_validator
     - keyring
     - dbus-python
-    - xmlschema <=2.5.0
 
 test:
   imports:

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -23,5 +23,5 @@ pytest-reverse
 eventlet>0.30.2
 dnspython>=2.0.0, <2.3.0
 gsl==2.7.0
-xmlschema<=2.5.0
+xmlschema<2.5.0
 

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -23,3 +23,5 @@ pytest-reverse
 eventlet>0.30.2
 dnspython>=2.0.0, <2.3.0
 gsl==2.7.0
+xmlschema<=2.5.0
+


### PR DESCRIPTION
**Purpose of PR?**:

see #2056,#2058

**Does this PR introduce a breaking change?**
pinning xmlschema because of incompatible to mamba-1.4.2 and werkzeug because of deprecations. 

