### PR TITLE
Enable dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This configuration will check the GitHub Actions workflows for outdated versions of actions and will open update PRs for those every week on Monday (the current default for a weekly schedule).

Fixes #2198.