### PR TITLE
Simplify GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_docs_gallery.yml
+++ b/.github/workflows/build_docs_gallery.yml
@@ -2,36 +2,19 @@ name: Build Gallery
 
 on:
    pull_request:
-     inputs:
-        branch_name:
-          required: true
-          type: string
-        secrets:
-          PAT:
-            required: true
-
-env:
-  PAT: ${{ secrets.PAT }}
 
 jobs:
   Test-MSS-docs:
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        shell: bash
-
     container:
       image: openmss/testing-develop
 
     steps:
-    - name: Trust My Directory
-      run: git config --global --add safe.directory /__w/MSS/MSS
     - uses: actions/checkout@v4
 
     - name: Create gallery
-      timeout-minutes: 25
+      timeout-minutes: 5
       run: |
-        source /opt/conda/bin/activate mssenv \
-        && cd $GITHUB_WORKSPACE/docs \
-        && python conf.py
+        cd docs
+        mamba run --no-capture-output -n mssenv python conf.py

--- a/.github/workflows/python-flake8.yml
+++ b/.github/workflows/python-flake8.yml
@@ -8,14 +8,12 @@ on:
     branches:
     - develop
     - stable
-    - GSOC2023-NilupulManodya
-    - GSOC2023-ShubhGaur
+    - 'GSOC**'
   pull_request:
     branches:
     - develop
     - stable
-    - GSOC2023-NilupulManodya
-    - GSOC2023-ShubhGaur
+    - 'GSOC**'
 
 jobs:
   lint:

--- a/.github/workflows/testing-develop.yml
+++ b/.github/workflows/testing-develop.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - develop
-
   pull_request:
     branches:
     - develop

--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: '30 5 * * 1'
 
-
 jobs:
   test-stable-scheduled:
     uses:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,16 +14,11 @@ on:
         required: true
 
 env:
-  PAT: ${{ secrets.PAT }}
-  EVENT: ${{ inputs.event_name }}
+  mamba-env: mss-${{ inputs.branch_name }}-env
 
 jobs:
   Test-MSS:
     runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        shell: bash
 
     container:
       image: openmss/testing-${{ inputs.branch_name }}
@@ -34,71 +29,49 @@ jobs:
         order: ["normal", "reverse"]
 
     steps:
-    - name: Trust My Directory
-      run: git config --global --add safe.directory /__w/MSS/MSS
-
     - uses: actions/checkout@v4
 
     - name: Check for changed dependencies
-      run: |
-        cmp -s /meta.yaml localbuild/meta.yaml && cmp -s /development.txt requirements.d/development.txt \
-        || (echo Dependencies differ \
-            && echo "triggerdockerbuild=yes" >> $GITHUB_ENV )
+      run: cmp -s /meta.yaml localbuild/meta.yaml && cmp -s /development.txt requirements.d/development.txt ||
+        (echo Dependencies differ && echo "triggerdockerbuild=yes" >> $GITHUB_ENV )
 
     - name: Always rebuild dependencies for scheduled builds
-      if: ${{ success() && inputs.event_name == 'schedule' && inputs.branch_name == 'stable' && env.triggerdockerbuild != 'yes' }}
-      run: |
-        echo "triggerdockerbuild=yes" >> $GITHUB_ENV
+      if: ${{ inputs.event_name == 'schedule' && inputs.branch_name == 'stable' && env.triggerdockerbuild != 'yes' }}
+      run: echo "triggerdockerbuild=yes" >> $GITHUB_ENV
 
     - name: Reinstall dependencies if changed
-      if: ${{ success() && env.triggerdockerbuild == 'yes' }}
+      if: ${{ env.triggerdockerbuild == 'yes' }}
       run: |
