### PR TITLE
using an IDP, email is already validated, we activate the profile

### DIFF
--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -220,7 +220,9 @@ def create_or_update_idp_user(email, username, token, authentication_backend):
     """
     user = User.query.filter_by(emailid=email).first()
     if not user:
-        user = User(email, username, password=token, confirmed=False, confirmed_on=None,
+        # using an IDP for a new account/profile, e-mail is already verified by the IDP
+        confirm_time = datetime.datetime.now() + datetime.timedelta(seconds=5)
+        user = User(email, username, password=token, confirmed=True, confirmed_on=confirm_time,
                     authentication_backend=authentication_backend)
         result = fm.modify_user(user, action="create")
     else:

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -221,7 +221,7 @@ def create_or_update_idp_user(email, username, token, authentication_backend):
     user = User.query.filter_by(emailid=email).first()
     if not user:
         # using an IDP for a new account/profile, e-mail is already verified by the IDP
-        confirm_time = datetime.datetime.now() + datetime.timedelta(seconds=5)
+        confirm_time = datetime.datetime.now() + datetime.timedelta(seconds=1)
         user = User(email, username, password=token, confirmed=True, confirmed_on=confirm_time,
                     authentication_backend=authentication_backend)
         result = fm.modify_user(user, action="create")


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2079

When an IDP user accesses an MSColab server first time, the e-mail is verified by the IDP and we create a valid user.
confirmed_on +1 second