### PR TITLE
Fix: Scheduled test now triggers testing-stable.yml using workflow_dispatch

### DIFF
--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -9,7 +9,7 @@ jobs:
   trigger-testing-stable:
     runs-on: ubuntu-latest
     permissions:
-        actions: write
+      actions: write
     steps:
       - uses: benc-uk/workflow-dispatch@v1.2.2
         with:

--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -6,12 +6,14 @@ on:
 
 
 jobs:
-  trigger_stable_test:
+  trigger-testing-stable:
     runs-on: ubuntu-latest
+    permissions:
+        actions: write
     steps:
       - uses: benc-uk/workflow-dispatch@v1.2.2
         with:
-          workflow: testing-stable
+          workflow: testing-stable.yml
           ref: stable
 
   test-develop-scheduled:

--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -5,16 +5,14 @@ on:
     - cron: '30 5 * * 1' 
 
 
-jobs:     
-  test-stable-scheduled:
-    uses: 
-      ./.github/workflows/testing.yml
-    with:
-      xdist: no
-      branch_name: stable
-      event_name: ${{ github.event_name }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
+jobs:
+  trigger_stable_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: benc-uk/workflow-dispatch@v1.2.2
+        with:
+          workflow: testing-stable
+          ref: stable
 
   test-develop-scheduled:
     uses: 


### PR DESCRIPTION
**Purpose of PR?**: This pull request addresses the issue where the scheduled test was running the `testing.yml` workflow from the develop branch but using the container image for the stable branch. This was incorrect behavior.

Fixes #2172 

Modified the` testing-scheduled.yml` workflow on the develop branch to directly trigger the `testing-stable.yml` workflow using the `benc-uk/workflow-dispatch@v1.2.2 action.`

This change was made to work directly on the develop branch.

**Checklist:**
- [ X] Bug fix. Fixes #2172 
