### PR TITLE
Refactor Qt related tests to use pytest-qt

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,7 +62,6 @@ jobs:
         | sed -e "s/menuinst.*//" \
         | sed -e "s/.*://" > reqs.txt \
         && cat requirements.d/development.txt >> reqs.txt \
-        && echo pyvirtualdisplay >> reqs.txt \
         && cat reqs.txt \
         && mamba env remove -n mss-${{ inputs.branch_name }}-env \
         && mamba create -y -n mss-${{ inputs.branch_name }}-env --file reqs.txt
@@ -82,9 +81,9 @@ jobs:
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate mss-${{ inputs.branch_name }}-env \
-        && pytest -v --durations=20 --reverse --cov=mslib tests \
+        && xvfb-run pytest -v --durations=20 --reverse --cov=mslib tests \
         || (for i in {1..5} \
-          ; do pytest tests -v --durations=0 --reverse --last-failed --lfnf=none \
+          ; do xvfb-run pytest tests -v --durations=0 --reverse --last-failed --lfnf=none \
           && break \
         ; done)
 
@@ -96,9 +95,9 @@ jobs:
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate mss-${{ inputs.branch_name }}-env \
-        && pytest -vv -n 6 --dist loadfile --max-worker-restart 4 tests \
+        && xvfb-run pytest -vv -n 6 --dist loadfile --max-worker-restart 4 tests \
         || (for i in {1..5} \
-          ; do pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests --last-failed --lfnf=none \
+          ; do xvfb-run pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests --last-failed --lfnf=none \
           && break \
         ; done)
 

--- a/.github/workflows/testing_gsoc.yml
+++ b/.github/workflows/testing_gsoc.yml
@@ -50,7 +50,6 @@ jobs:
         | sed -e "s/menuinst.*//" \
         | sed -e "s/.*://" > reqs.txt \
         && cat requirements.d/development.txt >> reqs.txt \
-        && echo pyvirtualdisplay >> reqs.txt \
         && cat reqs.txt \
         && mamba env remove -n mss-develop-env \
         && mamba create -y -n mss-develop-env --file reqs.txt
@@ -70,9 +69,9 @@ jobs:
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate mss-develop-env \
-        && pytest -v --durations=20 --reverse --cov=mslib tests \
+        && xvfb-run pytest -v --durations=20 --reverse --cov=mslib tests \
         || (for i in {1..5} \
-          ; do pytest tests -v --durations=0 --reverse --last-failed --lfnf=none \
+          ; do xvfb-run pytest tests -v --durations=0 --reverse --last-failed --lfnf=none \
           && break \
         ; done)
 
@@ -85,9 +84,9 @@ jobs:
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate mss-develop-env \
-        && pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests \
+        && xvfb-run pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests \
         || (for i in {1..5} \
-          ; do pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests --last-failed --lfnf=none \
+          ; do xvfb-run pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests --last-failed --lfnf=none \
           && break \
         ; done)
 

--- a/conftest.py
+++ b/conftest.py
@@ -28,8 +28,6 @@
 import importlib.util
 import os
 import sys
-import mock
-from PyQt5 import QtWidgets
 # Disable pyc files
 sys.dont_write_bytecode = True
 
@@ -252,27 +250,8 @@ def reset_config():
     read_config_file()
 
 
-@pytest.fixture(autouse=True)
-def fail_if_open_message_boxes_left():
-    """Fail a test if there are any Qt message boxes left open at the end
-    """
-    # Mock every MessageBox widget in the test suite to avoid unwanted freezes on unhandled error popups etc.
-    with mock.patch("PyQt5.QtWidgets.QMessageBox.question") as q, \
-            mock.patch("PyQt5.QtWidgets.QMessageBox.information") as i, \
-            mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as c, \
-            mock.patch("PyQt5.QtWidgets.QMessageBox.warning") as w:
-        yield
-        if any(box.call_count > 0 for box in [q, i, c, w]):
-            summary = "\n".join([f"PyQt5.QtWidgets.QMessageBox.{box()._extract_mock_name()}: {box.mock_calls[:-1]}"
-                                 for box in [q, i, c, w] if box.call_count > 0])
-            pytest.fail(f"An unhandled message box popped up during your test!\n{summary}")
-    # Try to close all remaining widgets after each test
-    for qobject in set(QtWidgets.QApplication.topLevelWindows() + QtWidgets.QApplication.topLevelWidgets()):
-        try:
-            qobject.destroy()
-        # Some objects deny permission, pass in that case
-        except RuntimeError:
-            pass
+# Make fixtures available everywhere
+from tests.fixtures import *
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -86,15 +86,6 @@ def pytest_generate_tests(metafunc):
         msui_settings_file_fs.close()
 
 
