### PR TITLE
Replace SIGKILL with SIGTERM

### DIFF
--- a/mslib/mscolab/mscolab.py
+++ b/mslib/mscolab/mscolab.py
@@ -280,7 +280,7 @@ def handle_mscolab_metadata_init(repo_exists):
         cmd_curl = ["curl", "http://localhost:8083/metadata/localhost_test_idp",
                     "-o", f"{mscolab_settings.MSCOLAB_SSO_DIR}/metadata_sp.xml"]
         subprocess.run(cmd_curl, check=True)
-        process.kill()
+        process.terminate()
         print('mscolab metadata file generated succesfully')
         return True
 


### PR DESCRIPTION
**Purpose of PR?**:

Replace the overly excessive `.kill()` call with `.terminate()`. SIGTERM is the less invasive one, allowing the process to gracefully shutdown on its own.

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Ran `python mslib/mscolab/mscolab.py sso_conf --init_sso_metadata` and it still worked.