### PR TITLE
docs: Updated urls in document `NOTICE`

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -107,8 +107,8 @@ Icons
 We use icons in mslib.mui.editor from the tango-icon-library
 Author: Jakub Steiner jimmac@gmail.com
 
-License: https://github.com/freedesktop/tango-icon-library/blob/master/COPYING.PublicDomain
-Further Information: http://tango.freedesktop.org
+License: https://gitlab.freedesktop.org/tango/tango-icon-library/-/blob/master/COPYING.PublicDomain
+Further Information: https://gitlab.freedesktop.org/tango/tango-icon-library
 
 Airports Data
 -------------


### PR DESCRIPTION
Fixes #1992 
As the URLs had been moved, I updated the URLs of Tango Icon Library in the document.

This PR results in some Documentation changes,
`NOTICE`

**Checklist:**
- [X] Bug fix. Fixes #1992 
- [ ] New feature (Non-API breaking changes that adds functionality)
- [X] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