-if os.getenv("TESTS_VISIBLE") == "TRUE":
-    Display = None
-else:
-    try:
-        from pyvirtualdisplay import Display
-    except ImportError:
-        Display = None
-
-
 def generate_initial_config():
     """Generate an initial state for the configuration directory in tests.constants.ROOT_FS
     """
@@ -252,17 +243,3 @@ def reset_config():
 
 # Make fixtures available everywhere
 from tests.fixtures import *
-
-
-@pytest.fixture(scope="session", autouse=True)
-def configure_testsetup(request):
-    if Display is not None:
-        # needs for invisible window output xvfb installed,
-        # default backend for visible output is xephyr
-        # by visible=0 you get xvfb
-        VIRT_DISPLAY = Display(visible=0, size=(1280, 1024))
-        VIRT_DISPLAY.start()
-        yield
-        VIRT_DISPLAY.stop()
-    else:
-        yield

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -220,11 +220,10 @@ For developers we provide additional packages for running tests, activate your e
 
   $ mamba install --file requirements.d/development.txt
 
-On linux install the `conda-forge package pyvirtualdisplay` and `xvfb` from your linux package manager.
-This is used to run tests on a virtual display.
-If you don't want tests redirected to the xvfb display just setup an environment variable::
+On linux install `xvfb` from your linux package manager.
+This can be used to run tests on an invisible virtual display by prepending the pytest call with `xvfb-run`, e.g.::
 
- $ export TESTS_VISIBLE=TRUE
+  $ xvfb-run pytest ...
 
 We have implemented demodata as data base for testing. On first call of pytest a set of demodata becomes stored
 in a /tmp/mss* folder. If you have installed gitpython a postfix of the revision head is added.
@@ -540,4 +539,3 @@ GSoC'19 Projects
 - `Anveshan Lal: Updating Geographical Plotting Routines <https://github.com/Open-MSS/MSS/wiki/Cartopy:-Updating-Geographical-Plotting-Routines----GSoC-2019>`_
 
 - `Shivashis Padhi: Collaborative editing of flight path in real-time <https://github.com/Open-MSS/MSS/wiki/Mscolab:-Collaborative-editing-of-flight-path-in-real-time---GSoC19>`_
-

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -1014,7 +1014,7 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
         """
         dlg = MSUI_AboutDialog(parent=self)
         dlg.setModal(True)
-        dlg.exec_()
+        dlg.show()
 
     def show_shortcuts(self, search_mode=False):
         """Show the shortcuts dialog to the user.

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -9,6 +9,7 @@ pytest
 pytest-cache
 pytest-pep8
 pytest-flake8
+pytest-qt
 pytest-xdist
 pytest-cov
 pytest-timeout
@@ -25,4 +26,3 @@ dnspython>=2.0.0, <2.3.0
 gsl==2.7.0
 boa
 xmlschema<2.5.0
-

--- a/tests/_test_msui/test_editor.py
+++ b/tests/_test_msui/test_editor.py
@@ -28,7 +28,6 @@ import pytest
 import mock
 import os
 import fs
-import sys
 from PyQt5 import QtWidgets
 from mslib.msui import editor
 from tests.constants import ROOT_DIR
