### PR TITLE
Remove unnecessary config settings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,11 +36,6 @@ omit =
 [tool:pytest]
 norecursedirs = .git .idea .cache
 
-[pycodestyle]
-ignore = E124,E125,E402,W504
-max-line-length = 120
-exclude = mslib/msui/qt5/*.py
-
 [flake8]
 ignore = E124,E125,E402,W504
 max-line-length = 120


### PR DESCRIPTION
Since pycodestyle is not used directly, but only as part of flake8, the flake8 settings apply already. Therefore it is unnecessary to duplicate these settings.