### PR TITLE
Remove unnecessary mocking

### DIFF
--- a/tests/_test_msui/test_kmloverlay_dockwidget.py
+++ b/tests/_test_msui/test_kmloverlay_dockwidget.py
@@ -87,8 +87,7 @@ class Test_KmlOverlayDockWidget:
         QtWidgets.QApplication.processEvents()
         assert mockopen.call_count == 1
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_select_file(self, mockbox):
+    def test_select_file(self):
         """
         Test All geometries and styles are being parsed without crashing
         """
@@ -100,27 +99,26 @@ class Test_KmlOverlayDockWidget:
             assert self.window.listWidget.item(index).checkState() == QtCore.Qt.Checked
             index = index + 1
         assert self.window.directory_location == path
-        assert mockbox.critical.call_count == 0
         assert self.window.listWidget.count() == index
         assert len(self.window.dict_files) == index
         assert self.count_patches() == 9
         self.window.select_all()
         self.window.remove_file()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_select_file_error(self, mockbox):
+    def test_select_file_error(self):
         """
         Test that program mitigates loading a non-existing file
         """
-        # load a non existing path
-        self.window.select_all()
-        self.window.remove_file()
-        path = fs.path.join(sample_path, "satellite_predictor.txt")
-        filename = (path,)  # converted to tuple
-        self.window.select_file(filename)
-        self.window.load_file()
-        QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 1
+        with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as critbox:
+            # load a non existing path
+            self.window.select_all()
+            self.window.remove_file()
+            path = fs.path.join(sample_path, "satellite_predictor.txt")
+            filename = (path,)  # converted to tuple
+            self.window.select_file(filename)
+            self.window.load_file()
+            QtWidgets.QApplication.processEvents()
+            critbox.assert_called_once()
         self.window.listWidget.clear()
         self.window.dict_files = {}
 
@@ -150,9 +148,8 @@ class Test_KmlOverlayDockWidget:
         assert self.window.dict_files == {}  # Dictionary should be empty
         assert self.count_patches() == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
     @mock.patch("mslib.msui.kmloverlay_dockwidget.get_save_filename", return_value=save_kml)
-    def test_merge_file(self, mocksave, mockbox):
+    def test_merge_file(self, mocksave):
         """
         Test merging files into a single file without crashing
         """

--- a/tests/_test_msui/test_linearview.py
+++ b/tests/_test_msui/test_linearview.py
@@ -49,14 +49,11 @@ class Test_MSS_LV_Options_Dialog:
         self.window.hide()
         QtWidgets.QApplication.processEvents()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_show(self, mockcrit):
-        assert mockcrit.critical.call_count == 0
+    def test_show(self):
+        pass
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_get(self, mockcrit):
+    def test_get(self):
         self.window.get_settings()
-        assert mockcrit.critical.call_count == 0
 
 
 class Test_MSSLinearViewWindow:
@@ -77,26 +74,21 @@ class Test_MSSLinearViewWindow:
         self.window.hide()
         QtWidgets.QApplication.processEvents()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_wms(self, mockbox):
+    def test_open_wms(self):
         self.window.cbTools.currentIndexChanged.emit(1)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_mouse_over(self, mockbox):
+    def test_mouse_over(self):
         # Test mouse over
         QtTest.QTest.mouseMove(self.window.mpl.canvas, QtCore.QPoint(782, 266), -1)
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseMove(self.window.mpl.canvas, QtCore.QPoint(100, 100), -1)
         QtWidgets.QApplication.processEvents()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
     @mock.patch("mslib.msui.linearview.MSUI_LV_Options_Dialog")
-    def test_options(self, mockdlg, mockbox):
+    def test_options(self, mockdlg):
         QtTest.QTest.mouseClick(self.window.lvoptionbtn, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         assert mockdlg.call_count == 1
         assert mockdlg.return_value.setModal.call_count == 1
         assert mockdlg.return_value.exec_.call_count == 1
@@ -138,12 +130,10 @@ class Test_LinearViewWMS:
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.wms_control.cpdlg.canceled)
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_server_getmap(self, mockbox, qtbot):
+    def test_server_getmap(self, qtbot):
         """
         assert that a getmap call to a WMS server displays an image
         """
         self.query_server(self.url)
         with qtbot.wait_signal(self.wms_control.image_displayed):
             QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
-        assert mockbox.critical.call_count == 0

