### PR TITLE
Refactor servers into fixtures

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -393,6 +393,23 @@ example::
 
 
 
+Writing Tests
+-------------
+
+Ideally every new feature or bug fix should be accompanied by tests
+that make sure that the feature works as intended or that the bug is indeed fixed
+(and won't turn up again in the future).
+The best way to find out how to write such tests is by taking a look at the existing tests,
+maybe finding one that is similar
+and adapting it to the new test case.
+
+MSS uses pytest as a test runner and therefore their `docs <https://docs.pytest.org/en/latest/contents.html>`_ are relevant here.
+
+Common resources that a test might need,
+like e.g. a running MSColab server or a QApplication instance for GUI tests,
+are collected in :mod:`tests.fixtures` in the form of pytest fixtures that can be requested as needed in tests.
+
+
 Pushing your changes
 --------------------
 

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -17,7 +17,6 @@ pytest-timeout
 sphinx
 sphinx_rtd_theme
 gitpython
-gevent
 pynco
 conda-verify
 Flask-Testing

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -19,7 +19,6 @@ sphinx_rtd_theme
 gitpython
 pynco
 conda-verify
-Flask-Testing
 pytest-reverse
 eventlet>0.30.2
 dnspython>=2.0.0, <2.3.0

--- a/tests/_test_mscolab/test_file_manager.py
+++ b/tests/_test_mscolab/test_file_manager.py
@@ -24,40 +24,23 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-from flask_testing import TestCase
 import os
 import datetime
 import pytest
 
-from mslib.mscolab.conf import mscolab_settings
 from mslib.mscolab.models import Operation, User
-from mslib.mscolab.server import APP
-from mslib.mscolab.file_manager import FileManager
 from mslib.mscolab.seed import add_user, get_user
-from mslib.mscolab.mscolab import handle_db_reset
 
 
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
-class Test_FileManager(TestCase):
-    render_templates = False
-
-    def create_app(self):
-        app = APP
-        app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-        app.config["TESTING"] = True
-        app.config['LIVESERVER_TIMEOUT'] = 10
-        app.config['LIVESERVER_PORT'] = 0
-        return app
-
-    def setUp(self):
-        handle_db_reset()
+class Test_FileManager:
+    @pytest.fixture(autouse=True)
+    def setup(self, mscolab_app, mscolab_managers):
+        self.app = mscolab_app
+        _, _, self.fm = mscolab_managers
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
         self.anotheruserdata = 'UV20@uv20', 'UV20', 'uv20'
-        self.fm = FileManager(self.app.config["MSCOLAB_DATA_DIR"])
 
         assert add_user(self.userdata[0], self.userdata[1], self.userdata[2])
         self.user = get_user(self.userdata[0])
@@ -77,9 +60,8 @@ class Test_FileManager(TestCase):
         assert add_user('UV80@uv80', 'UV80', 'uv80')
         self.adminuser = get_user('UV80@uv80')
         self._example_data()
-
-    def tearDown(self):
-        pass
+        with self.app.app_context():
+            yield
 
     def test_modify_user(self):
         with self.app.test_client():

--- a/tests/_test_mscolab/test_files_api.py
+++ b/tests/_test_mscolab/test_files_api.py
@@ -24,49 +24,29 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-from flask_testing import TestCase
 import os
 import fs
 import pytest
 
-from mslib.mscolab.conf import mscolab_settings
 from mslib.mscolab.models import Operation
-from mslib.mscolab.server import APP
-from mslib.mscolab.file_manager import FileManager
 from mslib.mscolab.seed import add_user, get_user
-from mslib.mscolab.mscolab import handle_db_reset
 
 
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
-class Test_Files(TestCase):
-    render_templates = False
-
-    def create_app(self):
-        app = APP
-        app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-        app.config["TESTING"] = True
-        app.config['LIVESERVER_TIMEOUT'] = 10
-        app.config['LIVESERVER_PORT'] = 0
-        return app
-
-    def setUp(self):
-        handle_db_reset()
-
-        self.fm = FileManager(self.app.config["MSCOLAB_DATA_DIR"])
+class Test_Files:
+    @pytest.fixture(autouse=True)
+    def setup(self, mscolab_app, mscolab_managers):
+        self.app = mscolab_app
+        _, _, self.fm = mscolab_managers
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
-
         assert add_user(self.userdata[0], self.userdata[1], self.userdata[2])
         self.user = get_user(self.userdata[0])
         assert self.user is not None
         assert add_user('UV20@uv20', 'UV20', 'uv20')
         self.user_2 = get_user('UV20@uv20')
-
-    def tearDown(self):
-        pass
+        with self.app.app_context():
+            yield
 
     def test_create_operation(self):
         with self.app.test_client():

--- a/tests/_test_mscolab/test_models.py
+++ b/tests/_test_mscolab/test_models.py
@@ -24,33 +24,20 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import pytest
 
-from flask_testing import TestCase
-from mslib.mscolab.conf import mscolab_settings
-from mslib.mscolab.mscolab import handle_db_reset
-from mslib.mscolab.server import register_user, APP
+from mslib.mscolab.server import register_user
 from mslib.mscolab.models import User
 
 
-class Test_User(TestCase):
-    render_templates = False
-
-    def create_app(self):
-        app = APP
-        app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-        app.config["TESTING"] = True
-        app.config['LIVESERVER_TIMEOUT'] = 10
-        app.config['LIVESERVER_PORT'] = 0
-        return app
-
-    def setUp(self):
-        handle_db_reset()
+class Test_User:
+    @pytest.fixture(autouse=True)
+    def setup(self, mscolab_app):
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
-        result = register_user(self.userdata[0], self.userdata[1], self.userdata[2])
-        assert result["success"] is True
+        with mscolab_app.app_context():
+            result = register_user(self.userdata[0], self.userdata[1], self.userdata[2])
+            assert result["success"] is True
+            yield
 
     def test_generate_auth_token(self):
         user = User(self.userdata[0], self.userdata[1], self.userdata[2])

--- a/tests/_test_mscolab/test_mscolab.py
+++ b/tests/_test_mscolab/test_mscolab.py
@@ -28,12 +28,10 @@ import os
 import pytest
 import mock
 import argparse
-from flask_testing import TestCase
 
 from mslib.mscolab.conf import mscolab_settings
 from mslib.mscolab.models import Operation, User, Permission
 from mslib.mscolab.mscolab import handle_db_reset, handle_db_seed, confirm_action, main
-from mslib.mscolab.server import APP
 from mslib.mscolab.seed import add_operation
 
 
@@ -62,20 +60,13 @@ def test_main():
         # currently only checking precedence of all args
 
 
-class Test_Mscolab(TestCase):
-    def create_app(self):
-        app = APP
-        app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-        app.config["TESTING"] = True
-        app.config['LIVESERVER_TIMEOUT'] = 10
-        app.config['LIVESERVER_PORT'] = 0
-        return app
+class Test_Mscolab:
+    @pytest.fixture(autouse=True)
+    def setup(self, mscolab_app):
+        with mscolab_app.app_context():
+            yield
 
-    def setUp(self):
-        handle_db_reset()
+    def test_initial_state(self):
         assert Operation.query.all() == []
         assert User.query.all() == []
         assert Permission.query.all() == []

--- a/tests/_test_mscolab/test_server.py
+++ b/tests/_test_mscolab/test_server.py
@@ -24,8 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-
-from flask_testing import TestCase
 import os
 import pytest
 import json
@@ -33,34 +31,20 @@ import io
 
 from mslib.mscolab.conf import mscolab_settings
 from mslib.mscolab.models import User, Operation
-from mslib.mscolab.mscolab import handle_db_reset
-from mslib.mscolab.server import initialize_managers, check_login, register_user, APP
+from mslib.mscolab.server import initialize_managers, check_login, register_user
 from mslib.mscolab.file_manager import FileManager
 from mslib.mscolab.seed import add_user, get_user
 
 
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
-class Test_Server(TestCase):
-    render_templates = False
-
-    def create_app(self):
-        app = APP
-        app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-        app.config["TESTING"] = True
-        app.config['LIVESERVER_TIMEOUT'] = 10
-        app.config['LIVESERVER_PORT'] = 0
-        return app
-
-    def setUp(self):
-        handle_db_reset()
+class Test_Server:
+    @pytest.fixture(autouse=True)
+    def setup(self, mscolab_app):
+        self.app = mscolab_app
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
-
-    def tearDown(self):
-        pass
+        with self.app.app_context():
+            yield
 
     def test_initialize_managers(self):
         app, sockio, cm, fm = initialize_managers(self.app)

--- a/tests/_test_mscolab/test_server_auth_required.py
+++ b/tests/_test_mscolab/test_server_auth_required.py
@@ -27,41 +27,23 @@
 import os
 import pytest
 
-from flask_testing import TestCase
 from mslib.mscolab.conf import mscolab_settings
 
 mscolab_settings.enable_basic_http_authentication = True
 try:
-    from mslib.mscolab.server import authfunc, verify_pw, initialize_managers, get_auth_token, register_user, APP
+    from mslib.mscolab.server import authfunc, verify_pw, initialize_managers, get_auth_token, register_user
 except ImportError:
     pytest.skip("this test runs only by an explicit call "
                 "e.g. pytest tests/_test_mscolab/test_server_auth_required.py", allow_module_level=True)
 
-from mslib.mscolab.mscolab import handle_db_reset
-
 
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
-class Test_Server_Auth_Not_Valid(TestCase):
-    render_templates = False
-
-    def create_app(self):
-        app = APP
-        app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-        app.config["TESTING"] = True
-        app.config['LIVESERVER_TIMEOUT'] = 10
-        app.config['LIVESERVER_PORT'] = 0
-        return app
-
-    def setUp(self):
-        handle_db_reset()
+class Test_Server_Auth_Not_Valid:
+    @pytest.fixture(autouse=True)
+    def setup(self, mscolab_app):
+        self.app = mscolab_app
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
-
-    def tearDown(self):
-        pass
 
     def test_initialize_managers(self):
         app, sockio, cm, fm = initialize_managers(self.app)

--- a/tests/_test_mscolab/test_sockets_manager.py
+++ b/tests/_test_mscolab/test_sockets_manager.py
@@ -26,46 +26,26 @@
 """
 import os
 import pytest
+import socket
 import socketio
 import datetime
 import requests
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from mslib.msui.icons import icons
 from mslib.mscolab.conf import mscolab_settings
-from tests.utils import mscolab_check_free_port, LiveSocketTestCase
-from mslib.mscolab.server import APP, initialize_managers
 from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_operation, get_operation
-from mslib.mscolab.mscolab import handle_db_reset
 from mslib.mscolab.sockets_manager import SocketsManager
 from mslib.mscolab.models import Permission, User, Message, MessageType
 
 
-PORTS = list(range(27000, 27500))
-
-
-class Test_Socket_Manager(LiveSocketTestCase):
-    run_gc_after_test = True
-    chat_messages_counter = [0, 0, 0]  # three sockets connected a, b, and c
-    chat_messages_counter_a = 0  # only for first test
-
-    def create_app(self):
-        app = APP
-        app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-        app.config["TESTING"] = True
-        app.config['LIVESERVER_TIMEOUT'] = 1
-        app.config['LIVESERVER_PORT'] = mscolab_check_free_port(PORTS, PORTS.pop())
-        return app
-
-    def setUp(self):
-        handle_db_reset()
+class Test_Socket_Manager:
+    @pytest.fixture(autouse=True)
+    def setup(self, mscolab_app, mscolab_managers, mscolab_server):
+        self.app = mscolab_app
+        _, self.cm, self.fm = mscolab_managers
+        self.url = mscolab_server
         self.sockets = []
-        # self.app = APP
-        self.app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        self.app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        self.app, _, self.cm, self.fm = initialize_managers(self.app)
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
         self.anotheruserdata = 'UV20@uv20', 'UV20', 'uv20'
         self.operation_name = "europe"
@@ -77,12 +57,22 @@ class Test_Socket_Manager(LiveSocketTestCase):
         self.anotheruser = get_user(self.anotheruserdata[0])
         self.token = self.user.generate_auth_token()
         self.operation = get_operation(self.operation_name)
-        self.url = self.get_server_url()
         self.sm = SocketsManager(self.cm, self.fm)
+        yield
+        for sock in self.sockets:
+            sock.disconnect()
 
-    def tearDown(self):
-        for socket in self.sockets:
-            socket.disconnect()
+    def _can_ping_server(self):
+        parsed_url = urlparse(self.url)
+        host, port = parsed_url.hostname, parsed_url.port
+        try:
+            sock = socket.create_connection((host, port))
+            success = True
+        except socket.error:
+            success = False
+        finally:
+            sock.close()
+        return success
 
     def _connect(self):
         sio = socketio.Client(reconnection_attempts=5)
@@ -109,7 +99,8 @@ class Test_Socket_Manager(LiveSocketTestCase):
     def test_join_creator_to_operatiom(self):
         sio = self._connect()
         operation = self._new_operation('new_operation', "example decription")
-        assert self.fm.get_file(int(operation.id), self.user) is False
+        with self.app.app_context():
+            assert self.fm.get_file(int(operation.id), self.user) is False
         json_config = {"token": self.token,
                        "op_id": operation.id}
 

--- a/tests/_test_mscolab/test_utils.py
+++ b/tests/_test_mscolab/test_utils.py
@@ -23,7 +23,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-from flask_testing import TestCase
 import os
 import pytest
 import json
@@ -31,11 +30,8 @@ import json
 from fs.tempfs import TempFS
 from mslib.mscolab.conf import mscolab_settings
 from mslib.mscolab.models import Operation, MessageType
-from mslib.mscolab.mscolab import handle_db_init, handle_db_reset
-from mslib.mscolab.server import APP
 from mslib.mscolab.seed import add_user, get_user
 from mslib.mscolab.utils import get_recent_op_id, get_session_id, get_message_dict, create_files, os_fs_create_dir
-from mslib.mscolab.sockets_manager import setup_managers
 
 
 class Message:
@@ -56,28 +52,15 @@ class Message:
 
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
-class Test_Utils(TestCase):
-    render_templates = False
-
-    def create_app(self):
-        app = APP
-        app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-        app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-        app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-        app.config["TESTING"] = True
-        app.config['LIVESERVER_TIMEOUT'] = 10
-        app.config['LIVESERVER_PORT'] = 0
-        return app
-
-    def setUp(self):
-        handle_db_init()
+class Test_Utils:
+    @pytest.fixture(autouse=True)
+    def setup(self, mscolab_app, mscolab_managers):
+        self.app = mscolab_app
+        _, _, self.fm = mscolab_managers
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
         self.anotheruserdata = 'UV20@uv20', 'UV20', 'uv20'
-        socketio, cm, self.fm = setup_managers(self.app)
-
-    def tearDown(self):
-        handle_db_reset()
+        with self.app.app_context():
+            yield
 
     @pytest.mark.skipif(os.name == "nt",
                         reason="multiprocessing needs currently start_method fork")

--- a/tests/_test_msui/test_linearview.py
+++ b/tests/_test_msui/test_linearview.py
@@ -29,16 +29,12 @@ import mock
 import os
 import pytest
 import shutil
-import multiprocessing
 import tempfile
-from mslib.mswms.mswms import application
 from PyQt5 import QtWidgets, QtTest, QtCore
 from mslib.msui import flighttrack as ft
 import mslib.msui.linearview as tv
 from mslib.msui.mpl_qtwidget import _DEFAULT_SETTINGS_LINEARVIEW
 from tests.utils import wait_until_signal
-
-PORTS = list(range(26000, 26500))
 
 
 class Test_MSS_LV_Options_Dialog:
@@ -111,15 +107,11 @@ class Test_MSSLinearViewWindow:
                     reason="multiprocessing needs currently start_method fork")
 class Test_LinearViewWMS:
     @pytest.fixture(autouse=True)
-    def setup(self, qapp):
-        self.port = PORTS.pop()
+    def setup(self, qapp, mswms_server):
+        self.url = mswms_server
         self.tempdir = tempfile.mkdtemp()
         if not os.path.exists(self.tempdir):
             os.mkdir(self.tempdir)
-        self.thread = multiprocessing.Process(
-            target=application.run,
-            args=("127.0.0.1", self.port))
-        self.thread.start()
 
         initial_waypoints = [ft.Waypoint(40., 25., 0), ft.Waypoint(60., -10., 0), ft.Waypoint(40., 10, 0)]
         waypoints_model = ft.WaypointsTableModel("")
@@ -139,7 +131,6 @@ class Test_LinearViewWMS:
         self.window.hide()
         QtWidgets.QApplication.processEvents()
         shutil.rmtree(self.tempdir)
-        self.thread.terminate()
 
     def query_server(self, url):
         QtWidgets.QApplication.processEvents()
@@ -154,7 +145,7 @@ class Test_LinearViewWMS:
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
+        self.query_server(self.url)
         QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.wms_control.image_displayed)

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -38,20 +38,16 @@ from mslib.mscolab.models import Permission, User
 from mslib.msui.flighttrack import WaypointsTableModel
 from PyQt5 import QtCore, QtTest, QtWidgets
 from mslib.utils.config import read_config_file, config_loader, modify_config_file
-from tests.utils import mscolab_start_server, create_msui_settings_file, ExceptionMock
+from tests.utils import create_msui_settings_file, ExceptionMock
 from mslib.msui import msui
 from mslib.msui import mscolab
-from mslib.mscolab.mscolab import handle_db_reset
 from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_operation
-
-PORTS = list(range(25000, 25500))
 
 
 class Test_Mscolab_connect_window:
     @pytest.fixture(autouse=True)
-    def setup(self, qapp):
-        handle_db_reset()
-        self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)
+    def setup(self, qapp, mscolab_server):
+        self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
         self.operation_name = "europe"
         assert add_user(self.userdata[0], self.userdata[1], self.userdata[2])
@@ -76,7 +72,6 @@ class Test_Mscolab_connect_window:
         self.window.hide()
         self.main_window.hide()
         QtWidgets.QApplication.processEvents()
-        self.process.terminate()
 
     def test_url_combo(self):
         assert self.window.urlCb.count() >= 1
@@ -270,9 +265,9 @@ class Test_Mscolab:
     }
 
     @pytest.fixture(autouse=True)
-    def setup(self, qapp):
-        handle_db_reset()
-        self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)
+    def setup(self, qapp, mscolab_app, mscolab_server):
+        self.app = mscolab_app
+        self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
         self.operation_name = "europe"
         assert add_user(self.userdata[0], self.userdata[1], self.userdata[2])
@@ -305,7 +300,6 @@ class Test_Mscolab:
             self.window.listViews.item(0).window.handle_force_close()
         # close all hanging operation option windows
         self.window.mscolab.close_external_windows()
-        self.process.terminate()
 
     def test_activate_operation(self):
         self._connect_to_mscolab()

--- a/tests/_test_msui/test_mscolab_admin_window.py
+++ b/tests/_test_msui/test_mscolab_admin_window.py
@@ -30,24 +30,18 @@ import pytest
 
 from mslib.mscolab.conf import mscolab_settings
 from PyQt5 import QtCore, QtTest, QtWidgets
-from tests.utils import mscolab_start_server
 from mslib.msui import mscolab
 from mslib.msui import msui
-from mslib.mscolab.mscolab import handle_db_reset
 from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_operation
 from mslib.utils.config import modify_config_file
-
-
-PORTS = list(range(24000, 24500))
 
 
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_MscolabAdminWindow:
     @pytest.fixture(autouse=True)
-    def setup(self, qapp):
-        handle_db_reset()
-        self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)
+    def setup(self, qapp, mscolab_server):
+        self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
         self.operation_name = "europe"
         assert add_user(self.userdata[0], self.userdata[1], self.userdata[2])
@@ -91,7 +85,6 @@ class Test_MscolabAdminWindow:
         with mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes):
             self.window.close()
         QtWidgets.QApplication.processEvents()
-        self.process.terminate()
 
     def test_permission_filter(self):
         len_added_users = self.admin_window.modifyUsersTable.rowCount()

--- a/tests/_test_msui/test_mscolab_merge_waypoints.py
+++ b/tests/_test_msui/test_mscolab_merge_waypoints.py
@@ -33,23 +33,19 @@ import mslib.utils.auth
 from mslib.msui import flighttrack as ft
 from mslib.mscolab.conf import mscolab_settings
 from PyQt5 import QtCore, QtTest, QtWidgets
-from tests.utils import (mscolab_start_server, mscolab_register_and_login, mscolab_create_operation,
+from tests.utils import (mscolab_register_and_login, mscolab_create_operation,
                          mscolab_delete_all_operations, mscolab_delete_user)
 from mslib.msui import mscolab
 from mslib.msui import msui
-from mslib.mscolab.mscolab import handle_db_reset
-
-
-PORTS = list(range(23000, 23500))
 
 
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_Mscolab_Merge_Waypoints:
     @pytest.fixture(autouse=True)
-    def setup(self, qapp):
-        handle_db_reset()
-        self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)
+    def setup(self, qapp, mscolab_app, mscolab_server):
+        self.app = mscolab_app
+        self.url = mscolab_server
         QtTest.QTest.qWait(500)
         self.window = msui.MSUIMainWindow(mscolab_data_dir=mscolab_settings.MSCOLAB_DATA_DIR)
         self.window.create_new_flight_track()
@@ -69,7 +65,6 @@ class Test_Mscolab_Merge_Waypoints:
         if self.window.mscolab.conn:
             self.window.mscolab.conn.disconnect()
         QtWidgets.QApplication.processEvents()
-        self.process.terminate()
 
     def _create_user_data(self, emailid='merge@alpha.org'):
         with self.app.app_context():

--- a/tests/_test_msui/test_mscolab_operation.py
+++ b/tests/_test_msui/test_mscolab_operation.py
@@ -30,14 +30,10 @@ import pytest
 from mslib.mscolab.conf import mscolab_settings
 from mslib.mscolab.models import Message
 from PyQt5 import QtCore, QtTest, QtWidgets
-from tests.utils import mscolab_start_server
 from mslib.msui import mscolab
 from mslib.msui import msui
-from mslib.mscolab.mscolab import handle_db_reset
 from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_operation
 from mslib.utils.config import modify_config_file
-
-PORTS = list(range(22000, 22500))
 
 
 class Actions:
@@ -52,9 +48,9 @@ class Actions:
                     reason="multiprocessing needs currently start_method fork")
 class Test_MscolabOperation:
     @pytest.fixture(autouse=True)
-    def setup(self, qapp):
-        handle_db_reset()
-        self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)
+    def setup(self, qapp, mscolab_app, mscolab_server):
+        self.app = mscolab_app
+        self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
         self.operation_name = "europe"
         assert add_user(self.userdata[0], self.userdata[1], self.userdata[2])
@@ -84,7 +80,6 @@ class Test_MscolabOperation:
             self.window.mscolab.conn.disconnect()
         self.window.hide()
         QtWidgets.QApplication.processEvents()
-        self.process.terminate()
 
     def test_send_message(self):
         self._send_message("**test message**")

--- a/tests/_test_msui/test_mscolab_save_merge_points.py
+++ b/tests/_test_msui/test_mscolab_save_merge_points.py
@@ -32,9 +32,6 @@ from mslib.msui import flighttrack as ft
 from PyQt5 import QtCore, QtTest, QtWidgets
 
 
-PORTS = list(range(21000, 21500))
-
-
 @pytest.mark.skip("Uses QTimer, which can break other unrelated tests")
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")

--- a/tests/_test_msui/test_mscolab_version_history.py
+++ b/tests/_test_msui/test_mscolab_version_history.py
@@ -28,26 +28,20 @@ import os
 import pytest
 import mock
 
-from tests.utils import mscolab_start_server
 from mslib.mscolab.conf import mscolab_settings
 from PyQt5 import QtCore, QtTest, QtWidgets
 from mslib.msui import mscolab
 from mslib.msui import msui
-from mslib.mscolab.mscolab import handle_db_reset
 from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_operation
 from mslib.utils.config import modify_config_file
-
-
-PORTS = list(range(20000, 20500))
 
 
 @pytest.mark.skipif(os.name == "nt",
                     reason="multiprocessing needs currently start_method fork")
 class Test_MscolabVersionHistory:
     @pytest.fixture(autouse=True)
-    def setup(self, qapp):
-        handle_db_reset()
-        self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)
+    def setup(self, qapp, mscolab_server):
+        self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
         self.operation_name = "europe"
         assert add_user(self.userdata[0], self.userdata[1], self.userdata[2])
@@ -76,7 +70,6 @@ class Test_MscolabVersionHistory:
             self.window.mscolab.version_window.close()
         if self.window.mscolab.conn:
             self.window.mscolab.conn.disconnect()
-        self.process.terminate()
 
     def test_changes(self):
         self._change_version_filter(1)

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -31,15 +31,11 @@ import shutil
 import tempfile
 import pytest
 import hashlib
-import multiprocessing
-from mslib.mswms.mswms import application
+import urllib
 from PyQt5 import QtWidgets, QtCore, QtTest
 from mslib.msui import flighttrack as ft
 import mslib.msui.wms_control as wc
 from tests.utils import wait_until_signal
-
-
-PORTS = list(range(18000, 18500))
 
 
 class HSecViewMockup(mock.Mock):
@@ -55,9 +51,14 @@ class VSecViewMockup(mock.Mock):
 
 
 class WMSControlWidgetSetup:
+    @pytest.fixture(autouse=True)
+    def _with_mswms_server(self, mswms_server):
+        self.url = mswms_server
+        parsed_url = urllib.parse.urlparse(self.url)
+        self.scheme, self.host, self.port = parsed_url.scheme, parsed_url.hostname, parsed_url.port
+
     def _setup(self, widget_type):
         wc.WMS_SERVICE_CACHE = {}
-        self.port = PORTS.pop()
         if widget_type == "hsec":
             self.view = HSecViewMockup()
         else:
@@ -66,10 +67,6 @@ class WMSControlWidgetSetup:
         if not os.path.exists(self.tempdir):
             os.mkdir(self.tempdir)
         QtTest.QTest.qWait(3000)
-        self.thread = multiprocessing.Process(
-            target=application.run,
-            args=("127.0.0.1", self.port))
-        self.thread.start()
         if widget_type == "hsec":
             self.window = wc.HSecWMSControlWidget(view=self.view, wms_cache=self.tempdir)
         else:
@@ -95,7 +92,6 @@ class WMSControlWidgetSetup:
         self.window.hide()
         QtWidgets.QApplication.processEvents()
         shutil.rmtree(self.tempdir)
-        self.thread.terminate()
 
     def query_server(self, url):
         while len(self.window.multilayers.cbWMS_URL.currentText()) > 0:
@@ -123,7 +119,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a message box informs about server troubles
         """
-        self.query_server("http://127.0.0.1:8882")
+        self.query_server(f"{self.scheme}://{self.host}:{self.port-1}")
         assert mockbox.critical.call_count == 1
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -131,7 +127,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a message box informs about server troubles
         """
-        self.query_server(f"127.0.0.1:{self.port}")
+        self.query_server(f"{self.host}:{self.port}")
         assert mockbox.critical.call_count == 1
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -139,7 +135,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a message box informs about server troubles
         """
-        self.query_server(f"hppd://127.0.0.1:{self.port}")
+        self.query_server(f"hppd://{self.host}:{self.port}")
         assert mockbox.critical.call_count == 1
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
@@ -147,7 +143,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a message box informs about server troubles
         """
-        self.query_server(f"http://???127.0.0.1:{self.port}")
+        self.query_server(f"{self.scheme}://???{self.host}:{self.port}")
         assert mockbox.critical.call_count == 1
 
     @pytest.mark.skip("problem in urllib3")
@@ -156,12 +152,12 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a message box informs about server troubles
         """
-        self.query_server(f"http://.....127.0.0.1:{self.port}")
+        self.query_server(f"{self.scheme}://.....{self.host}:{self.port}")
         assert mockbox.critical.call_count == 1
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     def test_forward_backward_clicks(self, mockbox):
-        self.query_server(f"http://127.0.0.1:{self.port}")
+        self.query_server(self.url)
         self.window.init_time_back_click()
         self.window.init_time_fwd_click()
         self.window.valid_time_fwd_click()
@@ -183,7 +179,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that an aborted getmap call does not change the displayed image
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
+        self.query_server(self.url)
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWait(20)
@@ -201,7 +197,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
+        self.query_server(self.url)
 
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
@@ -218,7 +214,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
+        self.query_server(self.url)
 
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
@@ -249,7 +245,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that changing between servers still allows image retrieval
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
+        self.query_server(self.url)
         assert mockbox.critical.call_count == 0
 
         QtTest.QTest.keyClick(self.window.multilayers.cbWMS_URL, QtCore.Qt.Key_Backspace)
@@ -285,13 +281,13 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that multilayers get created, handled and drawn properly
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
-        server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
+        self.query_server(self.url)
+        server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
         assert server is not None
-        assert "header" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
-        assert "wms" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
+        assert "header" in self.window.multilayers.layers[f"{self.url}/"]
+        assert "wms" in self.window.multilayers.layers[f"{self.url}/"]
         self.window.multilayers.cbMultilayering.setChecked(True)
 
         for i in range(0, server.childCount()):
@@ -327,13 +323,13 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
     @pytest.mark.skip("Fails testing reverse order")
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     def test_filter_handling(self, mockbox):
-        self.query_server(f"http://127.0.0.1:{self.port}")
-        server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
+        self.query_server(self.url)
+        server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
         assert server is not None
-        assert "header" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
-        assert "wms" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
+        assert "header" in self.window.multilayers.layers[f"{self.url}/"]
+        assert "wms" in self.window.multilayers.layers[f"{self.url}/"]
 
         starts_at = 40 * self.window.multilayers.scale
         icon_start_fav = starts_at + 3
@@ -367,7 +363,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtTest.QTest.mouseMove(self.window.multilayers.listLayers, QtCore.QPoint(icon_start_del + 3, 0), -1)
         QtWidgets.QApplication.processEvents()
         self.window.multilayers.check_icon_clicked(server)
-        assert len(self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
+        assert len(self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                                 QtCore.Qt.MatchFixedString)) == 0
         assert mockbox.critical.call_count == 0
 
@@ -376,13 +372,13 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that singlelayer mode behaves as expected
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
-        server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
+        self.query_server(self.url)
+        server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
         assert server is not None
-        assert "header" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
-        assert "wms" in self.window.multilayers.layers[f"http://127.0.0.1:{self.port}/"]
+        assert "header" in self.window.multilayers.layers[f"{self.url}/"]
+        assert "wms" in self.window.multilayers.layers[f"{self.url}/"]
 
         self.window.multilayers.cbMultilayering.setChecked(True)
         self.window.multilayers.cbMultilayering.setChecked(False)
@@ -413,8 +409,8 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that synced layers share their options
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
-        server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
+        self.query_server(self.url)
+        server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
         server.setExpanded(True)
@@ -443,8 +439,8 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     @mock.patch("mslib.msui.wms_control.WMSMapFetcher.moveToThread")
     def test_server_no_thread(self, mockbox, mockthread):
-        self.query_server(f"http://127.0.0.1:{self.port}")
-        server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
+        self.query_server(self.url)
+        server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
         server.setExpanded(True)
@@ -456,7 +452,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.window.image_displayed)
 