@@ -41,21 +40,17 @@ class Test_Editor:
 
     save_file_name = fs.path.join(ROOT_DIR, "testeditor_save.json")
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes)
-    def setup_method(self, mockmessage):
-        self.application = QtWidgets.QApplication(sys.argv)
-
-        self.window = editor.EditorMainWindow()
-        self.save_file_name = self.save_file_name
-        self.window.show()
-
-    def teardown_method(self):
-        if os.path.exists(self.save_file_name):
-            os.remove(self.save_file_name)
-        self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
-        QtWidgets.QApplication.processEvents()
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
+        with mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes):
+            self.window = editor.EditorMainWindow()
+            self.save_file_name = self.save_file_name
+            self.window.show()
+            yield
+            if os.path.exists(self.save_file_name):
+                os.remove(self.save_file_name)
+            self.window.hide()
+            QtWidgets.QApplication.processEvents()
 
     @mock.patch("mslib.msui.editor.get_open_filename", return_value=sample_file)
     def test_file_open(self, mockfile):

--- a/tests/_test_msui/test_kmloverlay_dockwidget.py
+++ b/tests/_test_msui/test_kmloverlay_dockwidget.py
@@ -27,8 +27,8 @@
 
 import os
 import fs
-import sys
 import mock
+import pytest
 from PyQt5 import QtWidgets, QtCore, QtTest, QtGui
 from tests.constants import ROOT_DIR
 import mslib.msui.kmloverlay_dockwidget as kd
@@ -41,8 +41,8 @@ save_kml = os.path.join(ROOT_DIR, "merged_file123.kml")
 # ToDo review needed helper functions
 class Test_KmlOverlayDockWidget:
 
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.view = mock.Mock()
         self.view.map = mock.Mock(side_effect=lambda x, y: (x, y))
         self.view.map.plot = mock.Mock(return_value=[mock.Mock()])
@@ -56,10 +56,7 @@ class Test_KmlOverlayDockWidget:
         self.window.select_all()
         self.window.remove_file()
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
+        yield
         QtWidgets.QApplication.processEvents()
         self.window.close()
         if os.path.exists(save_kml):

--- a/tests/_test_msui/test_linearview.py
+++ b/tests/_test_msui/test_linearview.py
@@ -29,7 +29,6 @@ import mock
 import os
 import pytest
 import shutil
-import sys
 import multiprocessing
 import tempfile
 from mslib.mswms.mswms import application
@@ -43,18 +42,15 @@ PORTS = list(range(26000, 26500))
 
 
 class Test_MSS_LV_Options_Dialog:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.window = tv.MSUI_LV_Options_Dialog(settings=_DEFAULT_SETTINGS_LINEARVIEW)
         self.window.show()
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -68,8 +64,8 @@ class Test_MSS_LV_Options_Dialog:
 
 
 class Test_MSSLinearViewWindow:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         initial_waypoints = [ft.Waypoint(40., 25., 300), ft.Waypoint(60., -10., 400), ft.Waypoint(40., 10, 300)]
 
         waypoints_model = ft.WaypointsTableModel("")
@@ -81,11 +77,8 @@ class Test_MSSLinearViewWindow:
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -117,8 +110,8 @@ class Test_MSSLinearViewWindow:
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_LinearViewWMS:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.port = PORTS.pop()
         self.tempdir = tempfile.mkdtemp()
         if not os.path.exists(self.tempdir):
@@ -142,11 +135,8 @@ class Test_LinearViewWMS:
         QtWidgets.QApplication.processEvents()
         self.wms_control = self.window.docks[0].widget()
         self.wms_control.multilayers.cbWMS_URL.setEditText("")
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
         shutil.rmtree(self.tempdir)
         self.thread.terminate()

--- a/tests/_test_msui/test_mpl_map.py
+++ b/tests/_test_msui/test_mpl_map.py
@@ -24,12 +24,15 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import pytest
+
 from matplotlib import pyplot as plt
 from mslib.msui.mpl_map import MapCanvas
 
 
 class Test_MapCanvas:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         kwargs = {'resolution': 'l', 'area_thresh': 1000.0, 'ax': plt.gca(), 'llcrnrlon': -15.0, 'llcrnrlat': 35.0,
                   'urcrnrlon': 30.0, 'urcrnrlat': 65.0, 'epsg': '4326'}
         self.map = MapCanvas(**kwargs)

