### PR TITLE
Fix: Refined QMessageBox mocking in test_no_serve function

### DIFF
--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -9,7 +9,7 @@ jobs:
   trigger-testing-stable:
     runs-on: ubuntu-latest
     permissions:
-        actions: write
+      actions: write
     steps:
       - uses: benc-uk/workflow-dispatch@v1.2.2
         with:

--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -6,12 +6,14 @@ on:
 
 
 jobs:
-  trigger_stable_test:
+  trigger-testing-stable:
     runs-on: ubuntu-latest
+    permissions:
+        actions: write
     steps:
       - uses: benc-uk/workflow-dispatch@v1.2.2
         with:
-          workflow: testing-stable
+          workflow: testing-stable.yml
           ref: stable
 
   test-develop-scheduled:

--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -5,16 +5,14 @@ on:
     - cron: '30 5 * * 1' 
 
 
-jobs:     
-  test-stable-scheduled:
-    uses: 
-      ./.github/workflows/testing.yml
-    with:
-      xdist: no
-      branch_name: stable
-      event_name: ${{ github.event_name }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
+jobs:
+  trigger_stable_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: benc-uk/workflow-dispatch@v1.2.2
+        with:
+          workflow: testing-stable
+          ref: stable
 
   test-develop-scheduled:
     uses: 

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -112,13 +112,13 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         yield
         self._teardown()
 
-    @mock.patch("PyQt5.QtWidgets.QMessageBox")
-    def test_no_server(self, mockbox):
+    def test_no_server(self):
         """
         assert that a message box informs about server troubles
         """
-        self.query_server(f"{self.scheme}://{self.host}:{self.port-1}")
-        assert mockbox.critical.call_count == 1
+        with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
+            self.query_server(f"{self.scheme}://{self.host}:{self.port-1}")
+            mock_critical.assert_called_once()
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox")
     def test_no_schema(self, mockbox):


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2210 

This PR refactors the `test_no_server` function in `test_wms_control.py` to mock only the critical method of QMessageBox and replace `.call_count == 1` with `.assert_called_once()`. This improves test clarity.