--- a/tests/_test_msui/test_mscolab_merge_waypoints.py
+++ b/tests/_test_msui/test_mscolab_merge_waypoints.py
@@ -36,6 +36,7 @@ from tests.utils import (mscolab_register_and_login, mscolab_create_operation,
                          mscolab_delete_all_operations, mscolab_delete_user)
 from mslib.msui import mscolab
 from mslib.msui import msui
+from mslib.utils.config import modify_config_file
 
 
 class Test_Mscolab_Merge_Waypoints:
@@ -85,6 +86,7 @@ class Test_Mscolab_Merge_Waypoints:
         QtTest.QTest.qWait(500)
 
     def _login(self, emailid="merge_waypoints_user", password="password"):
+        modify_config_file({"MSS_auth": {self.url: self.emailid}})
         self.connect_window.loginEmailLe.setText(emailid)
         self.connect_window.loginPasswordLe.setText(password)
         QtTest.QTest.mouseClick(self.connect_window.loginBtn, QtCore.Qt.LeftButton)
@@ -112,8 +114,7 @@ class AutoClickOverwriteMscolabMergeWaypointsDialog(mslib.msui.mscolab.MscolabMe
 
 
 class Test_Overwrite_To_Server(Test_Mscolab_Merge_Waypoints):
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_save_overwrite_to_server(self, mockbox, qtbot):
+    def test_save_overwrite_to_server(self, qtbot):
         self.emailid = "save_overwrite@alpha.org"
         self._create_user_data(emailid=self.emailid)
         wp_server_before = self.window.mscolab.waypoints_model.waypoint_data(0)
@@ -135,8 +136,10 @@ class Test_Overwrite_To_Server(Test_Mscolab_Merge_Waypoints):
         # trigger save to server action from server options combobox
         with mock.patch(
             "mslib.msui.mscolab.MscolabMergeWaypointsDialog",
-                AutoClickOverwriteMscolabMergeWaypointsDialog):
+            AutoClickOverwriteMscolabMergeWaypointsDialog), \
+                mock.patch("PyQt5.QtWidgets.QMessageBox.information") as m:
             self.window.serverOptionsCb.setCurrentIndex(2)
+            m.assert_called_once()
 
         def assert_():
             # get the updated waypoints model from the server