--- a/tests/_test_msui/test_mscolab_merge_waypoints.py
+++ b/tests/_test_msui/test_mscolab_merge_waypoints.py
@@ -25,7 +25,6 @@
     limitations under the License.
 """
 import os
-import sys
 import fs
 import mock
 import pytest
@@ -47,16 +46,15 @@ PORTS = list(range(23000, 23500))
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_Mscolab_Merge_Waypoints:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         handle_db_reset()
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)
         QtTest.QTest.qWait(500)
-        self.application = QtWidgets.QApplication(sys.argv)
         self.window = msui.MSUIMainWindow(mscolab_data_dir=mscolab_settings.MSCOLAB_DATA_DIR)
         self.window.create_new_flight_track()
         self.emailid = 'merge@alpha.org'
-
-    def teardown_method(self):
+        yield
         self.window.mscolab.logout()
         mslib.utils.auth.del_password_from_keyring("merge@alpha.org")
         with self.app.app_context():
@@ -70,7 +68,6 @@ class Test_Mscolab_Merge_Waypoints:
             self.window.mscolab.version_window.close()
         if self.window.mscolab.conn:
             self.window.mscolab.conn.disconnect()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
         self.process.terminate()
 

--- a/tests/_test_msui/test_mscolab_save_merge_points.py
+++ b/tests/_test_msui/test_mscolab_save_merge_points.py
@@ -35,11 +35,10 @@ from PyQt5 import QtCore, QtTest, QtWidgets
 PORTS = list(range(21000, 21500))
 
 
-# ToDo Understand why this needs to be skipped, it runs when direct called
+@pytest.mark.skip("Uses QTimer, which can break other unrelated tests")
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_Save_Merge_Points(Test_Mscolab_Merge_Waypoints):
-    @pytest.mark.skip("Uses QTimer, which can break other unrelated tests")
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     def test_save_merge_points(self, mockbox):
         self.emailid = "mergepoints@alpha.org"

--- a/tests/_test_msui/test_mscolab_version_history.py
+++ b/tests/_test_msui/test_mscolab_version_history.py
@@ -25,7 +25,6 @@
     limitations under the License.
 """
 import os
-import sys
 import pytest
 import mock
 
@@ -45,7 +44,8 @@ PORTS = list(range(20000, 20500))
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_MscolabVersionHistory:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         handle_db_reset()
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
@@ -55,7 +55,6 @@ class Test_MscolabVersionHistory:
         assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
         self.user = get_user(self.userdata[0])
         QtTest.QTest.qWait(500)
-        self.application = QtWidgets.QApplication(sys.argv)
         self.window = msui.MSUIMainWindow(mscolab_data_dir=mscolab_settings.MSCOLAB_DATA_DIR)
         self.window.create_new_flight_track()
         self.window.show()
@@ -71,15 +70,12 @@ class Test_MscolabVersionHistory:
         assert self.version_window is not None
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.mscolab.logout()
         if self.window.mscolab.version_window:
             self.window.mscolab.version_window.close()
         if self.window.mscolab.conn:
             self.window.mscolab.conn.disconnect()
-        self.application.quit()
-        QtWidgets.QApplication.processEvents()
         self.process.terminate()
 
     def test_changes(self):

