### PR TITLE
Fix : Updated seed module to use "mscolab_settings.ARCHIVE_THRESHOLD"

### DIFF
--- a/docs/samples/config/mscolab/mscolab_settings.py.sample
+++ b/docs/samples/config/mscolab/mscolab_settings.py.sample
@@ -28,6 +28,9 @@ import os
 import logging
 
 class mscolab_settings:
+    # In the unit "months" when Operations get archived because not used
+    ARCHIVE_THRESHOLD = 2
+
     # Set which origins are allowed to communicate with your server
     CORS_ORIGINS = ["*"]
 

--- a/docs/samples/config/mscolab/mscolab_settings.py.sample
+++ b/docs/samples/config/mscolab/mscolab_settings.py.sample
@@ -27,6 +27,7 @@
 import os
 import logging
 
+
 class mscolab_settings:
     # In the unit months when Operations get archived because not used
     ARCHIVE_THRESHOLD = 2

--- a/docs/samples/config/mscolab/mscolab_settings.py.sample
+++ b/docs/samples/config/mscolab/mscolab_settings.py.sample
@@ -28,7 +28,7 @@ import os
 import logging
 
 class mscolab_settings:
-    # In the unit "months" when Operations get archived because not used
+    # In the unit months when Operations get archived because not used
     ARCHIVE_THRESHOLD = 2
 
     # Set which origins are allowed to communicate with your server

--- a/mslib/mscolab/seed.py
+++ b/mslib/mscolab/seed.py
@@ -223,7 +223,9 @@ def archive_operation(path=None, emailid=None):
                 elif perm.access_level != "creator":
                     return False
                 operation.active = False
-                operation.last_used = datetime.datetime.utcnow() - dateutil.relativedelta.relativedelta(months=mscolab_settings.ARCHIVE_THRESHOLD)       
+                operation.last_used = datetime.datetime.utcnow() - \
+                        dateutil.relativedelta.relativedelta(months=mscolab_settings.ARCHIVE_THRESHOLD)
+
                 db.session.commit()
 
 

--- a/mslib/mscolab/seed.py
+++ b/mslib/mscolab/seed.py
@@ -224,7 +224,7 @@ def archive_operation(path=None, emailid=None):
                     return False
                 operation.active = False
                 operation.last_used = (
-                    datetime.datetime.utcnow() - 
+                    datetime.datetime.utcnow() -
                     dateutil.relativedelta.relativedelta(months=mscolab_settings.ARCHIVE_THRESHOLD)
                 )
 

--- a/mslib/mscolab/seed.py
+++ b/mslib/mscolab/seed.py
@@ -223,7 +223,7 @@ def archive_operation(path=None, emailid=None):
                 elif perm.access_level != "creator":
                     return False
                 operation.active = False
-                operation.last_used = datetime.datetime.utcnow() - dateutil.relativedelta.relativedelta(months=2)
+                operation.last_used = datetime.datetime.utcnow() - dateutil.relativedelta.relativedelta(months=mscolab_settings.ARCHIVE_THRESHOLD)       
                 db.session.commit()
 
 

--- a/mslib/mscolab/seed.py
+++ b/mslib/mscolab/seed.py
@@ -223,8 +223,10 @@ def archive_operation(path=None, emailid=None):
                 elif perm.access_level != "creator":
                     return False
                 operation.active = False
-                operation.last_used = datetime.datetime.utcnow() - \
-                        dateutil.relativedelta.relativedelta(months=mscolab_settings.ARCHIVE_THRESHOLD)
+                operation.last_used = (
+                    datetime.datetime.utcnow() - 
+                    dateutil.relativedelta.relativedelta(months=mscolab_settings.ARCHIVE_THRESHOLD)
+                )
 
                 db.session.commit()
 


### PR DESCRIPTION
Purpose of PR?

Fixes #2227 

Updated the seed module to always use `mscolab_settings.ARCHIVE_THRESHOLD` instead of hardcoded `dateutil.relativedelta.relativedelta(months=**2**)`.