@@ -161,8 +164,7 @@ class AutoClickKeepMscolabMergeWaypointsDialog(mslib.msui.mscolab.MscolabMergeWa
 
 
 class Test_Save_Keep_Server_Points(Test_Mscolab_Merge_Waypoints):
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_save_keep_server_points(self, mockbox, qtbot):
+    def test_save_keep_server_points(self, qtbot):
         self.emailid = "save_keepe@alpha.org"
         self._create_user_data(emailid=self.emailid)
         wp_server_before = self.window.mscolab.waypoints_model.waypoint_data(0)
@@ -182,8 +184,10 @@ class Test_Save_Keep_Server_Points(Test_Mscolab_Merge_Waypoints):
         wp_local_before = self.window.mscolab.waypoints_model.waypoint_data(0)
 
         # trigger save to server action from server options combobox
-        with mock.patch("mslib.msui.mscolab.MscolabMergeWaypointsDialog", AutoClickKeepMscolabMergeWaypointsDialog):
+        with mock.patch("mslib.msui.mscolab.MscolabMergeWaypointsDialog", AutoClickKeepMscolabMergeWaypointsDialog), \
+                mock.patch("PyQt5.QtWidgets.QMessageBox.information") as m:
             self.window.serverOptionsCb.setCurrentIndex(2)
+            m.assert_called_once()
 
         def assert_():
             # get the updated waypoints model from the server
@@ -203,8 +207,7 @@ class Test_Save_Keep_Server_Points(Test_Mscolab_Merge_Waypoints):
 
 
 class Test_Fetch_From_Server(Test_Mscolab_Merge_Waypoints):
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_fetch_from_server(self, mockbox):
+    def test_fetch_from_server(self):
         self.emailid = "fetch_from_server@alpha.org"
         self._create_user_data(emailid=self.emailid)
         wp_server_before = self.window.mscolab.waypoints_model.waypoint_data(0)
@@ -218,8 +221,10 @@ class Test_Fetch_From_Server(Test_Mscolab_Merge_Waypoints):
         assert wp_server_before.lat != wp_local_before.lat
 
         # trigger save to server action from server options combobox
-        with mock.patch("mslib.msui.mscolab.MscolabMergeWaypointsDialog", AutoClickKeepMscolabMergeWaypointsDialog):
+        with mock.patch("mslib.msui.mscolab.MscolabMergeWaypointsDialog", AutoClickKeepMscolabMergeWaypointsDialog), \
+                mock.patch("PyQt5.QtWidgets.QMessageBox.information") as m:
             self.window.serverOptionsCb.setCurrentIndex(1)
+            m.assert_called_once()
         QtWidgets.QApplication.processEvents()
         # get the updated waypoints model from the server
         # ToDo understand why requesting in follow up test of self.window.waypoints_model not working

--- a/tests/_test_msui/test_mscolab_save_merge_points.py
+++ b/tests/_test_msui/test_mscolab_save_merge_points.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import mock
 import pytest
 from tests._test_msui.test_mscolab_merge_waypoints import Test_Mscolab_Merge_Waypoints
 from mslib.msui import flighttrack as ft
@@ -33,8 +32,7 @@ from PyQt5 import QtCore, QtTest, QtWidgets
 
 @pytest.mark.skip("Uses QTimer, which can break other unrelated tests")
 class Test_Save_Merge_Points(Test_Mscolab_Merge_Waypoints):
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_save_merge_points(self, mockbox):
+    def test_save_merge_points(self):
         self.emailid = "mergepoints@alpha.org"
         self._create_user_data(emailid=self.emailid)
         self.window.workLocallyCheckbox.setChecked(True)

--- a/tests/_test_msui/test_msui.py
+++ b/tests/_test_msui/test_msui.py
@@ -198,70 +198,53 @@ class Test_MSSSideViewWindow:
     def test_no_updater(self):
         assert not hasattr(self.window, "updater")
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_app_start(self, mockbox):
-        assert mockbox.critical.call_count == 0
+    def test_app_start(self):
+        pass
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_new_flightrack(self, mockbox):
+    def test_new_flightrack(self):
         assert self.window.listFlightTracks.count() == 1
         self.window.actionNewFlightTrack.trigger()
         QtWidgets.QApplication.processEvents()
         assert self.window.listFlightTracks.count() == 2
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_topview(self, mockbox):
+    def test_open_topview(self):
         assert self.window.listViews.count() == 0
         self.window.actionTopView.trigger()
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         assert self.window.listViews.count() == 1
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_sideview(self, mockbox):
+    def test_open_sideview(self):
         assert self.window.listViews.count() == 0
         self.window.actionSideView.trigger()
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         assert self.window.listViews.count() == 1
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_tableview(self, mockbox):
+    def test_open_tableview(self):
         assert self.window.listViews.count() == 0
         self.window.actionTableView.trigger()
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         assert self.window.listViews.count() == 1
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_linearview(self, mockbox):
+    def test_open_linearview(self):
         assert self.window.listViews.count() == 0
         self.window.actionLinearView.trigger()
         self.window.listViews.itemActivated.emit(self.window.listViews.item(0))
         QtWidgets.QApplication.processEvents()
         assert self.window.listViews.count() == 1
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_about(self, mockbox):
+    def test_open_about(self):
         self.window.actionAboutMSUI.trigger()
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_config(self, mockbox):
+    def test_open_config(self):
         pytest.skip("To be done")
         self.window.actionConfigurationEditor.trigger()
         QtWidgets.QApplication.processEvents()
         self.window.config_editor.close()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_shortcut(self, mockbox):
+    def test_open_shortcut(self):
         self.window.actionShortcuts.trigger()
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
 
     @pytest.mark.parametrize("save_file", [[save_ftml]])
     def test_plugin_saveas(self, save_file):
@@ -316,7 +299,6 @@ class Test_MSSSideViewWindow:
             os.remove(save_file[0])
 
     @pytest.mark.skip("needs to be refactored to become independent")
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
     @mock.patch("mslib.msui.msui_mainwindow.config_loader", return_value=export_plugins)
     def test_add_plugins(self, mockopen, mockbox):
         assert len(self.window.menuImportFlightTrack.actions()) == 2
@@ -331,21 +313,22 @@ class Test_MSSSideViewWindow:
         assert len(self.window.export_plugins) == 1
         assert len(self.window.menuImportFlightTrack.actions()) == 2
         assert len(self.window.menuExportActiveFlightTrack.actions()) == 2
-        assert mockbox.critical.call_count == 0
 
         self.window.remove_plugins()
-        with mock.patch("importlib.import_module", new=ExceptionMock(Exception()).raise_exc):
+        with mock.patch("importlib.import_module", new=ExceptionMock(Exception()).raise_exc), \
+                mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as critbox:
             self.window.add_import_plugins("qt")
             self.window.add_export_plugins("qt")
-            assert mockbox.critical.call_count == 2
+            assert critbox.call_count == 2
 
         self.window.remove_plugins()
         with mock.patch("mslib.msui.ms"
                         "ui.MSUIMainWindow.add_plugin_submenu",
-                        new=ExceptionMock(Exception()).raise_exc):
+                        new=ExceptionMock(Exception()).raise_exc), \
+                mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as critbox:
             self.window.add_import_plugins("qt")
             self.window.add_export_plugins("qt")