--- a/tests/_test_msui/test_mss.py
+++ b/tests/_test_msui/test_mss.py
@@ -25,17 +25,13 @@
     limitations under the License.
 """
 import pytest
-import sys
 from PyQt5 import QtWidgets, QtTest, QtCore
 from mslib.msui import mss
 
 
 @pytest.mark.skip(reason='needs review, assert missing')
-def test_mss_rename_message():
-    application = QtWidgets.QApplication(sys.argv)
+def test_mss_rename_message(qapp):
     main_window = mss.MSSMainWindow()
     main_window.show()
     QtTest.QTest.mouseClick(main_window.pushButton, QtCore.Qt.LeftButton)
-    QtWidgets.QApplication.processEvents()
-    application.quit()
     QtWidgets.QApplication.processEvents()

--- a/tests/_test_msui/test_multiple_flightpath_dockwidget.py
+++ b/tests/_test_msui/test_multiple_flightpath_dockwidget.py
@@ -24,7 +24,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import sys
+import pytest
 from PyQt5 import QtWidgets, QtTest
 from mslib.msui import msui
 from mslib.msui.multiple_flightpath_dockwidget import MultipleFlightpathControlWidget
@@ -33,10 +33,8 @@ import mslib.msui.topview as tv
 
 
 class Test_MultipleFlightpathControlWidget:
-
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
-
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.window = msui.MSUIMainWindow()
         self.window.create_new_flight_track()
 
@@ -52,11 +50,8 @@ class Test_MultipleFlightpathControlWidget:
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     def test_initialization(self):

--- a/tests/_test_msui/test_remotesensing.py
+++ b/tests/_test_msui/test_remotesensing.py
@@ -27,11 +27,9 @@
 
 
 import datetime
-import sys
 
 from mock import Mock
 from matplotlib.collections import LineCollection
-from PyQt5 import QtWidgets
 import pytest
 import skyfield_data
 from mslib.msui.remotesensing_dockwidget import RemoteSensingControlWidget
@@ -47,8 +45,8 @@ class Test_RemoteSensingControlWidget:
     """
     Tests about RemoteSensingControlWidget
     """
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.view = Mock()
         self.map = qt.TopViewPlotter()
         self.map.init_map()

--- a/tests/_test_msui/test_satellite_dockwidget.py
+++ b/tests/_test_msui/test_satellite_dockwidget.py
@@ -26,26 +26,23 @@
 """
 
 import os
-import sys
 import mock
+import pytest
 from PyQt5 import QtWidgets, QtCore, QtTest
 import mslib.msui.satellite_dockwidget as sd
 
 
 class Test_SatelliteDockWidget:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.view = mock.Mock()
         self.window = sd.SatelliteControlWidget(view=self.view)
         self.window.show()
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     def test_load(self):

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -30,7 +30,6 @@ import mock
 import os
 import pytest
 import shutil
-import sys
 import multiprocessing
 import tempfile
 from mslib.mswms.mswms import application
@@ -44,18 +43,15 @@ PORTS = list(range(19000, 19500))
 
 
 class Test_MSS_SV_OptionsDialog:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.window = tv.MSUI_SV_OptionsDialog(settings=_DEFAULT_SETTINGS_SIDEVIEW)
         self.window.show()
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -95,8 +91,8 @@ class Test_MSS_SV_OptionsDialog:
 
 
 class Test_MSSSideViewWindow:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         initial_waypoints = [ft.Waypoint(40., 25., 300), ft.Waypoint(60., -10., 400), ft.Waypoint(40., 10, 300)]
 
         waypoints_model = ft.WaypointsTableModel("")
@@ -108,11 +104,8 @@ class Test_MSSSideViewWindow:
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -174,8 +167,8 @@ class Test_MSSSideViewWindow:
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_SideViewWMS:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.port = PORTS.pop()
         self.tempdir = tempfile.mkdtemp()
         if not os.path.exists(self.tempdir):
@@ -199,11 +192,8 @@ class Test_SideViewWMS:
         QtWidgets.QApplication.processEvents()
         self.wms_control = self.window.docks[0].widget()
         self.wms_control.multilayers.cbWMS_URL.setEditText("")
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
         shutil.rmtree(self.tempdir)
         self.thread.terminate()

--- a/tests/_test_msui/test_suffix.py
+++ b/tests/_test_msui/test_suffix.py
@@ -26,26 +26,23 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import pytest
 
-import sys
 from PyQt5 import QtWidgets, QtTest
 import mslib.msui.sideview as tv
 from mslib.msui.mpl_qtwidget import _DEFAULT_SETTINGS_SIDEVIEW
 
 
 class Test_SuffixChange:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.window = tv.MSUI_SV_OptionsDialog(settings=_DEFAULT_SETTINGS_SIDEVIEW)
         self.window.show()
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     def test_suffixchange(self):

--- a/tests/_test_msui/test_tableview.py
+++ b/tests/_test_msui/test_tableview.py
@@ -28,7 +28,6 @@
 import mock
 import os
 import pytest
-import sys
 
 from PyQt5 import QtWidgets, QtCore, QtTest
 from mslib.msui import flighttrack as ft
@@ -37,9 +36,8 @@ import mslib.msui.tableview as tv
 
 
 class Test_TableView:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
