### PR TITLE
Remove the serial test execution from CI

### DIFF
--- a/.github/workflows/testing-develop.yml
+++ b/.github/workflows/testing-develop.yml
@@ -11,22 +11,10 @@ on:
 
 jobs:
   test-develop:
-    uses: 
+    uses:
       ./.github/workflows/testing.yml
     with:
-      xdist: no
-      branch_name: develop
-      event_name: ${{ github.event_name }}
-    secrets: 
-      PAT: ${{ secrets.PAT }}
-
-  test-develop-xdist:
-    uses: 
-      ./.github/workflows/testing.yml
-    with:
-      xdist: yes
       branch_name: develop
       event_name: ${{ github.event_name }}
     secrets:
       PAT: ${{ secrets.PAT }}
-

--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -2,29 +2,24 @@ name: new dependency test (scheduled)
 
 on:
   schedule:
-    - cron: '30 5 * * 1' 
+    - cron: '30 5 * * 1'
 
 
-jobs:     
+jobs:
   test-stable-scheduled:
-    uses: 
+    uses:
       ./.github/workflows/testing.yml
     with:
-      xdist: no
       branch_name: stable
       event_name: ${{ github.event_name }}
     secrets:
       PAT: ${{ secrets.PAT }}
 
   test-develop-scheduled:
-    uses: 
+    uses:
       ./.github/workflows/testing.yml
     with:
-      xdist: no
       branch_name: develop
       event_name: ${{ github.event_name }}
     secrets:
       PAT: ${{ secrets.PAT }}
-
-
-

--- a/.github/workflows/testing-stable.yml
+++ b/.github/workflows/testing-stable.yml
@@ -8,25 +8,12 @@ on:
     branches:
     - stable
 
-jobs:     
+jobs:
   test-stable:
-    uses: 
+    uses:
       ./.github/workflows/testing.yml
     with:
-      xdist: no
       branch_name: stable
       event_name: ${{ github.event_name }}
     secrets:
       PAT: ${{ secrets.PAT }}
-
-  test-stable-xdist:
-    uses: 
-      ./.github/workflows/testing.yml
-    with:
-      xdist: yes
-      branch_name: stable
-      event_name: ${{ github.event_name }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
-
-

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,9 +3,6 @@ name: Pytest MSS
 on:
   workflow_call:
     inputs:
-      xdist:
-        required: true
-        type: string
       branch_name:
         required: true
         type: string
@@ -30,6 +27,11 @@ jobs:
 
     container:
       image: openmss/testing-${{ inputs.branch_name }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        order: ["normal", "reverse"]
 
     steps:
     - name: Trust My Directory
@@ -74,27 +76,17 @@ jobs:
         && mamba list
 
     - name: Run tests
-      if: ${{ success() && inputs.xdist == 'no' }}
-      timeout-minutes: 25
+      timeout-minutes: 10
       run: |
         cd $GITHUB_WORKSPACE \
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate mss-${{ inputs.branch_name }}-env \
-        && xvfb-run pytest -v --durations=20 --reverse --cov=mslib tests
-
-    - name: Run tests in parallel
-      if: ${{ success() && inputs.xdist == 'yes' }}
-      timeout-minutes: 25
-      run: |
-        cd $GITHUB_WORKSPACE \
-        && source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-${{ inputs.branch_name }}-env \
-        && xvfb-run pytest -vv -n 6 --dist loadfile --max-worker-restart 4 tests
+        && xvfb-run pytest -v -n 6 --dist loadfile --max-worker-restart 4 --durations=20 --cov=mslib \
+          ${{ (matrix.order == 'normal' && ' ') || (matrix.order == 'reverse' && '--reverse') }} tests
 
     - name: Collect coverage
-      if: ${{ success() && inputs.event_name == 'push' && inputs.branch_name == 'develop' && inputs.xdist == 'no'}}
+      if: ${{ success() && inputs.event_name == 'push' && inputs.branch_name == 'develop' && matrix.order == 'normal' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -106,7 +98,7 @@ jobs:
         && coveralls --service=github
 
     - name: Invoke dockertesting image creation
-      if: ${{ always() && inputs.event_name == 'push' && env.triggerdockerbuild == 'yes' && inputs.xdist == 'no'}}
+      if: ${{ always() && inputs.event_name == 'push' && env.triggerdockerbuild == 'yes' && matrix.order == 'normal' }}
       uses: benc-uk/workflow-dispatch@v1.2.2
       with:
         workflow: Update Image testing-${{ inputs.branch_name }}

--- a/.github/workflows/testing_gsoc.yml
+++ b/.github/workflows/testing_gsoc.yml
@@ -24,6 +24,11 @@ jobs:
     container:
       image: openmss/testing-develop
 
+    strategy:
+      fail-fast: false
+      matrix:
+        order: ["normal", "reverse"]
+
     steps:
     - name: Trust My Directory
       run: git config --global --add safe.directory /__w/MSS/MSS
@@ -63,23 +68,14 @@ jobs:
 
     - name: Run tests
       if: ${{ success() }}
-      timeout-minutes: 25
+      timeout-minutes: 10
       run: |
         cd $GITHUB_WORKSPACE \
         && source /opt/conda/etc/profile.d/conda.sh \
         && source /opt/conda/etc/profile.d/mamba.sh \
         && mamba activate mss-develop-env \
-        && xvfb-run pytest -v --durations=20 --reverse --cov=mslib tests
-
-    - name: Run tests in parallel
-      if: ${{ success() }}
-      timeout-minutes: 25
-      run: |
-        cd $GITHUB_WORKSPACE \
-        && source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-develop-env \
-        && xvfb-run pytest -vv -n 6 --dist loadfile --max-worker-restart 0 tests
+        && xvfb-run pytest -v -n 6 --dist loadfile --max-worker-restart 4 --durations=20 --cov=mslib \
+          ${{ (matrix.order == 'normal' && ' ') || (matrix.order == 'reverse' && '--reverse') }} tests
 
     - name: Collect coverage
       if: ${{ success() }}


### PR DESCRIPTION
There is no necessity to have a serial and a parallel execution of the test suite. Pytest-xdist and pytest-cov can be combined. Since the retries get removed when #2153 (which this PR depends on) lands there should no longer be a difference between the test coverages due to the crashes and retries that existed previously.

Fixes #2191.