### PR TITLE
Remove unnecessary skips

### DIFF
--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -389,7 +389,6 @@ class Test_Mscolab:
             imported_wp = self.window.mscolab.waypoints_model
             assert len(imported_wp.waypoints) == name[2]
 
-    @pytest.mark.skip("Runs in a timeout locally > 60s")
     def test_work_locally_toggle(self):
         self._connect_to_mscolab()
         modify_config_file({"MSS_auth": {self.url: self.userdata[0]}})
@@ -408,10 +407,8 @@ class Test_Mscolab:
         wpdata_server = self.window.mscolab.waypoints_model.waypoint_data(0)
         assert wpdata_local.lat != wpdata_server.lat
 
-    @pytest.mark.skip("fails often on github on a timeout >60s")
-    @mock.patch("mslib.msui.mscolab.QtWidgets.QErrorMessage.showMessage")
     @mock.patch("mslib.msui.mscolab.get_open_filename", return_value=os.path.join(sample_path, u"example.ftml"))
-    def test_browse_add_operation(self, mockopen, mockmessage, qtbot):
+    def test_browse_add_operation(self, mockopen, qtbot):
         self._connect_to_mscolab()
         modify_config_file({"MSS_auth": {self.url: "something@something.org"}})
         self._create_user(qtbot, "something", "something@something.org", "something")
@@ -428,7 +425,9 @@ class Test_Mscolab:
         QtWidgets.QApplication.processEvents()
         okWidget = self.window.mscolab.add_proj_dialog.buttonBox.button(
             self.window.mscolab.add_proj_dialog.buttonBox.Ok)
-        QtTest.QTest.mouseClick(okWidget, QtCore.Qt.LeftButton)
+        with mock.patch("PyQt5.QtWidgets.QMessageBox.information") as m:
+            QtTest.QTest.mouseClick(okWidget, QtCore.Qt.LeftButton)
+            m.assert_called_once()
         # we need to wait for the update of the operation list
         QtTest.QTest.qWait(200)
         QtWidgets.QApplication.processEvents()
@@ -461,7 +460,6 @@ class Test_Mscolab:
 
     @mock.patch("PyQt5.QtWidgets.QInputDialog.getText", return_value=("flight7", True))
     def test_handle_delete_operation(self, mocktext, qtbot):
-        # pytest.skip('needs a review for the delete button pressed. Seems to delete a None operation')
         self._connect_to_mscolab()
         modify_config_file({"MSS_auth": {self.url: "berta@something.org"}})
         self._create_user(qtbot, "berta", "berta@something.org", "something")

--- a/tests/_test_msui/test_mscolab_save_merge_points.py
+++ b/tests/_test_msui/test_mscolab_save_merge_points.py
@@ -24,13 +24,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import pytest
+import mock
 from tests._test_msui.test_mscolab_merge_waypoints import Test_Mscolab_Merge_Waypoints
 from mslib.msui import flighttrack as ft
 from PyQt5 import QtCore, QtTest, QtWidgets
 
 
-@pytest.mark.skip("Uses QTimer, which can break other unrelated tests")
 class Test_Save_Merge_Points(Test_Mscolab_Merge_Waypoints):
     def test_save_merge_points(self):
         self.emailid = "mergepoints@alpha.org"
@@ -53,7 +52,9 @@ class Test_Save_Merge_Points(Test_Mscolab_Merge_Waypoints):
         QtCore.QTimer.singleShot(3000, handle_merge_dialog)
         # QtTest.QTest.mouseClick(self.window.save_ft, QtCore.Qt.LeftButton, delay=1)
         # trigger save to server action from server options combobox
-        self.window.serverOptionsCb.setCurrentIndex(2)
+        with mock.patch("PyQt5.QtWidgets.QMessageBox.information") as m:
+            self.window.serverOptionsCb.setCurrentIndex(2)
+            m.assert_called_once()
         QtWidgets.QApplication.processEvents()
         # get the updated waypoints model from the server
         # ToDo understand why requesting in follow up test of self.window.waypoints_model not working

--- a/tests/_test_msui/test_mss.py
+++ b/tests/_test_msui/test_mss.py
@@ -24,12 +24,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import pytest
 from PyQt5 import QtWidgets, QtTest, QtCore
 from mslib.msui import mss
 
 
-@pytest.mark.skip(reason='needs review, assert missing')
 def test_mss_rename_message(qapp):
     main_window = mss.MSSMainWindow()
     main_window.show()