-        cd $GITHUB_WORKSPACE \
-        && source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-${{ inputs.branch_name }}-env \
-        && mamba deactivate \
-        && cat localbuild/meta.yaml \
-        | sed -n '/^requirements:/,/^test:/p' \
-        | sed -e "s/.*- //" \
-        | sed -e "s/menuinst.*//" \
-        | sed -e "s/.*://" > reqs.txt \
-        && cat requirements.d/development.txt >> reqs.txt \
-        && cat reqs.txt \
-        && mamba env remove -n mss-${{ inputs.branch_name }}-env \
-        && mamba create -y -n mss-${{ inputs.branch_name }}-env --file reqs.txt
+        cat localbuild/meta.yaml |
+          sed -n '/^requirements:/,/^test:/p' |
+          sed -e "s/.*- //" |
+          sed -e "s/menuinst.*//" |
+          sed -e "s/.*://" > reqs.txt
+        cat requirements.d/development.txt >> reqs.txt
+        cat reqs.txt
+        mamba env remove -n ${{ env.mamba-env }}
+        mamba create -y -n ${{ env.mamba-env }} --file reqs.txt
 
     - name: Print conda list
-      run: |
-        source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-${{ inputs.branch_name }}-env \
-        && mamba list
+      run: mamba run --no-capture-output -n ${{ env.mamba-env }} mamba list
 
     - name: Run tests
       timeout-minutes: 10
-      run: |
-        cd $GITHUB_WORKSPACE \
-        && source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-${{ inputs.branch_name }}-env \
-        && xvfb-run pytest -v -n 6 --dist loadfile --max-worker-restart 4 --durations=20 --cov=mslib \
-          ${{ (matrix.order == 'normal' && ' ') || (matrix.order == 'reverse' && '--reverse') }} tests
+      run: mamba run --no-capture-output -n ${{ env.mamba-env }} xvfb-run pytest
+        -v -n 6 --dist loadfile --max-worker-restart 4 --durations=20 --cov=mslib
+        ${{ (matrix.order == 'normal' && ' ') || (matrix.order == 'reverse' && '--reverse') }} tests
 
     - name: Collect coverage
