### PR TITLE
catch exception when USE_SAML2 is True but configuration not completed

### DIFF
--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -839,7 +839,7 @@ if mscolab_settings.USE_SAML2:
                 APP.add_url_rule(f'/{assertion_consumer_endpoint}/', assertion_consumer_endpoint,
                                  create_acs_post_handler(idp_config), methods=['POST'])
         except (NameError, AttributeError, KeyError) as ex:
-            logging.debug("USE_SAML2 is %s, Failure is: %s" % (mscolab_settings.USE_SAML2, ex))
+            logging.warning("USE_SAML2 is %s, Failure is: %s", (mscolab_settings.USE_SAML2, ex))
 
     @APP.route('/idp_login_auth/', methods=['POST'])
     def idp_login_auth():

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -839,7 +839,7 @@ if mscolab_settings.USE_SAML2:
                 APP.add_url_rule(f'/{assertion_consumer_endpoint}/', assertion_consumer_endpoint,
                                  create_acs_post_handler(idp_config), methods=['POST'])
         except (NameError, AttributeError, KeyError) as ex:
-            logging.warning("USE_SAML2 is %s, Failure is: %s", (mscolab_settings.USE_SAML2, ex))
+            logging.warning("USE_SAML2 is %s, Failure is: %s", mscolab_settings.USE_SAML2, ex)
 
     @APP.route('/idp_login_auth/', methods=['POST'])
     def idp_login_auth():

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -833,10 +833,13 @@ if mscolab_settings.USE_SAML2:
 
     # Implementation for handling configured SAML assertion consumer endpoints
     for idp_config in setup_saml2_backend.CONFIGURED_IDPS:
-        for assertion_consumer_endpoint in idp_config['idp_data']['assertion_consumer_endpoints']:
-            # Dynamically add the route for the current endpoint
-            APP.add_url_rule(f'/{assertion_consumer_endpoint}/', assertion_consumer_endpoint,
-                             create_acs_post_handler(idp_config), methods=['POST'])
+        try:
+            for assertion_consumer_endpoint in idp_config['idp_data']['assertion_consumer_endpoints']:
+                # Dynamically add the route for the current endpoint
+                APP.add_url_rule(f'/{assertion_consumer_endpoint}/', assertion_consumer_endpoint,
+                                 create_acs_post_handler(idp_config), methods=['POST'])
+        except (NameError, AttributeError, KeyError) as ex:
+            logging.debug("USE_SAML2 is %s, Failure is: %s" % (mscolab_settings.USE_SAML2, ex))
 
     @APP.route('/idp_login_auth/', methods=['POST'])
     def idp_login_auth():


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2212

At least on development you will have different states on the configurations when you want to test something else.
This gives an user a hint what can be wrong.