### PR TITLE
Simplify mslib.utils.qt.Worker mock

### DIFF
--- a/tests/_test_msui/test_updater.py
+++ b/tests/_test_msui/test_updater.py
@@ -53,17 +53,7 @@ class SubprocessSameMock:
         self.args = args
 
 
-def create_mock(function, on_success=None, on_failure=None, start=True):
-    worker = Worker(function)
-    if on_success:
-        worker.finished.connect(on_success)
-    if on_failure:
-        worker.failed.connect(on_failure)
-    if start:
-        worker.run()
-    return worker
-
-
+@mock.patch("mslib.utils.qt.Worker.start", Worker.run)
 class Test_MSS_ShortcutDialog:
     @pytest.fixture(autouse=True)
     def setup(self, qapp):
@@ -89,7 +79,6 @@ class Test_MSS_ShortcutDialog:
 
     @mock.patch("subprocess.Popen", new=SubprocessDifferentVersionMock)
     @mock.patch("subprocess.run", new=SubprocessDifferentVersionMock)
-    @mock.patch("mslib.utils.qt.Worker.create", create_mock)
     def test_update_recognised(self):
         self.updater.run()
 
@@ -103,7 +92,6 @@ class Test_MSS_ShortcutDialog:
 
     @mock.patch("subprocess.Popen", new=SubprocessSameMock)
     @mock.patch("subprocess.run", new=SubprocessSameMock)
-    @mock.patch("mslib.utils.qt.Worker.create", create_mock)
     def test_no_update(self):
         self.updater.run()
         assert self.status == "Your MSS is up to date."
@@ -112,7 +100,6 @@ class Test_MSS_ShortcutDialog:
 
     @mock.patch("subprocess.Popen", new=SubprocessDifferentVersionMock)
     @mock.patch("subprocess.run", new=SubprocessDifferentVersionMock)
-    @mock.patch("mslib.utils.qt.Worker.create", create_mock)
     def test_update_failed(self):
         self.updater.run()
         assert self.updater.new_version == "999.999.999"
@@ -124,7 +111,6 @@ class Test_MSS_ShortcutDialog:
 
     @mock.patch("subprocess.Popen", new=no_conda)
     @mock.patch("subprocess.run", new=no_conda)
-    @mock.patch("mslib.utils.qt.Worker.create", create_mock)
     def test_no_conda(self):
         self.updater.run()
         assert self.updater.new_version is None and self.updater.old_version is None
@@ -133,7 +119,6 @@ class Test_MSS_ShortcutDialog:
 
     @mock.patch("subprocess.Popen", new=no_conda)
     @mock.patch("subprocess.run", new=no_conda)
-    @mock.patch("mslib.utils.qt.Worker.create", create_mock)
     def test_exception(self):
         self.updater.new_version = "999.999.999"
         self.updater.old_version = "999.999.999"
@@ -144,7 +129,6 @@ class Test_MSS_ShortcutDialog:
     @mock.patch("subprocess.Popen", new=SubprocessSameMock)
     @mock.patch("subprocess.run", new=SubprocessSameMock)
     @mock.patch("PyQt5.QtWidgets.QMessageBox.information", return_value=QtWidgets.QMessageBox.Yes)
-    @mock.patch("mslib.utils.qt.Worker.create", create_mock)
     def test_ui(self, mock):
         ui = UpdaterUI()
         ui.updater.on_update_available.emit("", "")


### PR DESCRIPTION
Simplifies the given mock so that it does not re-implement the actual logic of the mslib.utils.qt.Worker class.

Split off from #2100.