### PR TITLE
Run a lot of tests in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,6 +32,8 @@ jobs:
       fail-fast: false
       matrix:
         order: ["normal", "reverse"]
+        a: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        b: [0, 1, 2, 3, 4]
 
     steps:
     - name: Trust My Directory


### PR DESCRIPTION
This PR is not intended to be merged.

It runs the testing job on develop 50 times in normal order, and 50 times in reverse order, so 100 times in total.

If all runs are green, I think we can close #1972, close #1685, close #1102, close #870 as not reproducible at this time and potentially fixed by some of the changes to the test suite. If they are not then there are still issues remaining.