--- a/tests/_test_msui/test_msui.py
+++ b/tests/_test_msui/test_msui.py
@@ -237,10 +237,10 @@ class Test_MSSSideViewWindow:
         QtWidgets.QApplication.processEvents()
 
     def test_open_config(self):
-        pytest.skip("To be done")
-        self.window.actionConfigurationEditor.trigger()
+        self.window.actionConfiguration.trigger()
         QtWidgets.QApplication.processEvents()
-        self.window.config_editor.close()
+        with mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes):
+            self.window.config_editor.close()
 
     def test_open_shortcut(self):
         self.window.actionShortcuts.trigger()
@@ -298,21 +298,20 @@ class Test_MSSSideViewWindow:
             assert os.path.exists(save_file[0])
             os.remove(save_file[0])
 
-    @pytest.mark.skip("needs to be refactored to become independent")
     @mock.patch("mslib.msui.msui_mainwindow.config_loader", return_value=export_plugins)
-    def test_add_plugins(self, mockopen, mockbox):
+    def test_add_plugins(self, mockopen):
         assert len(self.window.menuImportFlightTrack.actions()) == 2
         assert len(self.window.menuExportActiveFlightTrack.actions()) == 2
-        assert len(self.window.import_plugins) == 1
-        assert len(self.window.export_plugins) == 1
+        assert len(self.window.import_plugins) == 0
+        assert len(self.window.export_plugins) == 0
 
         self.window.remove_plugins()
         self.window.add_import_plugins("qt")
         self.window.add_export_plugins("qt")
         assert len(self.window.import_plugins) == 1
         assert len(self.window.export_plugins) == 1
-        assert len(self.window.menuImportFlightTrack.actions()) == 2
-        assert len(self.window.menuExportActiveFlightTrack.actions()) == 2
+        assert len(self.window.menuImportFlightTrack.actions()) == 3
+        assert len(self.window.menuExportActiveFlightTrack.actions()) == 3
 
         self.window.remove_plugins()
         with mock.patch("importlib.import_module", new=ExceptionMock(Exception()).raise_exc), \
@@ -333,8 +332,8 @@ class Test_MSSSideViewWindow:
         self.window.remove_plugins()
         assert len(self.window.import_plugins) == 0
         assert len(self.window.export_plugins) == 0
-        assert len(self.window.menuImportFlightTrack.actions()) == 1
-        assert len(self.window.menuExportActiveFlightTrack.actions()) == 1
+        assert len(self.window.menuImportFlightTrack.actions()) == 2
+        assert len(self.window.menuExportActiveFlightTrack.actions()) == 2
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes)
     @mock.patch("PyQt5.QtWidgets.QMessageBox.information", return_value=QtWidgets.QMessageBox.Yes)

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -117,7 +117,6 @@ class Test_MSSSideViewWindow:
         assert mockdlg.return_value.exec_.call_count == 1
         assert mockdlg.return_value.destroy.call_count == 1
 
-    @pytest.mark.skip("fails with mockbox.critical.call_count in reverse order")
     def test_insert_point(self):
         """
         Test inserting a point inside and outside the canvas

--- a/tests/_test_mswms/test_mss_plot_driver.py
+++ b/tests/_test_mswms/test_mss_plot_driver.py
@@ -186,7 +186,6 @@ class Test_VSec:
         assert noframe != img
 
     def test_VS_LagrantoTrajStyle_PL_01(self):
-        pytest.skip("data not available")
         img = self.plot(mpl_vsec_styles.VS_LagrantoTrajStyle_PL_01(driver=self.vsec))
         assert img is not None
         noframe = self.plot(mpl_vsec_styles.VS_LagrantoTrajStyle_PL_01(driver=self.vsec), noframe=True)
@@ -199,7 +198,6 @@ class Test_VSec:
         assert noframe != img
 
     def test_VS_gallery_template(self):
-        pytest.skip('Test can be biased. In pytest-reverse when there is not a plot_examples it can''t import')
         # ToDo Test Data have to be written to a random tmp dir and that may become purged afterwards
         templates_location = os.path.join(mslib.mswms.gallery_builder.DOCS_LOCATION, "plot_examples")
         sys.path.append(templates_location)
@@ -504,7 +502,6 @@ class Test_HSec:
         assert noframe != img
 
     def test_HS_gallery_template(self):
-        pytest.skip('Test can be biased. In pytest-reverse when there is not a plot_examples it can''t import')
         # ToDo Test Data have to be written to a random tmp dir and that may become purged afterwards
         templates_location = os.path.join(mslib.mswms.gallery_builder.DOCS_LOCATION, "plot_examples")
         sys.path.append(templates_location)

--- a/tests/_test_utils/test_config.py
+++ b/tests/_test_utils/test_config.py
@@ -121,8 +121,6 @@ class TestConfigLoader:
         """
         on a user defined empty msui_settings_json this test should return the default value for num_labels
         """
-        if not fs.open_fs(MSUI_CONFIG_PATH).exists("msui_settings.json"):
-            pytest.skip('undefined test msui_settings.json')
         with fs.open_fs(MSUI_CONFIG_PATH) as file_dir:
             file_content = file_dir.readtext("msui_settings.json")
         assert ":" not in file_content
@@ -143,8 +141,6 @@ class TestConfigLoader:
         on a user defined msui_settings_json without a defined num_labels this test should return its default value
         """
         create_msui_settings_file('{"num_interpolation_points": 20 }')
