### PR TITLE
fix: the flake8 max line failure

### DIFF
--- a/.github/workflows/python-flake8.yml
+++ b/.github/workflows/python-flake8.yml
@@ -27,4 +27,4 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8
-        flake8 --count --max-line-length=127 --statistics mslib tests
+        flake8 --count --statistics mslib tests

--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -569,7 +569,7 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                             self.dict_files[self.listWidget.item(index).text()]["patch"] = patch
 
                 except (AttributeError, IOError, TypeError, et.XMLSyntaxError, et.XMLSchemaError,
-                        et.XMLSchemaParseError, et.XMLSchemaValidateError) as ex:  # catches KML Syntax Errors                 
+                        et.XMLSchemaParseError, et.XMLSchemaValidateError) as ex:  # catches KML Syntax Errors
                     logging.error("KML Overlay - %s: %s", type(ex), ex)
                     self.labelStatusBar.setText(str(self.listWidget.item(index).text()) +
                                                 " is either an invalid KML File or has an error.")

--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -568,8 +568,8 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                                                  self.dict_files[self.listWidget.item(index).text()]["linewidth"])
                             self.dict_files[self.listWidget.item(index).text()]["patch"] = patch
 
-                except (AttributeError, IOError, TypeError, et.XMLSyntaxError, et.XMLSchemaError, et.XMLSchemaParseError,
-                        et.XMLSchemaValidateError) as ex:  # catches KML Syntax Errors
+                except (AttributeError, IOError, TypeError, et.XMLSyntaxError, et.XMLSchemaError,
+                        et.XMLSchemaParseError, et.XMLSchemaValidateError) as ex:  # catches KML Syntax Errors                 
                     logging.error("KML Overlay - %s: %s", type(ex), ex)
                     self.labelStatusBar.setText(str(self.listWidget.item(index).text()) +
                                                 " is either an invalid KML File or has an error.")


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2111

**Checklist:**
- [X] Bug fix. Fixes #2111 

**I removed the max-line-length = 127 from the python-flake8 because it was overwriting setup.cfg. These changes ensure that the codebase adheres to the project's coding standards and resolves the reported issues.**