-      if: ${{ success() && inputs.event_name == 'push' && inputs.branch_name == 'develop' && matrix.order == 'normal' }}
+      if: ${{ inputs.event_name == 'push' && inputs.branch_name == 'develop' && matrix.order == 'normal' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd $GITHUB_WORKSPACE \
-        && source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-${{ inputs.branch_name }}-env \
-        && mamba install coveralls \
-        && coveralls --service=github
+        git config --global --add safe.directory /__w/MSS/MSS
+        mamba install -n ${{ env.mamba-env }} coveralls
+        mamba run --no-capture-output -n ${{ env.mamba-env }} coveralls --service=github
 
     - name: Invoke dockertesting image creation
-      if: ${{ always() && inputs.event_name == 'push' && env.triggerdockerbuild == 'yes' && matrix.order == 'normal' }}
+      if: ${{ !cancelled() && inputs.event_name == 'push' && env.triggerdockerbuild == 'yes' && matrix.order == 'normal' }}
       uses: benc-uk/workflow-dispatch@v1.2.2
       with:
         workflow: Update Image testing-${{ inputs.branch_name }}

--- a/.github/workflows/testing_gsoc.yml
+++ b/.github/workflows/testing_gsoc.yml
@@ -4,22 +4,13 @@ on:
   push:
     branches:
     - 'GSOC**'
-
   pull_request:
     branches:
     - 'GSOC**'
 
-env:
-  PAT: ${{ secrets.PAT }}
-
-
 jobs:
   Test-MSS-GSOC:
     runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        shell: bash
 
     container:
       image: openmss/testing-develop
@@ -30,61 +21,38 @@ jobs:
         order: ["normal", "reverse"]
 
     steps:
-    - name: Trust My Directory
-      run: git config --global --add safe.directory /__w/MSS/MSS
-
     - uses: actions/checkout@v4
 
     - name: Check for changed dependencies
-      run: |
-        cmp -s /meta.yaml localbuild/meta.yaml && cmp -s /development.txt requirements.d/development.txt \
-        || (echo Dependencies differ \
-            && echo "triggerdockerbuild=yes" >> $GITHUB_ENV )
+      run: cmp -s /meta.yaml localbuild/meta.yaml && cmp -s /development.txt requirements.d/development.txt ||
+        (echo Dependencies differ && echo "triggerdockerbuild=yes" >> $GITHUB_ENV )
 
     - name: Reinstall dependencies if changed
-      if: ${{ success() && env.triggerdockerbuild == 'yes' }}
+      if: ${{ env.triggerdockerbuild == 'yes' }}
       run: |
-        cd $GITHUB_WORKSPACE \
-        && source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-develop-env \
-        && mamba deactivate \
-        && cat localbuild/meta.yaml \
-        | sed -n '/^requirements:/,/^test:/p' \
-        | sed -e "s/.*- //" \
-        | sed -e "s/menuinst.*//" \
-        | sed -e "s/.*://" > reqs.txt \
-        && cat requirements.d/development.txt >> reqs.txt \
-        && cat reqs.txt \
-        && mamba env remove -n mss-develop-env \
-        && mamba create -y -n mss-develop-env --file reqs.txt
+        cat localbuild/meta.yaml |
+          sed -n '/^requirements:/,/^test:/p' |
+          sed -e "s/.*- //" |
+          sed -e "s/menuinst.*//" |
+          sed -e "s/.*://" > reqs.txt
+        cat requirements.d/development.txt >> reqs.txt
+        cat reqs.txt
+        mamba env remove -n mss-develop-env
+        mamba create -y -n mss-develop-env --file reqs.txt
 
     - name: Print conda list
-      run: |
-        source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-develop-env \
-        && mamba list
+      run: mamba run --no-capture-output -n mss-develop-env mamba list
 
     - name: Run tests
-      if: ${{ success() }}
       timeout-minutes: 10
-      run: |
-        cd $GITHUB_WORKSPACE \
-        && source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-develop-env \
-        && xvfb-run pytest -v -n 6 --dist loadfile --max-worker-restart 4 --durations=20 --cov=mslib \
-          ${{ (matrix.order == 'normal' && ' ') || (matrix.order == 'reverse' && '--reverse') }} tests
+      run: mamba run --no-capture-output -n mss-develop-env xvfb-run pytest
+        -v -n 6 --dist loadfile --max-worker-restart 4 --durations=20 --cov=mslib
+        ${{ (matrix.order == 'normal' && ' ') || (matrix.order == 'reverse' && '--reverse') }} tests
 
     - name: Collect coverage
-      if: ${{ success() }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd $GITHUB_WORKSPACE \
-        && source /opt/conda/etc/profile.d/conda.sh \
-        && source /opt/conda/etc/profile.d/mamba.sh \
-        && mamba activate mss-develop-env \
-        && mamba install coveralls \
-        && coveralls --service=github
+        git config --global --add safe.directory /__w/MSS/MSS
+        mamba install -n mss-develop-env coveralls
+        mamba run --no-capture-output -n mss-develop-env coveralls --service=github


### PR DESCRIPTION
This removes a bit of unnecessary code. The resulting workflows should do effectively the same as before. The changes and reasoning are these:
- remove `success()` in `if:` blocks, since that is the implicit default
- replace `source` and `activate` calls with just `mamba run`, because that is more concise and readable
- remove ineffective `inputs:` definition for pull_request event, because it does nothing
- remove the specification of bash as the shell, since the default of `sh` works just fine
- rearrange shell invocations to remove unnecessary backslashes, because I find that to be much more pleasant to read
- replace `always()` with `!cancelled()` in `if:`, since the first would even run if the workflow is manually cancelled
- move trusting the git repository to the location where it is needed
- do not hardcode specific GSoC branches
- remove unused env variables

Fixes #2189.

Depends on #2158.