-        if not fs.open_fs(MSUI_CONFIG_PATH).exists("msui_settings.json"):
-            pytest.skip('undefined test msui_settings.json')
         with fs.open_fs(MSUI_CONFIG_PATH) as file_dir:
             file_content = file_dir.readtext("msui_settings.json")
         assert "num_labels" not in file_content
@@ -168,8 +164,6 @@ class TestConfigLoader:
         on a user defined msui_settings_json without a defined num_labels this test should return its default value
         """
         create_msui_settings_file('{"num_interpolation_points": 201, "num_labels": 10 }')
-        if not fs.open_fs(MSUI_CONFIG_PATH).exists("msui_settings.json"):
-            pytest.skip('undefined test msui_settings.json')
         with fs.open_fs(MSUI_CONFIG_PATH) as file_dir:
             file_content = file_dir.readtext("msui_settings.json")
         assert "num_labels" in file_content
@@ -187,8 +181,6 @@ class TestConfigLoader:
         on a user defined msui_settings_json with duplicate and empty keys should raise FatalUserError
         """
         create_msui_settings_file('{"num_interpolation_points": 201, "num_interpolation_points": 10 }')
-        if not fs.open_fs(MSUI_CONFIG_PATH).exists("msui_settings.json"):
-            pytest.skip('undefined test msui_settings.json')
         with fs.open_fs(MSUI_CONFIG_PATH) as file_dir:
             file_content = file_dir.readtext("msui_settings.json")
         assert "num_interpolation_points" in file_content
@@ -197,8 +189,6 @@ class TestConfigLoader:
             read_config_file(path=config_file)
 
         create_msui_settings_file('{"": 201, "num_labels": 10 }')
-        if not fs.open_fs(MSUI_CONFIG_PATH).exists("msui_settings.json"):
-            pytest.skip('undefined test msui_settings.json')
         with fs.open_fs(MSUI_CONFIG_PATH) as file_dir:
             file_content = file_dir.readtext("msui_settings.json")
         assert "num_labels" in file_content
@@ -209,8 +199,6 @@ class TestConfigLoader:
         """
         Test to check if modify_config_file properly stores a key-value pair in an empty config file
         """
-        if not fs.open_fs(MSUI_CONFIG_PATH).exists("msui_settings.json"):
-            pytest.skip('undefined test msui_settings.json')
         data_to_save_in_config_file = {
             "num_labels": 20
         }
@@ -225,8 +213,6 @@ class TestConfigLoader:
         Test to check if modify_config_file properly modifies a key-value pair in the config file
         """
         create_msui_settings_file('{"num_labels": 14}')
-        if not fs.open_fs(MSUI_CONFIG_PATH).exists("msui_settings.json"):
-            pytest.skip('undefined test msui_settings.json')
         data_to_save_in_config_file = {
             "num_labels": 20
         }
@@ -240,8 +226,6 @@ class TestConfigLoader:
         """
         Test to check if modify_config_file raises a KeyError when a key is empty
         """
-        if not fs.open_fs(MSUI_CONFIG_PATH).exists("msui_settings.json"):
-            pytest.skip('undefined test msui_settings.json')
         data_to_save_in_config_file = {
             "": "sree",
             "num_labels": "20"


### PR DESCRIPTION
This PR removes many unnecessary skips for tests that either work fine or needed just a small amount of changes.

Fixes #2188.

Split off from #2100.

I want to wait with this until after #2158 is merged.