### PR TITLE
UTC based timestamps

### DIFF
--- a/mslib/mscolab/models.py
+++ b/mslib/mscolab/models.py
@@ -50,7 +50,7 @@ class User(db.Model):
         self.username = username
         self.emailid = emailid
         self.hash_password(password)
-        self.registered_on = datetime.datetime.now()
+        self.registered_on = datetime.datetime.now(tz=datetime.timezone.utc)
         self.confirmed = confirmed
         self.confirmed_on = confirmed_on
         self.authentication_backend = authentication_backend

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -332,7 +332,7 @@ def confirm_email(token):
         if user.confirmed:
             return render_template('user/confirmed.html', username=user.username)
         else:
-            fm.modify_user(user, attribute="confirmed_on", value=datetime.datetime.now())
+            fm.modify_user(user, attribute="confirmed_on", value=datetime.datetime.now(tz=datetime.timezone.utc))
             fm.modify_user(user, attribute="confirmed", value=True)
             return render_template('user/confirmed.html', username=user.username)
 

--- a/tests/_test_mscolab/test_file_manager.py
+++ b/tests/_test_mscolab/test_file_manager.py
@@ -95,7 +95,7 @@ class Test_FileManager(TestCase):
             # cannot create a user a second time
             assert self.fm.modify_user(user, action="create") is False
             # confirming the user
-            confirm_time = datetime.datetime.now() + datetime.timedelta(days=1)
+            confirm_time = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=1)
             self.fm.modify_user(user_query, attribute="confirmed_on", value=confirm_time)
             self.fm.modify_user(user_query, attribute="confirmed", value=True)
             user_query = User.query.filter_by(id=user.id).first()

--- a/tests/_test_mscolab/test_sockets_manager.py
+++ b/tests/_test_mscolab/test_sockets_manager.py
@@ -204,7 +204,7 @@ class Test_Socket_Manager(LiveSocketTestCase):
             messages = self.cm.get_messages(1, timestamp)
             assert len(messages) == 2
             assert messages[0]["u_id"] == self.user.id
-            timestamp = datetime.datetime.now().strftime("%Y-%m-%d, %H:%M:%S")
+            timestamp = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S")
             messages = self.cm.get_messages(1, timestamp)
             assert len(messages) == 0
 


### PR DESCRIPTION
**Purpose of PR?**:
We use in mscolab `datetime.datetime.now() `
This can have a timezone issue, we should replace it by a timezone based on UTC
`datetime.datetime.now(tz=datetime.timezone.utc)`
Fixes #2122 

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->