-        urlstr = f"http://127.0.0.1:{self.port}/mss/logo.png"
+        urlstr = f"{self.url}/mss/logo.png"
         md5_filname = os.path.join(self.window.wms_cache, hashlib.md5(urlstr.encode('utf-8')).hexdigest() + ".png")
         self.window.fetcher.fetch_legend(urlstr, use_cache=False, md5_filename=md5_filname)
         self.window.fetcher.fetch_legend(urlstr, use_cache=True, md5_filename=md5_filname)
@@ -482,7 +478,7 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
+        self.query_server(self.url)
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.window.image_displayed)
@@ -499,8 +495,8 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that drawing a layer through code doesn't fail for vsec
         """
-        self.query_server(f"http://127.0.0.1:{self.port}")
-        server = self.window.multilayers.listLayers.findItems(f"http://127.0.0.1:{self.port}/",
+        self.query_server(self.url)
+        server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         server.child(0).draw()
         wait_until_signal(self.window.image_displayed)

--- a/tests/_test_mswms/test_wms.py
+++ b/tests/_test_mswms/test_wms.py
@@ -35,20 +35,23 @@ import pytest
 
 import mslib.mswms.wms
 import mslib.mswms.gallery_builder
-import mslib.mswms.mswms as mswms
 from importlib import reload
 from tests.utils import callback_ok_image, callback_ok_xml, callback_ok_html, callback_404_plain
 from tests.constants import DATA_DIR
 
 
 class Test_WMS:
+    @pytest.fixture(autouse=True)
+    def setup(self, mswms_app):
+        self.app = mswms_app
+
     def test_get_query_string_missing_parameters(self):
         environ = {
             'wsgi.url_scheme': 'http',
             'REQUEST_METHOD': 'GET', 'PATH_INFO': '/', 'SERVER_PROTOCOL': 'HTTP/1.1', 'HTTP_HOST': 'localhost:8081',
             'QUERY_STRING': 'request=GetCapabilities'}
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_404_plain(result.status, result.headers)
         assert isinstance(result.data, bytes), result
@@ -60,7 +63,7 @@ class Test_WMS:
             'REQUEST_METHOD': 'GET', 'PATH_INFO': '/', 'SERVER_PROTOCOL': 'HTTP/1.1', 'HTTP_HOST': 'localhost:8081',
             'QUERY_STRING': 'request=GetCapabilities&service=WMS&version=1.4.0'}
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_404_plain(result.status, result.headers)
         assert isinstance(result.data, bytes), result
@@ -102,7 +105,7 @@ class Test_WMS:
         )
 
         for tst_case in cases:
-            self.client = mswms.application.test_client()
+            self.client = self.app.test_client()
             result = self.client.get('/?{}'.format(tst_case["QUERY_STRING"]))
             callback_ok_xml(result.status, result.headers)
             assert isinstance(result.data, bytes), result
@@ -112,7 +115,7 @@ class Test_WMS:
             'wsgi.url_scheme': 'http',
             'REQUEST_METHOD': 'GET', 'PATH_INFO': '/', 'SERVER_PROTOCOL': 'HTTP/1.1', 'HTTP_HOST': 'localhost:8081',
             'QUERY_STRING': 'request=getcapabilities&service=wms&version=1.1.1'}
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_ok_xml(result.status, result.headers)
         assert isinstance(result.data, bytes), result
@@ -126,7 +129,7 @@ class Test_WMS:
                 'request=GetMap&bgcolor=0xFFFFFF&height=376&dim_init_time=2012-10-17T12%3A00%3A00Z&width=479&'
                 'version=1.1.1&bbox=-50.0%2C20.0%2C20.0%2C75.0&time=2012-10-17T12%3A00%3A00Z&'
                 'exceptions=application%2Fvnd.ogc.se_xml&transparent=FALSE'}
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_ok_image(result.status, result.headers)
 
@@ -151,7 +154,7 @@ class Test_WMS:
                 'version=1.1.1&bbox=-50.0%2C20.0%2C20.0%2C75.0&time=2012-10-17T12%3A00%3A00Z&'
                 'exceptions=application%2Fvnd.ogc.se_xml&transparent=FALSE'}
         query_string = environ["QUERY_STRING"]
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(query_string))
         callback_ok_image(result.status, result.headers)
         assert result.data.count(b"ServiceExceptionReport") == 0, result
@@ -185,7 +188,7 @@ class Test_WMS:
                 'version=1.1.1&bbox=201%2C500.0%2C10%2C100.0&time=2012-10-17T12%3A00%3A00Z&'
                 'exceptions=application%2Fvnd.ogc.se_xml&path=52.78%2C-8.93%2C48.08%2C11.28&transparent=FALSE'}
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_ok_image(result.status, result.headers)
 
@@ -212,7 +215,7 @@ class Test_WMS:
                 'exceptions=application%2Fvnd.ogc.se_xml&path=52.78%2C-8.93%2C48.08%2C11.28&transparent=FALSE'}
         query_string = environ["QUERY_STRING"]
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(query_string))
         callback_ok_image(result.status, result.headers)
         assert result.data.count(b"ServiceExceptionReport") == 0, result
@@ -243,7 +246,7 @@ class Test_WMS:
                 'version=1.1.1&bbox=201&time=2012-10-17T12%3A00%3A00Z&'
                 'exceptions=application%2Fvnd.ogc.se_xml&path=52.78%2C-8.93%2C25000%2C48.08%2C11.28%2C25000'}
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_ok_xml(result.status, result.headers)
 
@@ -270,7 +273,7 @@ class Test_WMS:
                 'exceptions=application%2Fvnd.ogc.se_xml&path=52.78%2C-8.93%2C25000%2C48.08%2C11.28%2C25000'}
         query_string = environ["QUERY_STRING"]
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(query_string))
         callback_ok_xml(result.status, result.headers)
         assert result.data.count(b"ServiceExceptionReport") == 0, result
@@ -302,7 +305,7 @@ class Test_WMS:
                 'version=1.1.1&bbox=-50.0%2C20.0%2C20.0%2C75.0&time=2012-10-17T12%3A00%3A00Z&'
                 'exceptions=application%2Fvnd.ogc.se_xml&transparent=FALSE'}
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         assert isinstance(result.data, bytes), result
 
@@ -316,7 +319,7 @@ class Test_WMS:
                 'version=1.1.1&bbox=-50.0%2C20.0%2C20.0%2C75.0&time=2012-10-17T12%3A00%3A00Z&'
                 'exceptions=application%2Fvnd.ogc.se_xml&transparent=FALSE'}
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         assert isinstance(result.data, bytes), result
 
@@ -327,7 +330,7 @@ class Test_WMS:
             'QUERY_STRING': '',
         }
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_ok_html(result.status, result.headers)
         assert isinstance(result.data, bytes), result
@@ -339,7 +342,7 @@ class Test_WMS:
             'REQUEST_METHOD': 'GET', 'PATH_INFO': '/', 'SERVER_PROTOCOL': 'HTTP/1.1', 'HTTP_HOST': 'localhost:8081',
             'QUERY_STRING': 'request=abraham',
         }
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_404_plain(result.status, result.headers)
         assert isinstance(result.data, bytes), result
@@ -356,7 +359,7 @@ class Test_WMS:
                 'version=1.1.1&bbox=-50.0%2C20.0%2C20.0%2C75.0&time=2012-10-17T12%3A00%3A00Z&'
                 'exceptions=application%2Fvnd.ogc.se_xml&transparent=FALSE'}
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_ok_image(result.status, result.headers)
         assert isinstance(result.data, bytes), result
@@ -371,7 +374,7 @@ class Test_WMS:
                 'version=1.1.1&bbox=201&time=2012-10-17T12%3A00%3A00Z&'
                 'exceptions=application%2Fvnd.ogc.se_xml&path=52.78%2C-8.93%2C25000%2C48.08%2C11.28%2C25000'}
 
-        self.client = mswms.application.test_client()
+        self.client = self.app.test_client()
         result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
         callback_ok_xml(result.status, result.headers)
 
@@ -397,7 +400,7 @@ class Test_WMS:
                 'exceptions=XML&transparent=FALSE'}
             pl_file = next(file for file in os.listdir(DATA_DIR) if ".pl" in file)
 
-            self.client = mswms.application.test_client()
+            self.client = self.app.test_client()
             result = self.client.get('/?{}'.format(environ["QUERY_STRING"]))
 
             # Assert modified file was reloaded and now looks different

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,10 +38,7 @@ from urllib.parse import urljoin
 from mslib.mscolab.server import register_user
 from flask import json
 from tests.constants import MSUI_CONFIG_PATH
-from mslib.mscolab.conf import mscolab_settings
-from mslib.mscolab.server import APP, initialize_managers, start_server
-from mslib.mscolab.mscolab import handle_db_init
-from mslib.utils.config import modify_config_file
+from mslib.mscolab.server import initialize_managers, start_server
 
 
 def callback_ok_image(status, response_headers):
@@ -182,60 +179,17 @@ def mscolab_check_free_port(all_ports, port):
     return port
 
 
-def mscolab_ping_server(port):
-    url = f"http://127.0.0.1:{port}/status"
-    try:
-        r = requests.get(url, timeout=(2, 10))
-        data = json.loads(r.text)
-        if data['message'] == "Mscolab server" and isinstance(data['USE_SAML2'], bool):
-            return True
-    except requests.exceptions.ConnectionError:
-        return False
-    return False
-
-
-def mscolab_start_server(all_ports, mscolab_settings=mscolab_settings, timeout=10):
-    handle_db_init()
-    port = mscolab_check_free_port(all_ports, all_ports.pop())
-
-    url = f"http://localhost:{port}"
-
-    # Update mscolab URL to avoid "Update Server List" message boxes
-    modify_config_file({"default_MSCOLAB": [url]})
-
-    _app = APP
-    _app.config['SQLALCHEMY_DATABASE_URI'] = mscolab_settings.SQLALCHEMY_DB_URI
-    _app.config['MSCOLAB_DATA_DIR'] = mscolab_settings.MSCOLAB_DATA_DIR
-    _app.config['UPLOAD_FOLDER'] = mscolab_settings.UPLOAD_FOLDER
-    _app.config['URL'] = url
-
-    _app, sockio, cm, fm = initialize_managers(_app)
-
-    # ToDo refactoring for spawn needed, fork is not implemented on windows, spawn is default on MAC and Windows
-    if multiprocessing.get_start_method(allow_none=True) != 'fork':
-        multiprocessing.set_start_method("fork")
-    process = multiprocessing.Process(
-        target=start_server,
-        args=(_app, sockio, cm, fm,),
-        kwargs={'port': port})
-    process.start()
-    start_time = time.time()
-    while True:
-        elapsed_time = (time.time() - start_time)
-        if elapsed_time > timeout:
-            raise RuntimeError(
-                "Failed to start the server after %d seconds. " % timeout
-            )
-
-        if mscolab_ping_server(port):
-            break
-
-    return process, url, _app, sockio, cm, fm
-
-
 def create_msui_settings_file(content):
     with fs.open_fs(MSUI_CONFIG_PATH) as file_dir:
         file_dir.writetext("msui_settings.json", content)
+
+
+def is_url_response_ok(url):
+    try:
+        response = requests.get(url)
+        return response.status_code == 200
+    except:  # noqa: E722
+        return False
 
 
 def wait_until_signal(signal, timeout=5):


### PR DESCRIPTION
This refactors the mscolab and mswms servers into pytest fixtures and also gets rid of some remnants from unittest (TestCase classes). The advantage is that this consolidates server setup and teardown code into one place, so that the tests requesting the fixtures no long have to care about e.g. resetting the database before tests or stopping the process afterwards. This also removes the need for the global `PORTS` variables.

Split off from #2100.