### PR TITLE
Install pyvirtualdisplay in testing workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,6 +43,13 @@ jobs:
         || (echo Dependencies differ \
             && echo "triggerdockerbuild=yes" >> $GITHUB_ENV )
 
+    - name: Install pyvirtualdisplay if on stable
+      if: ${{ inputs.branch_name == 'stable' }}
+      run: |
+        source /opt/conda/etc/profile.d/conda.sh
+        source /opt/conda/etc/profile.d/mamba.sh
+        mamba install -n mss-${{ inputs.branch_name }}-env pyvirtualdisplay
+
     - name: Always rebuild dependencies for scheduled builds
       if: ${{ success() && inputs.event_name == 'schedule' && inputs.branch_name == 'stable' && env.triggerdockerbuild != 'yes' }}
       run: |


### PR DESCRIPTION
The testing-stable container image no longer includes pyvirtualdisplay due to a change that made it unnecessary for develop that also affected the stable image. This installs the package as part of the testing workflow instead. This is a band-aid to fix the stable CI until all of the recent changes to the tests are backported from develop to stable.

Fixes #2199.