### PR TITLE
Fix ConversionError with pint=0.23

### DIFF
--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -77,7 +77,7 @@ requirements:
     - PyMySQL >=0.9.3
     - validate_email
     - multidict
-    - pint <=0.22
+    - pint
     - python-socketio >=5
     - python-engineio >=4
     - markdown

--- a/mslib/msui/mpl_qtwidget.py
+++ b/mslib/msui/mpl_qtwidget.py
@@ -475,6 +475,10 @@ class SideViewPlotter(ViewPlotter):
         for ax, typ in zip((self.ax, self.ax2), (vaxis, vaxis2)):
             ylabel, major_ticks, minor_ticks, labels = self._determine_ticks_labels(typ)
 
+            major_ticks_units = getattr(major_ticks, "units", None)
+            if ax.yaxis.units is None and major_ticks_units is not None:
+                ax.yaxis.set_units(major_ticks_units)
+
             ax.set_ylabel(ylabel, fontsize=plot_title_size)
             ax.set_yticks(minor_ticks, minor=True)
             ax.set_yticks(major_ticks, minor=False)


### PR DESCRIPTION
The error happens when trying to use a pint Quantity in a matplotlib axis that has no units set, because the attempted conversion to `units=None` fails. This change sets the units of the axis to be the same as the ticks' units, but only if the ticks have units set and the axis does not. This is effectively a fallback to the Quantity's units if nothing else is set.

Fixes #2162.