### PR TITLE
refactor : Used urljoin instead of string concatenation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -107,8 +107,8 @@ Icons
 We use icons in mslib.mui.editor from the tango-icon-library
 Author: Jakub Steiner jimmac@gmail.com
 
-License: https://github.com/freedesktop/tango-icon-library/blob/master/COPYING.PublicDomain
-Further Information: http://tango.freedesktop.org
+License: https://gitlab.freedesktop.org/tango/tango-icon-library/-/blob/master/COPYING.PublicDomain
+Further Information: https://gitlab.freedesktop.org/tango/tango-icon-library
 
 Airports Data
 -------------

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -325,8 +325,8 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
         s = requests.Session()
         s.auth = self.auth
         s.headers.update({'x-test': 'true'})
-        url = urljoin(self.mscolab_server_url,"/token")
-        url_recover_password = urljoin(self.mscolab_server_url,"reset_request")
+        url = urljoin(self.mscolab_server_url, "/token")
+        url_recover_password = urljoin(self.mscolab_server_url, "reset_request")
         try:
             r = s.post(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.status_code == 401:
@@ -350,13 +350,13 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
 
     def idp_login_handler(self):
         """Handle IDP login Button"""
-        url_idp_login = urljoin(self.mscolab_server_url,"/available_idps")
+        url_idp_login = urljoin(self.mscolab_server_url, "/available_idps")
         webbrowser.open(url_idp_login, new=2)
         self.stackedWidget.setCurrentWidget(self.idpAuthPage)
 
     def idp_auth_token_submit_handler(self):
         """Handle IDP authentication token submission"""
-        url_idp_login_auth = urljoin(self.mscolab_server_url,"/idp_login_auth")
+        url_idp_login_auth = urljoin(self.mscolab_server_url, "/idp_login_auth")
         user_token = self.idpAuthPasswordLe.text()
 
         try:
@@ -379,7 +379,7 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
                 s = requests.Session()
                 s.auth = self.auth
                 s.headers.update({'x-test': 'true'})
-                url = urljoin(self.mscolab_server_url,"/token")
+                url = urljoin(self.mscolab_server_url, "/token")
 
                 r = s.post(url, data=data, timeout=(2, 10))
                 if r.status_code == 401:
@@ -428,7 +428,7 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
         s = requests.Session()
         s.auth = self.auth
         s.headers.update({'x-test': 'true'})
-        url = urljoin(self.mscolab_server_url,"/register")
+        url = urljoin(self.mscolab_server_url, "/register")
         try:
             r = s.post(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         except requests.exceptions.RequestException as ex:
@@ -824,7 +824,7 @@ class MSUIMscolab(QtCore.QObject):
             }
 
             try:
-                url = urljoin(self.mscolab_server_url,"/delete_own_account")
+                url = urljoin(self.mscolab_server_url, "/delete_own_account")
                 r = requests.post(url, data=data,
                                   timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             except requests.exceptions.RequestException as e:
@@ -924,7 +924,7 @@ class MSUIMscolab(QtCore.QObject):
         if self.add_proj_dialog.f_content is not None:
             data["content"] = self.add_proj_dialog.f_content
         try:
-            url = urljoin(self.mscolab_server_url,"create_operation")
+            url = urljoin(self.mscolab_server_url, "create_operation")
             r = requests.post(url, data=data,
                               timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         except requests.exceptions.RequestException as e:
@@ -1446,7 +1446,7 @@ class MSUIMscolab(QtCore.QObject):
                 "token": self.token
             }
             url = urljoin(self.mscolab_server_url, "/operations")
-            r = requests.get(url ,data=data,timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+            r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.text != "False":
                 _json = json.loads(r.text)
                 operations = _json["operations"]
@@ -1487,7 +1487,7 @@ class MSUIMscolab(QtCore.QObject):
             'token': self.token
         }
         url = urljoin(self.mscolab_server_url, "/user")
-        r = requests.get(url, data=data,timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+        r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         if r.text != "False":
             _json = json.loads(r.text)
             if _json['user']['id'] == u_id:
@@ -1614,7 +1614,7 @@ class MSUIMscolab(QtCore.QObject):
                 }
                 url = urljoin(self.mscolab_server_url, "/operations")
                 try:
-                    r = requests.get(url, data=data,timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+                    r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
                 except requests.exceptions.MissingSchema:
                     show_popup(self.ui, "Error", "Session expired, new login required")
             if r is not None and r.text != "False":
@@ -1645,7 +1645,7 @@ class MSUIMscolab(QtCore.QObject):
                 "skip_archived": skip_archived
             }
             url = urljoin(self.mscolab_server_url, "/operations")
-            r = requests.get(url, data=data,timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+            r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.text != "False":
                 _json = json.loads(r.text)
                 self.operations = _json["operations"]

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -325,8 +325,8 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
         s = requests.Session()
         s.auth = self.auth
         s.headers.update({'x-test': 'true'})
-        url = f'{self.mscolab_server_url}/token'
-        url_recover_password = f'{self.mscolab_server_url}/reset_request'
+        url = urljoin(self.mscolab_server_url,"/token")
+        url_recover_password = urljoin(self.mscolab_server_url,"reset_request")
         try:
             r = s.post(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.status_code == 401:
@@ -350,13 +350,13 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
 
     def idp_login_handler(self):
         """Handle IDP login Button"""
-        url_idp_login = f'{self.mscolab_server_url}/available_idps'
+        url_idp_login = urljoin(self.mscolab_server_url,"/available_idps")
         webbrowser.open(url_idp_login, new=2)
         self.stackedWidget.setCurrentWidget(self.idpAuthPage)
 
     def idp_auth_token_submit_handler(self):
         """Handle IDP authentication token submission"""
-        url_idp_login_auth = f'{self.mscolab_server_url}/idp_login_auth'
+        url_idp_login_auth = urljoin(self.mscolab_server_url,"/idp_login_auth")
         user_token = self.idpAuthPasswordLe.text()
 
         try:
@@ -379,7 +379,7 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
                 s = requests.Session()
                 s.auth = self.auth
                 s.headers.update({'x-test': 'true'})
-                url = f'{self.mscolab_server_url}/token'
+                url = urljoin(self.mscolab_server_url,"/token")
 
                 r = s.post(url, data=data, timeout=(2, 10))
                 if r.status_code == 401:
@@ -428,7 +428,7 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
         s = requests.Session()
         s.auth = self.auth
         s.headers.update({'x-test': 'true'})
-        url = f'{self.mscolab_server_url}/register'
+        url = urljoin(self.mscolab_server_url,"/register")
         try:
             r = s.post(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         except requests.exceptions.RequestException as ex:
@@ -824,7 +824,8 @@ class MSUIMscolab(QtCore.QObject):
             }
 
             try:
-                r = requests.post(self.mscolab_server_url + '/delete_own_account', data=data,
+                url = urljoin(self.mscolab_server_url,"/delete_own_account")
+                r = requests.post(url, data=data,
                                   timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             except requests.exceptions.RequestException as e:
                 logging.error(e)
@@ -923,7 +924,8 @@ class MSUIMscolab(QtCore.QObject):
         if self.add_proj_dialog.f_content is not None:
             data["content"] = self.add_proj_dialog.f_content
         try:
-            r = requests.post(f'{self.mscolab_server_url}/create_operation', data=data,
+            url = urljoin(self.mscolab_server_url,"create_operation")
+            r = requests.post(url, data=data,
                               timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         except requests.exceptions.RequestException as e:
             logging.error(e)
@@ -955,7 +957,8 @@ class MSUIMscolab(QtCore.QObject):
                 "token": self.token,
                 "skip_archived": skip_archived
             }
-            r = requests.get(self.mscolab_server_url + '/operations', data=data)
+            url = urljoin(self.mscolab_server_url, "/operations")
+            r = requests.get(url, data=data)
             if r.text != "False":
                 _json = json.loads(r.text)
                 operations = _json["operations"]
@@ -1442,8 +1445,8 @@ class MSUIMscolab(QtCore.QObject):
             data = {
                 "token": self.token
             }
-            r = requests.get(self.mscolab_server_url + '/operations', data=data,
-                             timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+            url = urljoin(self.mscolab_server_url, "/operations")
+            r = requests.get(url ,data=data,timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.text != "False":
                 _json = json.loads(r.text)
                 operations = _json["operations"]
@@ -1483,8 +1486,8 @@ class MSUIMscolab(QtCore.QObject):
         data = {
             'token': self.token
         }
-        r = requests.get(self.mscolab_server_url + '/user', data=data,
-                         timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+        url = urljoin(self.mscolab_server_url, "/user")
+        r = requests.get(url, data=data,timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         if r.text != "False":
             _json = json.loads(r.text)
             if _json['user']['id'] == u_id:
@@ -1609,9 +1612,9 @@ class MSUIMscolab(QtCore.QObject):
                 data = {
                     "token": self.token
                 }
+                url = urljoin(self.mscolab_server_url, "/operations")
                 try:
-                    r = requests.get(f'{self.mscolab_server_url}/operations', data=data,
-                                     timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+                    r = requests.get(url, data=data,timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
                 except requests.exceptions.MissingSchema:
                     show_popup(self.ui, "Error", "Session expired, new login required")
             if r is not None and r.text != "False":
@@ -1641,8 +1644,8 @@ class MSUIMscolab(QtCore.QObject):
                 "token": self.token,
                 "skip_archived": skip_archived
             }
-            r = requests.get(f'{self.mscolab_server_url}/operations', data=data,
-                             timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
+            url = urljoin(self.mscolab_server_url, "/operations")
+            r = requests.get(url, data=data,timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.text != "False":
                 _json = json.loads(r.text)
                 self.operations = _json["operations"]
@@ -1887,7 +1890,8 @@ class MSUIMscolab(QtCore.QObject):
                 "token": self.token,
                 "op_id": self.active_op_id
             }
-            r = requests.get(self.mscolab_server_url + '/get_operation_by_id', data=data)
+            url = urljoin(self.mscolab_server_url, "/get_operation_by_id")
+            r = requests.get(url, data=data)
             if r.text != "False":
                 xml_content = json.loads(r.text)["content"]
                 return xml_content

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -325,7 +325,7 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
         s = requests.Session()
         s.auth = self.auth
         s.headers.update({'x-test': 'true'})
-        url = urljoin(self.mscolab_server_url, "/token")
+        url = urljoin(self.mscolab_server_url, "token")
         url_recover_password = urljoin(self.mscolab_server_url, "reset_request")
         try:
             r = s.post(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
@@ -350,13 +350,13 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
 
     def idp_login_handler(self):
         """Handle IDP login Button"""
-        url_idp_login = urljoin(self.mscolab_server_url, "/available_idps")
+        url_idp_login = urljoin(self.mscolab_server_url, "available_idps")
         webbrowser.open(url_idp_login, new=2)
         self.stackedWidget.setCurrentWidget(self.idpAuthPage)
 
     def idp_auth_token_submit_handler(self):
         """Handle IDP authentication token submission"""
-        url_idp_login_auth = urljoin(self.mscolab_server_url, "/idp_login_auth")
+        url_idp_login_auth = urljoin(self.mscolab_server_url, "idp_login_auth")
         user_token = self.idpAuthPasswordLe.text()
 
         try:
@@ -379,7 +379,7 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
                 s = requests.Session()
                 s.auth = self.auth
                 s.headers.update({'x-test': 'true'})
-                url = urljoin(self.mscolab_server_url, "/token")
+                url = urljoin(self.mscolab_server_url, "token")
 
                 r = s.post(url, data=data, timeout=(2, 10))
                 if r.status_code == 401:
@@ -428,7 +428,7 @@ class MSColab_ConnectDialog(QtWidgets.QDialog, ui_conn.Ui_MSColabConnectDialog):
         s = requests.Session()
         s.auth = self.auth
         s.headers.update({'x-test': 'true'})
-        url = urljoin(self.mscolab_server_url, "/register")
+        url = urljoin(self.mscolab_server_url, "register")
         try:
             r = s.post(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         except requests.exceptions.RequestException as ex:
@@ -583,7 +583,7 @@ class MSUIMscolab(QtCore.QObject):
             "token": self.token,
             "op_id": self.active_op_id
         }
-        url = urljoin(self.mscolab_server_url, "/creator_of_operation")
+        url = urljoin(self.mscolab_server_url, "creator_of_operation")
         r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         creator_name = "unknown"
         if r.text != "False":
@@ -824,7 +824,7 @@ class MSUIMscolab(QtCore.QObject):
             }
 
             try:
-                url = urljoin(self.mscolab_server_url, "/delete_own_account")
+                url = urljoin(self.mscolab_server_url, "delete_own_account")
                 r = requests.post(url, data=data,
                                   timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             except requests.exceptions.RequestException as e:
@@ -957,7 +957,7 @@ class MSUIMscolab(QtCore.QObject):
                 "token": self.token,
                 "skip_archived": skip_archived
             }
-            url = urljoin(self.mscolab_server_url, "/operations")
+            url = urljoin(self.mscolab_server_url, "operations")
             r = requests.get(url, data=data)
             if r.text != "False":
                 _json = json.loads(r.text)
@@ -1445,7 +1445,7 @@ class MSUIMscolab(QtCore.QObject):
             data = {
                 "token": self.token
             }
-            url = urljoin(self.mscolab_server_url, "/operations")
+            url = urljoin(self.mscolab_server_url, "operations")
             r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.text != "False":
                 _json = json.loads(r.text)
@@ -1486,7 +1486,7 @@ class MSUIMscolab(QtCore.QObject):
         data = {
             'token': self.token
         }
-        url = urljoin(self.mscolab_server_url, "/user")
+        url = urljoin(self.mscolab_server_url, "user")
         r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
         if r.text != "False":
             _json = json.loads(r.text)
@@ -1612,7 +1612,7 @@ class MSUIMscolab(QtCore.QObject):
                 data = {
                     "token": self.token
                 }
-                url = urljoin(self.mscolab_server_url, "/operations")
+                url = urljoin(self.mscolab_server_url, "operations")
                 try:
                     r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
                 except requests.exceptions.MissingSchema:
@@ -1644,7 +1644,7 @@ class MSUIMscolab(QtCore.QObject):
                 "token": self.token,
                 "skip_archived": skip_archived
             }
-            url = urljoin(self.mscolab_server_url, "/operations")
+            url = urljoin(self.mscolab_server_url, "operations")
             r = requests.get(url, data=data, timeout=tuple(config_loader(dataset="MSCOLAB_timeout")))
             if r.text != "False":
                 _json = json.loads(r.text)
@@ -1890,7 +1890,7 @@ class MSUIMscolab(QtCore.QObject):
                 "token": self.token,
                 "op_id": self.active_op_id
             }
-            url = urljoin(self.mscolab_server_url, "/get_operation_by_id")
+            url = urljoin(self.mscolab_server_url, "get_operation_by_id")
             r = requests.get(url, data=data)
             if r.text != "False":
                 xml_content = json.loads(r.text)["content"]

--- a/mslib/msui/multiple_flightpath_dockwidget.py
+++ b/mslib/msui/multiple_flightpath_dockwidget.py
@@ -34,6 +34,7 @@ import mslib.msui.msui_mainwindow as msui_mainwindow
 from mslib.utils.verify_user_token import verify_user_token
 from mslib.utils.qt import Worker
 from mslib.utils.config import config_loader
+from urllib.parse import urljoin
 
 
 class QMscolabOperationsListWidgetItem(QtWidgets.QListWidgetItem):
@@ -557,7 +558,8 @@ class MultipleFlightpathOperations:
             "token": self.token,
             "skip_archived": skip_archived
         }
-        r = requests.get(self.mscolab_server_url + "/operations", data=data, timeout=(2, 10))
+        url = urljoin(self.mscolab_server_url, "/operations")
+        r = requests.get(url, data=data, timeout=(2, 10))
         if r.text != "False":
             _json = json.loads(r.text)
             operations = _json["operations"]
@@ -572,7 +574,8 @@ class MultipleFlightpathOperations:
                 "token": self.token,
                 "op_id": op_id
             }
-            r = requests.get(self.mscolab_server_url + '/get_operation_by_id', data=data, timeout=(2, 10))
+            url = urljoin(self.mscolab_server_url, "/get_operation_by_id")
+            r = requests.get(url, data=data, timeout=(2, 10))
             if r.text != "False":
                 xml_content = json.loads(r.text)["content"]
                 return xml_content

--- a/mslib/msui/multiple_flightpath_dockwidget.py
+++ b/mslib/msui/multiple_flightpath_dockwidget.py
@@ -558,7 +558,7 @@ class MultipleFlightpathOperations:
             "token": self.token,
             "skip_archived": skip_archived
         }
-        url = urljoin(self.mscolab_server_url, "/operations")
+        url = urljoin(self.mscolab_server_url, "operations")
         r = requests.get(url, data=data, timeout=(2, 10))
         if r.text != "False":
             _json = json.loads(r.text)
@@ -574,7 +574,7 @@ class MultipleFlightpathOperations:
                 "token": self.token,
                 "op_id": op_id
             }
-            url = urljoin(self.mscolab_server_url, "/get_operation_by_id")
+            url = urljoin(self.mscolab_server_url, "get_operation_by_id")
             r = requests.get(url, data=data, timeout=(2, 10))
             if r.text != "False":
                 xml_content = json.loads(r.text)["content"]

--- a/mslib/utils/verify_user_token.py
+++ b/mslib/utils/verify_user_token.py
@@ -28,7 +28,7 @@
 import logging
 import requests
 from mslib.utils.config import config_loader
-
+from urllib.parse import urljoin
 
 def verify_user_token(mscolab_server_url, token):
 
@@ -39,7 +39,8 @@ def verify_user_token(mscolab_server_url, token):
         "token": token
     }
     try:
-        r = requests.get(f'{mscolab_server_url}/test_authorized', data=data, timeout=(2, 10))
+        url = urljoin(mscolab_server_url, "/test_authorized")
+        r = requests.get(url, data=data, timeout=(2, 10))
     except requests.exceptions.SSLError:
         logging.debug("Certificate Verification Failed")
         return False

--- a/mslib/utils/verify_user_token.py
+++ b/mslib/utils/verify_user_token.py
@@ -30,6 +30,7 @@ import requests
 from mslib.utils.config import config_loader
 from urllib.parse import urljoin
 
+
 def verify_user_token(mscolab_server_url, token):
 
     if config_loader(dataset="mscolab_skip_verify_user_token"):

--- a/mslib/utils/verify_user_token.py
+++ b/mslib/utils/verify_user_token.py
@@ -40,7 +40,7 @@ def verify_user_token(mscolab_server_url, token):
         "token": token
     }
     try:
-        url = urljoin(mscolab_server_url, "/test_authorized")
+        url = urljoin(mscolab_server_url, "test_authorized")
         r = requests.get(url, data=data, timeout=(2, 10))
     except requests.exceptions.SSLError:
         logging.debug("Certificate Verification Failed")


### PR DESCRIPTION
Fixes #1929
Used urljoins instead of '+' operation and f' string. 


**Checklist:**
- [X] Bug fix. Fixes #1929
- [ ] New feature (Non-API breaking changes that adds functionality)
- [X] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests
