### PR TITLE
use a compatible py3 version for RTFD

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -23,3 +23,4 @@ dependencies:
       - owslib
   - basemap >=1.3.3
   - pint
+  - python <3.12

--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -76,7 +76,7 @@ requirements:
     - PyMySQL >=0.9.3
     - validate_email
     - multidict
-    - pint
+    - pint <=0.22
     - python-socketio >=5
     - python-engineio >=4
     - markdown


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2186 

xstatic is not available yet for 3.12 and imp was deprecated in 3.11.


