### PR TITLE
Consolidate skips due to start method "fork"

### DIFF
--- a/tests/_test_mscolab/test_file_manager.py
+++ b/tests/_test_mscolab/test_file_manager.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import datetime
 import pytest
 
@@ -32,8 +31,6 @@ from mslib.mscolab.models import Operation, User
 from mslib.mscolab.seed import add_user, get_user
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_FileManager:
     @pytest.fixture(autouse=True)
     def setup(self, mscolab_app, mscolab_managers):

--- a/tests/_test_mscolab/test_files.py
+++ b/tests/_test_mscolab/test_files.py
@@ -34,8 +34,6 @@ from mslib.mscolab.seed import add_user, get_user
 from mslib.mscolab.utils import get_recent_op_id
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_Files:
     @pytest.fixture(autouse=True)
     def setup(self, mscolab_app, mscolab_managers):

--- a/tests/_test_mscolab/test_files_api.py
+++ b/tests/_test_mscolab/test_files_api.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import fs
 import pytest
 
@@ -32,8 +31,6 @@ from mslib.mscolab.models import Operation
 from mslib.mscolab.seed import add_user, get_user
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_Files:
     @pytest.fixture(autouse=True)
     def setup(self, mscolab_app, mscolab_managers):

--- a/tests/_test_mscolab/test_server.py
+++ b/tests/_test_mscolab/test_server.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import pytest
 import json
 import io
@@ -36,8 +35,6 @@ from mslib.mscolab.file_manager import FileManager
 from mslib.mscolab.seed import add_user, get_user
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_Server:
     @pytest.fixture(autouse=True)
     def setup(self, mscolab_app):

--- a/tests/_test_mscolab/test_server_auth_required.py
+++ b/tests/_test_mscolab/test_server_auth_required.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import pytest
 
 from mslib.mscolab.conf import mscolab_settings
@@ -37,8 +36,6 @@ except ImportError:
                 "e.g. pytest tests/_test_mscolab/test_server_auth_required.py", allow_module_level=True)
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_Server_Auth_Not_Valid:
     @pytest.fixture(autouse=True)
     def setup(self, mscolab_app):

--- a/tests/_test_mscolab/test_utils.py
+++ b/tests/_test_mscolab/test_utils.py
@@ -50,8 +50,6 @@ class Message:
             pass
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_Utils:
     @pytest.fixture(autouse=True)
     def setup(self, mscolab_app, mscolab_managers):
@@ -62,8 +60,6 @@ class Test_Utils:
         with self.app.app_context():
             yield
 
-    @pytest.mark.skipif(os.name == "nt",
-                        reason="multiprocessing needs currently start_method fork")
     def test_get_recent_oid(self):
         assert add_user(self.userdata[0], self.userdata[1], self.userdata[2])
         assert add_user(self.anotheruserdata[0], self.anotheruserdata[1], self.anotheruserdata[2])

--- a/tests/_test_msui/test_linearview.py
+++ b/tests/_test_msui/test_linearview.py
@@ -103,8 +103,6 @@ class Test_MSSLinearViewWindow:
         assert mockdlg.return_value.destroy.call_count == 1
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_LinearViewWMS:
     @pytest.fixture(autouse=True)
     def setup(self, qapp, mswms_server):

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -250,8 +250,6 @@ class Test_Mscolab_connect_window:
         QtWidgets.QApplication.processEvents()
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_Mscolab:
     sample_path = os.path.join(os.path.dirname(__file__), "..", "data")
     # import/export plugins

--- a/tests/_test_msui/test_mscolab_admin_window.py
+++ b/tests/_test_msui/test_mscolab_admin_window.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import mock
 import pytest
 
@@ -36,8 +35,6 @@ from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_op
 from mslib.utils.config import modify_config_file
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_MscolabAdminWindow:
     @pytest.fixture(autouse=True)
     def setup(self, qapp, mscolab_server):

--- a/tests/_test_msui/test_mscolab_merge_waypoints.py
+++ b/tests/_test_msui/test_mscolab_merge_waypoints.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import fs
 import mock
 import pytest
@@ -39,8 +38,6 @@ from mslib.msui import mscolab
 from mslib.msui import msui
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_Mscolab_Merge_Waypoints:
     @pytest.fixture(autouse=True)
     def setup(self, qapp, mscolab_app, mscolab_server):

--- a/tests/_test_msui/test_mscolab_operation.py
+++ b/tests/_test_msui/test_mscolab_operation.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import pytest
 
 from mslib.mscolab.conf import mscolab_settings
@@ -44,8 +43,6 @@ class Actions:
     DELETE = 4
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_MscolabOperation:
     @pytest.fixture(autouse=True)
     def setup(self, qapp, mscolab_app, mscolab_server):

--- a/tests/_test_msui/test_mscolab_save_merge_points.py
+++ b/tests/_test_msui/test_mscolab_save_merge_points.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import mock
 import pytest
 from tests._test_msui.test_mscolab_merge_waypoints import Test_Mscolab_Merge_Waypoints
@@ -33,8 +32,6 @@ from PyQt5 import QtCore, QtTest, QtWidgets
 
 
 @pytest.mark.skip("Uses QTimer, which can break other unrelated tests")
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_Save_Merge_Points(Test_Mscolab_Merge_Waypoints):
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     def test_save_merge_points(self, mockbox):

--- a/tests/_test_msui/test_mscolab_version_history.py
+++ b/tests/_test_msui/test_mscolab_version_history.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os
 import pytest
 import mock
 
@@ -36,8 +35,6 @@ from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_op
 from mslib.utils.config import modify_config_file
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_MscolabVersionHistory:
     @pytest.fixture(autouse=True)
     def setup(self, qapp, mscolab_server):

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -160,8 +160,6 @@ class Test_MSSSideViewWindow:
         assert mockbox.critical.call_count == 0
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_SideViewWMS:
     @pytest.fixture(autouse=True)
     def setup(self, qapp, mswms_server):

--- a/tests/_test_msui/test_topview.py
+++ b/tests/_test_msui/test_topview.py
@@ -283,8 +283,6 @@ class Test_MSSTopViewWindow:
             assert mockbox.critical.call_count == 0
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_TopViewWMS:
     @pytest.fixture(autouse=True)
     def setup(self, qapp, mswms_server):

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -105,8 +105,6 @@ class WMSControlWidgetSetup:
         wait_until_signal(self.window.cpdlg.canceled)
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
     @pytest.fixture(autouse=True)
     def setup(self, qapp):
@@ -463,8 +461,6 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert self.view.draw_metadata.call_count == 1
 
 
-@pytest.mark.skipif(os.name == "nt",
-                    reason="multiprocessing needs currently start_method fork")
 class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
     @pytest.fixture(autouse=True)
     def setup(self, qapp):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -175,6 +175,8 @@ def _running_eventlet_server(app):
     port = socket.getsockname()[1]
     url = f"{scheme}://{host}:{port}"
     app.config['URL'] = url
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("requires the multiprocessing start_method 'fork', which is unavailable on this system")
     ctx = multiprocessing.get_context("fork")
     process = ctx.Process(target=eventlet.wsgi.server, args=(socket, app), daemon=True)
     try:


### PR DESCRIPTION
There is just one place where the start method "fork" is used, which is in tests.fixtures. By adding a conditional skip at that location all other skips for this reason become obsolete, since the tests will be automatically skipped if they request one of the fixtures that require this start method from multiprocessing and the start method is unsupported on the given system.

This PR addresses an issue that was found in https://github.com/Open-MSS/MSS/pull/2100#issuecomment-1877243231, where some tests that needed to be skipped actually weren't and therefore failed on windows.