### PR TITLE
any member of an operation should see who created the operation

### DIFF
--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -495,7 +495,9 @@ class FileManager:
         return users
 
     def fetch_operation_creator(self, op_id, u_id):
-        if not self.is_admin(u_id, op_id) and not self.is_creator(u_id, op_id):
+        if (not self.is_admin(u_id, op_id) and not self.is_creator(u_id, op_id) and
+                not self.is_collaborator(u_id, op_id) and not self.is_viewer(u_id, op_id)):
+            # any participant of the OP is allowed to see who is the creator
             return False
         current_operation_creator = Permission.query.filter_by(op_id=op_id, access_level="creator").first()
         return current_operation_creator.user.username

--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -495,8 +495,7 @@ class FileManager:
         return users
 
     def fetch_operation_creator(self, op_id, u_id):
-        if (not self.is_admin(u_id, op_id) and not self.is_creator(u_id, op_id) and
-                not self.is_collaborator(u_id, op_id) and not self.is_viewer(u_id, op_id)):
+        if not self.is_member(u_id, op_id):
             # any participant of the OP is allowed to see who is the creator
             return False
         current_operation_creator = Permission.query.filter_by(op_id=op_id, access_level="creator").first()

--- a/tests/_test_mscolab/test_file_manager.py
+++ b/tests/_test_mscolab/test_file_manager.py
@@ -97,8 +97,15 @@ class Test_FileManager:
     def test_fetch_operation_creator(self):
         with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="more_than_one")
+            self.fm.add_bulk_permission(operation.id, self.user, [self.collaboratoruser.id], "collaborator")
+            self.fm.add_bulk_permission(operation.id, self.user, [self.vieweruser.id], "viewer")
+
             assert operation.path == flight_path
             assert self.fm.fetch_operation_creator(operation.id, self.user.id) == self.user.username
+            assert self.fm.fetch_operation_creator(operation.id, self.collaboratoruser.id) == self.user.username
+            assert self.fm.fetch_operation_creator(operation.id, self.vieweruser.id) == self.user.username
+            # this user is not defined in that OP
+            assert self.fm.fetch_operation_creator(operation.id, self.op2user.id) is False
 
     def test_create_operation(self):
         with self.app.test_client():

--- a/tests/_test_mscolab/test_file_manager.py
+++ b/tests/_test_mscolab/test_file_manager.py
@@ -99,11 +99,14 @@ class Test_FileManager:
             flight_path, operation = self._create_operation(flight_path="more_than_one")
             self.fm.add_bulk_permission(operation.id, self.user, [self.collaboratoruser.id], "collaborator")
             self.fm.add_bulk_permission(operation.id, self.user, [self.vieweruser.id], "viewer")
+            self.fm.add_bulk_permission(operation.id, self.user, [self.adminuser.id], "admin")
 
             assert operation.path == flight_path
             assert self.fm.fetch_operation_creator(operation.id, self.user.id) == self.user.username
             assert self.fm.fetch_operation_creator(operation.id, self.collaboratoruser.id) == self.user.username
             assert self.fm.fetch_operation_creator(operation.id, self.vieweruser.id) == self.user.username
+            assert self.fm.fetch_operation_creator(operation.id, self.adminuser.id) == self.user.username
+
             # this user is not defined in that OP
             assert self.fm.fetch_operation_creator(operation.id, self.op2user.id) is False
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2005

removing the limitation to the creator to see who created an operation. 