-
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         # Create an initital flight track.
         initial_waypoints = [ft.Waypoint(flightlevel=0, location="EDMO", comments="take off OP"),
                              ft.Waypoint(48.10, 10.27, 200),
@@ -57,11 +55,8 @@ class Test_TableView:
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     def test_open_hex(self):

--- a/tests/_test_msui/test_topview.py
+++ b/tests/_test_msui/test_topview.py
@@ -29,7 +29,6 @@ import mock
 import os
 import pytest
 import shutil
-import sys
 import multiprocessing
 import tempfile
 import mslib.msui.topview as tv
@@ -44,18 +43,15 @@ PORTS = list(range(28000, 28500))
 
 
 class Test_MSS_TV_MapAppearanceDialog:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.window = tv.MSUI_TV_MapAppearanceDialog(settings=_DEFAULT_SETTINGS_TOPVIEW)
         self.window.show()
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -70,9 +66,9 @@ class Test_MSS_TV_MapAppearanceDialog:
 
 
 class Test_MSSTopViewWindow:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         mainwindow = MSUIMainWindow()
-        self.application = QtWidgets.QApplication(sys.argv)
         initial_waypoints = [ft.Waypoint(40., 25., 0), ft.Waypoint(60., -10., 0), ft.Waypoint(40., 10, 0)]
         waypoints_model = ft.WaypointsTableModel("")
         waypoints_model.insertRows(
@@ -82,11 +78,8 @@ class Test_MSSTopViewWindow:
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -297,9 +290,9 @@ class Test_MSSTopViewWindow:
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_TopViewWMS:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.port = PORTS.pop()
-        self.application = QtWidgets.QApplication(sys.argv)
 
         self.tempdir = tempfile.mkdtemp()
         if not os.path.exists(self.tempdir):
@@ -325,11 +318,8 @@ class Test_TopViewWMS:
         QtWidgets.QApplication.processEvents()
         self.wms_control = self.window.docks[0].widget()
         self.wms_control.multilayers.cbWMS_URL.setEditText("")
-
-    def teardown_method(self):
+        yield
         self.window.hide()
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
         QtWidgets.QApplication.processEvents()
         shutil.rmtree(self.tempdir)
         self.thread.terminate()
@@ -360,8 +350,9 @@ class Test_TopViewWMS:
 
 
 class Test_MSUITopViewWindow:
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
+        pass
 
     def test_kwargs_update_does_not_harm(self):
         initial_waypoints = [ft.Waypoint(40., 25., 0), ft.Waypoint(60., -10., 0), ft.Waypoint(40., 10, 0)]

--- a/tests/_test_msui/test_updater.py
+++ b/tests/_test_msui/test_updater.py
@@ -24,8 +24,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import sys
 import mock
+import pytest
 from PyQt5 import QtWidgets, QtTest
 
 from mslib.msui.updater import UpdaterUI, Updater
@@ -65,7 +65,8 @@ def create_mock(function, on_success=None, on_failure=None, start=True):
 
 
 class Test_MSS_ShortcutDialog:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.updater = Updater()
         self.status = ""
         self.update_available = False
@@ -83,10 +84,7 @@ class Test_MSS_ShortcutDialog:
         self.updater.on_update_available.connect(update_signal)
         self.updater.on_status_update.connect(status_signal)
         self.updater.on_update_finished.connect(update_finished_signal)
-        self.application = QtWidgets.QApplication(sys.argv)
-
-    def teardown_method(self):
-        self.application.quit()
+        yield
         QtWidgets.QApplication.processEvents()
 
     @mock.patch("subprocess.Popen", new=SubprocessDifferentVersionMock)

--- a/tests/_test_msui/test_wms_capabilities.py
+++ b/tests/_test_msui/test_wms_capabilities.py
@@ -25,8 +25,8 @@
     limitations under the License.
 """
 
-import sys
 import mock
+import pytest
 
 from PyQt5 import QtWidgets, QtTest, QtCore
 import mslib.msui.wms_capabilities as wc
@@ -34,8 +34,8 @@ import mslib.msui.wms_capabilities as wc
 
 class Test_WMSCapabilities:
 
-    def setup_method(self):
-        self.application = QtWidgets.QApplication(sys.argv)
+    @pytest.fixture(autouse=True)
+    def setup(self, qapp):
         self.capabilities = mock.Mock()
         self.capabilities.capabilities_document = u"Hölla die Waldfee".encode("utf-8")
         self.capabilities.provider = mock.Mock()
@@ -47,6 +47,8 @@ class Test_WMSCapabilities:
         self.capabilities.provider.contact.address = None
         self.capabilities.provider.contact.postcode = None
         self.capabilities.provider.contact.city = None
+        yield
+        QtWidgets.QApplication.processEvents()
 
     def start_window(self):
         self.window = wc.WMSCapabilitiesBrowser(
@@ -55,11 +57,6 @@ class Test_WMSCapabilities:
         QtTest.QTest.qWaitForWindowExposed(self.window)
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWait(100)
-
-    def teardown_method(self):
-        QtWidgets.QApplication.processEvents()
-        self.application.quit()
-        QtWidgets.QApplication.processEvents()
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     def test_window_start(self, mockbox):

--- a/tests/_test_utils/test_auth.py
+++ b/tests/_test_utils/test_auth.py
@@ -49,7 +49,7 @@ def test_keyring():
 
 def test_get_auth_from_url_and_name():
     # set start condition to prevent definitions from a test earlier
-    constants.AUTH_LOGIN_CACHE == {}
+    constants.AUTH_LOGIN_CACHE = {}
     # empty http_auth definition
     server_url = "http://example.com"
     http_auth = config_loader(dataset="MSS_auth")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""
+
+    tests.fixtures
+    ~~~~~~~~~~~~~~
+
+    This module provides utils for pytest to test mslib modules
+
+    This file is part of MSS.
+
+    :copyright: Copyright 2023 by the MSS team, see AUTHORS.
+    :license: APACHE-2.0, see LICENSE for details.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+import pytest
+import mock
+
+from PyQt5 import QtWidgets
+
+
+@pytest.fixture
+def fail_if_open_message_boxes_left():
+    # Mock every MessageBox widget in the test suite to avoid unwanted freezes on unhandled error popups etc.
+    with mock.patch("PyQt5.QtWidgets.QMessageBox.question") as q, \
+            mock.patch("PyQt5.QtWidgets.QMessageBox.information") as i, \
+            mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as c, \
+            mock.patch("PyQt5.QtWidgets.QMessageBox.warning") as w:
+        yield
+
+        # Fail a test if there are any Qt message boxes left open at the end
+        if any(box.call_count > 0 for box in [q, i, c, w]):
+            summary = "\n".join([f"PyQt5.QtWidgets.QMessageBox.{box()._extract_mock_name()}: {box.mock_calls[:-1]}"
+                                 for box in [q, i, c, w] if box.call_count > 0])
+            pytest.fail(f"An unhandled message box popped up during your test!\n{summary}")
+
+
+@pytest.fixture
+def close_remaining_widgets():
+    yield
+    # Try to close all remaining widgets after each test
+    for qobject in set(QtWidgets.QApplication.topLevelWindows() + QtWidgets.QApplication.topLevelWidgets()):
+        try:
+            qobject.destroy()
+        # Some objects deny permission, pass in that case
+        except RuntimeError:
+            pass
+
+
+@pytest.fixture
+def qapp(qapp, fail_if_open_message_boxes_left, close_remaining_widgets):
+    yield qapp


### PR DESCRIPTION
Using pytest-qt the QApplication instance can just be taken from its qapp fixture instead of being setup in each test. The fixture to fail if there are message boxes left at the end of a test can then be used by making the qapp fixture request it, which means that only tests that actually use Qt will have this fixture run (as opposed to the previous autouse fixture, which always ran).

Using the pytest-qt plugin also has other benefits:
- catches exceptions in Qt methods that are overloaded (explained here: https://pytest-qt.readthedocs.io/en/latest/virtual_methods.html)
- provides `addWidget` method which will help with proper widget cleanup in tests
- provides `waitSignal`, `waitUntil`, `waitCallback` methods which will help in reducing race conditions in tests where currently a `qWait` is used, i.e. which mistakenly use time for synchronization
- ... and probably more

Split off from #2100.