-            assert mockbox.critical.call_count == 4
+            assert critbox.call_count == 2
 
         self.window.remove_plugins()
         assert len(self.window.import_plugins) == 0
@@ -353,13 +336,12 @@ class Test_MSSSideViewWindow:
         assert len(self.window.menuImportFlightTrack.actions()) == 1
         assert len(self.window.menuExportActiveFlightTrack.actions()) == 1
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox.critical")
     @mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes)
     @mock.patch("PyQt5.QtWidgets.QMessageBox.information", return_value=QtWidgets.QMessageBox.Yes)
     @mock.patch("PyQt5.QtWidgets.QMessageBox.question", return_value=QtWidgets.QMessageBox.Yes)
     @mock.patch("mslib.msui.msui_mainwindow.get_save_filename", return_value=save_ftml)
     @mock.patch("mslib.msui.msui_mainwindow.get_open_filenames", return_value=[save_ftml])
-    def test_flight_track_io(self, mockload, mocksave, mockq, mocki, mockw, mockbox):
+    def test_flight_track_io(self, mockload, mocksave, mockq, mocki, mockw):
         self.window.actionCloseSelectedFlightTrack.trigger()
         assert mocki.call_count == 1
         self.window.actionNewFlightTrack.trigger()

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -50,26 +50,19 @@ class Test_MSS_SV_OptionsDialog:
         self.window.hide()
         QtWidgets.QApplication.processEvents()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_show(self, mockcrit):
-        assert mockcrit.critical.call_count == 0
+    def test_show(self):
+        pass
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_get(self, mockcrit):
+    def test_get(self):
         self.window.get_settings()
