### PR TITLE
Remove unnecessary development dependencies

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -342,9 +342,7 @@ Use the -v option to get a verbose result. By the -k option you could select one
 Verify Code Style
 .................
 
-A flake8 only test is done by `py.test --flake8 -m flake8`  or `pytest --flake8 -m flake8`
-
-Instead of running a ibrary module as a script by the -m option you may also use the pytest command.
+A flake8 only test is done with `flake8 mslib tests`.
 
 Coverage
 ........

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -1,15 +1,11 @@
 # This file may be used to create an environment using:
 # $ conda create --name <env> --file <this file>
 # platform: linux-64
-pep8
+flake8
 flake8-builtins
 py
 mock
-pycodestyle
 pytest
-pytest-cache
-pytest-pep8
-pytest-flake8
 pytest-qt
 pytest-xdist
 pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,25 +34,7 @@ omit =
  tests/*
 
 [tool:pytest]
-addopts = --flake8
-flake8-max-line-length = 120
-flake8-ignore =
- *.py E402 W504 N801 N802 N803 N805 N806 N813
- conftest.py F821
- setup.py F821
- docs/conf.py ALL
- mslib/__init__.py F401
- mslib/msui/mss_qt.py F401  # lots of imports for importing code
- mslib/msui/mss_pyui.py F401  # nappy imported for testing
- mslib/msui/qt5/*.py ALL  # ignore all pyuic5 created files
-pep8maxlinelength = 120
 norecursedirs = .git .idea .cache
-pep8ignore =
- *.py E402  # futurize requires some code between imports
- *.py E124  # closing bracket does not match visual indentation (behaves strange!?)
- *.py E125  # continuation line does not distinguish itself from next logical line (difficult to avoid!)
- mslib/msui/qt5/*.py ALL  # ignore all pyuic5 created files
- docs/conf.py ALL
 
 [pycodestyle]
 ignore = E124,E125,E402,W504


### PR DESCRIPTION
We have a GitHub Action that runs flake8, which in turn wraps PyFlakes, pycodestyle and McCabe. Since pep8 was renamed to pycodestyle those two are the same. Adding flake8 to the dependencies therefore means we can remove pep8 and pycodestyle. The pytest-pep8, which is really old, and pytest-flake8 plugins also become redundant since we have the CI action anyway.

Extracted from #2100.