### PR TITLE
Remove wrong config file modification

### DIFF
--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -217,7 +217,6 @@ class Test_Mscolab_connect_window:
         assert config_loader(dataset="MSS_auth").get(self.url) == "something@something.org"
         self._connect_to_mscolab()
         assert self.window.mscolab_server_url is not None
-        modify_config_file({"MSS_auth": {self.url: "anand@something.org"}})
         self._create_user("anand", "anand@something.org", "anand_pass")
         # check changed settings
         assert config_loader(dataset="MSS_auth").get(self.url) == "anand@something.org"


### PR DESCRIPTION
The functionality under test here is that MSS does update the config file with the new credentials when creating a user, therefore modifying the file in the test defeated its purpose.