### PR TITLE
[Change] datetime.datetime.utcnow()

### DIFF
--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -64,7 +64,7 @@ class FileManager:
         if proj_available is not None:
             return False
         if last_used is None:
-            last_used = datetime.datetime.utcnow()
+            last_used = datetime.datetime.now(tz=datetime.timezone.utc)
         operation = Operation(path, description, last_used, category, active=active)
         db.session.add(operation)
         db.session.flush()
@@ -120,7 +120,7 @@ class FileManager:
         for permission in permissions:
             operation = Operation.query.filter_by(id=permission.op_id).first()
             if operation.last_used is not None and (
-                    datetime.datetime.utcnow() - operation.last_used).days > mscolab_settings.ARCHIVE_THRESHOLD:
+                    datetime.datetime.now(tz=datetime.timezone.utc) - operation.last_used).days > mscolab_settings.ARCHIVE_THRESHOLD:
                 # outdated OPs get archived
                 self.update_operation(permission.op_id, "active", False, user)
             # new query to get uptodate data

--- a/mslib/mscolab/models.py
+++ b/mslib/mscolab/models.py
@@ -145,7 +145,7 @@ class Operation(db.Model):
         self.category = category
         self.active = active
         if self.last_used is None:
-            self.last_used = datetime.datetime.utcnow()
+            self.last_used = datetime.datetime.now(tz=datetime.timezone.utc)
         else:
             self.last_used = last_used
 

--- a/mslib/mscolab/seed.py
+++ b/mslib/mscolab/seed.py
@@ -218,7 +218,7 @@ def archive_operation(path=None, emailid=None):
                 elif perm.access_level != "creator":
                     return False
                 operation.active = False
-                operation.last_used = datetime.datetime.utcnow() - dateutil.relativedelta.relativedelta(months=2)
+                operation.last_used = datetime.datetime.now(tz=datetime.timezone.utc) - dateutil.relativedelta.relativedelta(months=2)
                 db.session.commit()
 
 

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -425,7 +425,7 @@ def create_operation():
     description = request.form.get('description', None)
     category = request.form.get('category', "default")
     active = (request.form.get('active', "True") == "True")
-    last_used = datetime.datetime.utcnow()
+    last_used = datetime.datetime.now(tz=datetime.timezone.utc)
     user = g.user
     r = str(fm.create_operation(path, description, user, last_used,
                                 content=content, category=category, active=active))
@@ -545,7 +545,7 @@ def set_last_used():
     user = g.user
     days_ago = int(request.form.get('days', 0))
     fm.update_operation(int(op_id), 'last_used',
-                        datetime.datetime.utcnow() - datetime.timedelta(days=days_ago),
+                        datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=days_ago),
                         user)
     if days_ago > mscolab_settings.ARCHIVE_THRESHOLD:
         fm.update_operation(int(op_id), "active", False, user)


### PR DESCRIPTION
Fix #2183 

This pull request addresses the usage of the datetime.datetime.utcnow() function, which is documented as potentially dangerous due to its reliance on the system's timezone settings. Instead, this PR replaces all occurrences of datetime.datetime.utcnow() with datetime.datetime.now(tz=datetime.timezone.utc)