-        assert mockcrit.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_addLevel(self, mockcrit):
+    def test_addLevel(self):
         QtTest.QTest.mouseClick(self.window.btAdd, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        assert mockcrit.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_removeLevel(self, mockcrit):
+    def test_removeLevel(self):
         QtTest.QTest.mouseClick(self.window.btDelete, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        assert mockcrit.critical.call_count == 0
 
     def test_getFlightLevels(self):
         levels = self.window.get_flight_levels()
@@ -104,34 +97,28 @@ class Test_MSSSideViewWindow:
         self.window.hide()
         QtWidgets.QApplication.processEvents()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_wms(self, mockbox):
+    def test_open_wms(self):
         self.window.cbTools.currentIndexChanged.emit(1)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_mouse_over(self, mockbox):
+    def test_mouse_over(self):
         # Test mouse over
         QtTest.QTest.mouseMove(self.window.mpl.canvas, QtCore.QPoint(782, 266), -1)
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseMove(self.window.mpl.canvas, QtCore.QPoint(20, 20), -1)
         QtWidgets.QApplication.processEvents()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
     @mock.patch("mslib.msui.sideview.MSUI_SV_OptionsDialog")
-    def test_options(self, mockdlg, mockbox):
+    def test_options(self, mockdlg):
         QtTest.QTest.mouseClick(self.window.btOptions, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         assert mockdlg.call_count == 1
         assert mockdlg.return_value.setModal.call_count == 1
         assert mockdlg.return_value.exec_.call_count == 1
         assert mockdlg.return_value.destroy.call_count == 1
 
     @pytest.mark.skip("fails with mockbox.critical.call_count in reverse order")
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_insert_point(self, mockbox):
+    def test_insert_point(self):
         """
         Test inserting a point inside and outside the canvas
         """
@@ -149,15 +136,12 @@ class Test_MSSSideViewWindow:
         # click again on same position
         QtWidgets.QApplication.processEvents()
         assert len(self.window.waypoints_model.waypoints) == 5
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_y_axes(self, mockbox):
+    def test_y_axes(self):
         self.window.getView().get_settings()["secondary_axis"] = "pressure altitude"
         self.window.getView().set_settings(self.window.getView().get_settings())
         self.window.getView().get_settings()["secondary_axis"] = "flight level"
         self.window.getView().set_settings(self.window.getView().get_settings())
-        assert mockbox.critical.call_count == 0
 
 
 class Test_SideViewWMS:
@@ -195,8 +179,7 @@ class Test_SideViewWMS:
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.wms_control.cpdlg.canceled)
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_server_getmap(self, mockbox, qtbot):
+    def test_server_getmap(self, qtbot):
         """
         assert that a getmap call to a WMS server displays an image
         """
@@ -207,4 +190,3 @@ class Test_SideViewWMS:
 
         self.window.getView().plotter.clear_figure()
         assert self.window.getView().plotter.image is None
-        assert mockbox.critical.call_count == 0

--- a/tests/_test_msui/test_tableview.py
+++ b/tests/_test_msui/test_tableview.py
@@ -97,11 +97,10 @@ class Test_TableView:
         assert mockbox.call_count == 1
         assert len(self.window.waypoints_model.waypoints) == 5
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox.critical")
     @mock.patch("mslib.msui.performance_settings.get_open_filename",
                 return_value=os.path.join(
                     os.path.dirname(__file__), "..", "data", "performance_simple.json"))
-    def test_performance(self, mockopen, mockcrit):
+    def test_performance(self, mockopen):
         """
         Check effect of performance settings on TableView
         """
@@ -126,7 +125,6 @@ class Test_TableView:
         QtTest.QTest.mouseClick(self.window.docks[1].widget().pbLoadPerformance, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
         assert mockopen.call_count == 1
-        assert mockcrit.call_count == 0
 
     def test_insert_point(self):
         """
@@ -224,8 +222,7 @@ class Test_TableView:
         wps_after = list(self.window.waypoints_model.waypoints)
         assert wps_before != wps_after, (wps_before, wps_after)
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_roundtrip(self, mockbox):
+    def test_roundtrip(self):
         """
         Test connecting the last and first point
         Test connecting the first point to itself
@@ -251,4 +248,3 @@ class Test_TableView:
         # Remove connection
         self.window.waypoints_model.removeRows(count, 1)
         assert len(self.window.waypoints_model.waypoints) == count
-        assert mockbox.critical.call_count == 0

--- a/tests/_test_msui/test_topview.py
+++ b/tests/_test_msui/test_topview.py
@@ -50,15 +50,11 @@ class Test_MSS_TV_MapAppearanceDialog:
         self.window.hide()
         QtWidgets.QApplication.processEvents()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_show(self, mockcrit):
-        assert mockcrit.critical.call_count == 0
+    def test_show(self):
+        pass
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_get(self, mockcrit):
-        assert mockcrit.critical.call_count == 0
+    def test_get(self):
         self.window.get_settings()
-        assert mockcrit.critical.call_count == 0
 
 
 class Test_MSSTopViewWindow:
@@ -78,20 +74,15 @@ class Test_MSSTopViewWindow:
         self.window.hide()
         QtWidgets.QApplication.processEvents()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_wms(self, mockbox):
+    def test_open_wms(self):
         self.window.cbTools.currentIndexChanged.emit(1)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_sat(self, mockbox):
+    def test_open_sat(self):
         self.window.cbTools.currentIndexChanged.emit(2)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_rs(self, mockcrit):
+    def test_open_rs(self):
         self.window.cbTools.currentIndexChanged.emit(3)
         QtWidgets.QApplication.processEvents()
         rsdock = self.window.docks[2].widget()
@@ -104,16 +95,12 @@ class Test_MSSTopViewWindow:
         QtTest.QTest.mouseClick(rsdock.cbDrawTangents, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
         rsdock.cbShowSolarAngle.setChecked(True)
-        assert mockcrit.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_open_kml(self, mockbox):
+    def test_open_kml(self):
         self.window.cbTools.currentIndexChanged.emit(4)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_insert_point(self, mockbox):
+    def test_insert_point(self):
         """
         Test inserting a point inside and outside the canvas
         """
@@ -130,12 +117,10 @@ class Test_MSSTopViewWindow:
         # click again on same position
         QtWidgets.QApplication.processEvents()
         assert len(self.window.waypoints_model.waypoints) == 5
-        assert mockbox.critical.call_count == 0
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox.question",
                 return_value=QtWidgets.QMessageBox.Yes)
-    @mock.patch("PyQt5.QtWidgets.QMessageBox.critical")
-    def test_remove_point_yes(self, mockcrit, mockbox):
+    def test_remove_point_yes(self, mockbox):
         self.window.mpl.navbar._actions['insert_wp'].trigger()
         QtWidgets.QApplication.processEvents()
         assert len(self.window.waypoints_model.waypoints) == 3
@@ -147,14 +132,12 @@ class Test_MSSTopViewWindow:
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseClick(self.window.mpl.canvas, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        assert mockcrit.call_count == 0
         assert len(self.window.waypoints_model.waypoints) == 3
         assert mockbox.call_count == 1
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox.question",
                 return_value=QtWidgets.QMessageBox.No)
-    @mock.patch("PyQt5.QtWidgets.QMessageBox.critical")
-    def test_remove_point_no(self, mockcrit, mockbox):
+    def test_remove_point_no(self, mockbox):
         self.window.mpl.navbar._actions['insert_wp'].trigger()
         QtWidgets.QApplication.processEvents()
         assert len(self.window.waypoints_model.waypoints) == 3
@@ -172,10 +155,8 @@ class Test_MSSTopViewWindow:
         QtWidgets.QApplication.processEvents()
         assert mockbox.call_count == 1
         assert len(self.window.waypoints_model.waypoints) == 4
-        assert mockcrit.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_move_point(self, mockbox):
+    def test_move_point(self):
         self.window.mpl.navbar._actions['insert_wp'].trigger()
         QtWidgets.QApplication.processEvents()
         assert len(self.window.waypoints_model.waypoints) == 3
@@ -195,10 +176,8 @@ class Test_MSSTopViewWindow:
             self.window.mpl.canvas, QtCore.Qt.LeftButton, pos=point)
         QtWidgets.QApplication.processEvents()
         assert len(self.window.waypoints_model.waypoints) == 4
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_roundtrip(self, mockbox):
+    def test_roundtrip(self):
         """
         Test connecting the last and first point
         Test connecting the first point to itself
@@ -224,63 +203,49 @@ class Test_MSSTopViewWindow:
         # Remove connection
         self.window.waypoints_model.removeRows(count, 1)
         assert len(self.window.waypoints_model.waypoints) == count
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_map_options(self, mockbox):
+    def test_map_options(self):
         self.window.mpl.canvas.map.set_graticule_visible(True)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         self.window.mpl.canvas.map.set_graticule_visible(False)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         self.window.mpl.canvas.map.set_fillcontinents_visible(False)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         self.window.mpl.canvas.map.set_fillcontinents_visible(True)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         self.window.mpl.canvas.map.set_coastlines_visible(False)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         self.window.mpl.canvas.map.set_coastlines_visible(True)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
 
         with mock.patch("mslib.msui.mpl_map.get_airports", return_value=[{"type": "small_airport", "name": "Test",
                                                                           "latitude_deg": 52, "longitude_deg": 13,
                                                                           "elevation_ft": 0}]):
             self.window.mpl.canvas.map.set_draw_airports(True)
             QtWidgets.QApplication.processEvents()
-            assert mockbox.critical.call_count == 0
         with mock.patch("mslib.msui.mpl_map.get_airports", return_value=[]):
             self.window.mpl.canvas.map.set_draw_airports(True)
             QtWidgets.QApplication.processEvents()
-            assert mockbox.critical.call_count == 0
         with mock.patch("mslib.msui.mpl_map.get_airports", return_value=[{"type": "small_airport", "name": "Test",
                                                                           "latitude_deg": -52, "longitude_deg": -13,
                                                                           "elevation_ft": 0}]):
             self.window.mpl.canvas.map.set_draw_airports(True)
             QtWidgets.QApplication.processEvents()
-            assert mockbox.critical.call_count == 0
 
         with mock.patch("mslib.msui.mpl_map.get_airspaces", return_value=[{"name": "Test", "top": 1, "bottom": 0,
                                                                            "polygon": [(13, 52), (14, 53), (13, 52)],
                                                                            "country": "DE"}]):
             self.window.mpl.canvas.map.set_draw_airspaces(True)
             QtWidgets.QApplication.processEvents()
-            assert mockbox.critical.call_count == 0
         with mock.patch("mslib.msui.mpl_map.get_airspaces", return_value=[]):
             self.window.mpl.canvas.map.set_draw_airspaces(True)
             QtWidgets.QApplication.processEvents()
-            assert mockbox.critical.call_count == 0
         with mock.patch("mslib.msui.mpl_map.get_airspaces", return_value=[{"name": "Test", "top": 1, "bottom": 0,
                                                                            "polygon": [(-13, -52), (-14, -53),
                                                                                        (-13, -52)],
                                                                            "country": "DE"}]):
             self.window.mpl.canvas.map.set_draw_airspaces(True)
             QtWidgets.QApplication.processEvents()
-            assert mockbox.critical.call_count == 0
 
 
 class Test_TopViewWMS:
@@ -320,8 +285,7 @@ class Test_TopViewWMS:
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.wms_control.cpdlg.canceled)
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_server_getmap(self, mockbox):
+    def test_server_getmap(self):
         """
         assert that a getmap call to a WMS server displays an image
         """
@@ -334,7 +298,6 @@ class Test_TopViewWMS:
         self.window.getView().clear_figure()
         assert self.window.getView().map.image is None
         self.window.mpl.canvas.redraw_map()
-        assert mockbox.critical.call_count == 0
 
 
 class Test_MSUITopViewWindow:

--- a/tests/_test_msui/test_wms_capabilities.py
+++ b/tests/_test_msui/test_wms_capabilities.py
@@ -58,23 +58,16 @@ class Test_WMSCapabilities:
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.qWait(100)
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_window_start(self, mockbox):
+    def test_window_start(self):
         self.start_window()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_window_contact_none(self, mockbox):
+    def test_window_contact_none(self):
         self.capabilities.provider.contact = None
         self.start_window()
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_switch_view(self, mockbox):
+    def test_switch_view(self):
         self.start_window()
         QtTest.QTest.mouseClick(self.window.cbFullView, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0
         QtTest.QTest.mouseClick(self.window.cbFullView, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
-        assert mockbox.critical.call_count == 0

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -154,8 +154,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert mockbox.critical.call_count == 1
 
     @pytest.mark.skip("Breaks other tests in this class because of a lingering message box, for some reason")
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_forward_backward_clicks(self, mockbox):
+    def test_forward_backward_clicks(self):
         self.query_server(self.url)
         self.window.init_time_back_click()
         self.window.init_time_fwd_click()
@@ -171,11 +170,9 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
             self.window.secs_from_timestep("Wrong")
         except ValueError:
             pass
-        assert mockbox.critical.call_count == 0
 
     @pytest.mark.skip("Has a race condition where the abort might not happen fast enough")
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_server_abort_getmap(self, mockbox):
+    def test_server_abort_getmap(self):
         """
         assert that an aborted getmap call does not change the displayed image
         """
@@ -192,8 +189,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert self.view.draw_metadata.call_count == 0
         self.view.reset_mock()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_server_getmap(self, mockbox, qtbot):
+    def test_server_getmap(self, qtbot):
         """
         assert that a getmap call to a WMS server displays an image
         """
@@ -202,14 +198,11 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
 
-        assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
-        self.view.reset_mock()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_server_getmap_cached(self, mockbox, qtbot):
+    def test_server_getmap_cached(self, qtbot):
         """
         assert that a getmap call to a WMS server displays an image
         """
@@ -217,8 +210,6 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
 
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
-
-        # assert mockbox.critical.call_count == 0
 
         assert self.view.draw_image.call_count == 1
         assert self.view.draw_legend.call_count == 1
@@ -231,20 +222,16 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.window.image_displayed)
 
-        assert mockbox.critical.call_count == 0
-
         assert self.view.draw_image.call_count == 1
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
 
     @pytest.mark.skip("needs a review")
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_server_service_cache(self, mockbox):
+    def test_server_service_cache(self):
         """
         assert that changing between servers still allows image retrieval
         """
         self.query_server(self.url)
-        assert mockbox.critical.call_count == 0
 
         QtTest.QTest.keyClick(self.window.multilayers.cbWMS_URL, QtCore.Qt.Key_Backspace)
         QtTest.QTest.keyClick(self.window.multilayers.cbWMS_URL, QtCore.Qt.Key_Backspace)
@@ -252,30 +239,25 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtTest.QTest.mouseClick(self.window.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.window.cpdlg.canceled)
-        assert mockbox.critical.call_count == 1
         assert self.view.draw_image.call_count == 0
         assert self.view.draw_legend.call_count == 0
         assert self.view.draw_metadata.call_count == 0
-        mockbox.reset_mock()
         QtTest.QTest.keyClick(self.window.multilayers.cbWMS_URL, ord(str(self.port)[3]))
         QtTest.QTest.keyClick(self.window.multilayers.cbWMS_URL, QtCore.Qt.Key_Slash)
         QtWidgets.QApplication.processEvents()
         QtTest.QTest.mouseClick(self.window.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.window.cpdlg.canceled)
-        assert mockbox.critical.call_count == 0
 
         QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.window.image_displayed)
 
-        assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_multilayer_handling(self, mockbox):
+    def test_multilayer_handling(self):
         """
         assert that multilayers get created, handled and drawn properly
         """
@@ -313,14 +295,12 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.window.image_displayed)
 
-        assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
 
     @pytest.mark.skip("Fails testing reverse order")
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_filter_handling(self, mockbox):
+    def test_filter_handling(self):
         self.query_server(self.url)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
@@ -363,10 +343,8 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         self.window.multilayers.check_icon_clicked(server)
         assert len(self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                                 QtCore.Qt.MatchFixedString)) == 0
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_singlelayer_handling(self, mockbox):
+    def test_singlelayer_handling(self):
         """
         assert that singlelayer mode behaves as expected
         """
@@ -397,13 +375,11 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         QtWidgets.QApplication.processEvents()
         wait_until_signal(self.window.image_displayed)
 
-        assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_multilayer_syncing(self, mockbox):
+    def test_multilayer_syncing(self):
         """
         assert that synced layers share their options
         """
@@ -432,11 +408,9 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert layer_a.get_level() == layer_b.get_level()
         assert layer_a.get_vtime() == layer_b.get_vtime()
         assert layer_a.get_itime() == layer_a.get_itimes()[-1]
-        assert mockbox.critical.call_count == 0
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
     @mock.patch("mslib.msui.wms_control.WMSMapFetcher.moveToThread")
-    def test_server_no_thread(self, mockbox, mockthread):
+    def test_server_no_thread(self, mockthread):
         self.query_server(self.url)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
@@ -455,7 +429,6 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         self.window.fetcher.fetch_legend(urlstr, use_cache=False, md5_filename=md5_filname)
         self.window.fetcher.fetch_legend(urlstr, use_cache=True, md5_filename=md5_filname)
 
-        assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
@@ -468,8 +441,7 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         yield
         self._teardown()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_server_getmap(self, mockbox, qtbot):
+    def test_server_getmap(self, qtbot):
         pytest.skip("unknown problem")
         """
         assert that a getmap call to a WMS server displays an image
@@ -478,15 +450,12 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         with qtbot.wait_signal(self.wms_control.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
 
-        assert mockbox.critical.call_count == 0
         assert self.view.draw_image.call_count == 1
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
-        self.view.reset_mock()
 
     @pytest.mark.skip("IndexError: list index out of range")
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_multilayer_drawing(self, mockbox):
+    def test_multilayer_drawing(self):
         """
         assert that drawing a layer through code doesn't fail for vsec
         """
@@ -495,8 +464,6 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
                                                               QtCore.Qt.MatchFixedString)[0]
         server.child(0).draw()
         wait_until_signal(self.window.image_displayed)
-
-        assert mockbox.critical.call_count == 0
 
 
 class TestWMSControlWidgetSetupSimple:
@@ -796,8 +763,7 @@ class TestWMSControlWidgetSetupSimple:
         assert [self.window.cbInitTime.itemText(i) for i in range(self.window.cbInitTime.count())] == \
             ['2012-10-16T12:00:00Z', '2012-10-17T12:00:00Z']
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_xml_time_error(self, mockbox):
+    def test_xml_time_error(self):
         dimext_time_error = """
             <Dimension name="TIME" units="ISO8610"> </Dimension>
             <Extent name="TIME"> a2012-10-17T12:00:00Z/2012-10-18T00:00:00Z/PT6H </Extent>"""

--- a/tests/_test_utils/test_airdata.py
+++ b/tests/_test_utils/test_airdata.py
@@ -132,7 +132,6 @@ def test_get_downloaded_airports(mockbox):
         airports = get_airports(force_download=True)
         assert len(airports) > 0
         assert 'continent' in airports[0].keys()
-        assert mockbox.critical.call_count == 0
 
 
 def test_get_available_airspaces():
@@ -150,7 +149,6 @@ def test_update_airspace(mockbox):
         with open(example_file, 'r') as f:
             text = f.read()
         assert "<!-- For Testing ONLY -->" in text
-        assert mockbox.critical.call_count == 0
 
 
 @mock.patch("PyQt5.QtWidgets.QMessageBox.question", return_value=QtWidgets.QMessageBox.No)
@@ -204,7 +202,6 @@ def test_get_airspaces(mockbox):
                      (22.739444444444445, 42.88527777777778)]
         }
     ]
-    assert mockbox.critical.call_count == 0
 
 
 @mock.patch("mslib.utils.airdata.download_progress", _download_incomplete_airspace)


### PR DESCRIPTION
The removed QMessageBox mocks are unnecessary since there is a check in tests.fixtures that makes sure no open message boxes remain after each test and many of these mocks are actually detrimental since they mock all types of message boxes but only check for one.

Fixes #2157.

I want to wait with this until after #2153 or even #2158 is merged.