### PR TITLE
Replace: occurrences of tests.utils.wait_until_signal with qtbot.wait_signal

### DIFF
--- a/tests/_test_msui/test_linearview.py
+++ b/tests/_test_msui/test_linearview.py
@@ -106,7 +106,7 @@ class Test_LinearViewWMS:
         self.window.hide()
         shutil.rmtree(self.tempdir)
 
-    def query_server(self, url, qtbot):
+    def query_server(self, qtbot, url):
         QtTest.QTest.keyClicks(self.wms_control.multilayers.cbWMS_URL, url)
         with qtbot.wait_signal(self.wms_control.cpdlg.canceled):
             QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
@@ -115,6 +115,6 @@ class Test_LinearViewWMS:
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         with qtbot.wait_signal(self.wms_control.image_displayed):
             QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)

--- a/tests/_test_msui/test_linearview.py
+++ b/tests/_test_msui/test_linearview.py
@@ -115,6 +115,6 @@ class Test_LinearViewWMS:
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         with qtbot.wait_signal(self.wms_control.image_displayed):
             QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)

--- a/tests/_test_msui/test_linearview.py
+++ b/tests/_test_msui/test_linearview.py
@@ -34,7 +34,6 @@ from PyQt5 import QtTest, QtCore
 from mslib.msui import flighttrack as ft
 import mslib.msui.linearview as tv
 from mslib.msui.mpl_qtwidget import _DEFAULT_SETTINGS_LINEARVIEW
-from tests.utils import wait_until_signal
 
 
 class Test_MSS_LV_Options_Dialog:

--- a/tests/_test_msui/test_linearview.py
+++ b/tests/_test_msui/test_linearview.py
@@ -107,10 +107,10 @@ class Test_LinearViewWMS:
         self.window.hide()
         shutil.rmtree(self.tempdir)
 
-    def query_server(self, url):
+    def query_server(self, url, qtbot):
         QtTest.QTest.keyClicks(self.wms_control.multilayers.cbWMS_URL, url)
-        QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
-        wait_until_signal(self.wms_control.cpdlg.canceled)
+        with qtbot.wait_signal(self.wms_control.cpdlg.canceled):
+            QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
 
     def test_server_getmap(self, qtbot):
         """

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -35,7 +35,6 @@ from PyQt5 import QtTest, QtCore, QtGui
 from mslib.msui import flighttrack as ft
 import mslib.msui.sideview as tv
 from mslib.msui.mpl_qtwidget import _DEFAULT_SETTINGS_SIDEVIEW
-from tests.utils import wait_until_signal
 
 
 class Test_MSS_SV_OptionsDialog:
@@ -149,11 +148,8 @@ class Test_SideViewWMS:
 
     def query_server(self, url, qtbot):
         QtTest.QTest.keyClicks(self.wms_control.multilayers.cbWMS_URL, url)
-        QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
         with qtbot.wait_signal(self.wms_control.cpdlg.canceled):
-            cancel_button = self.window.cpdlg.findChildren(QtWidgets.QPushButton,
-                                                        "cancelButtonName")  # the actual button will go
-            QtTest.QTest.mouseClick(cancel_button, QtCore.Qt.LeftButton)
+            QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
 
     def test_server_getmap(self, qtbot):
         """

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -155,7 +155,7 @@ class Test_SideViewWMS:
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         with qtbot.wait_signal(self.wms_control.image_displayed):
             QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
         assert self.window.getView().plotter.image is not None

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -146,7 +146,7 @@ class Test_SideViewWMS:
         self.window.hide()
         shutil.rmtree(self.tempdir)
 
-    def query_server(self, url, qtbot):
+    def query_server(self, qtbot, url):
         QtTest.QTest.keyClicks(self.wms_control.multilayers.cbWMS_URL, url)
         with qtbot.wait_signal(self.wms_control.cpdlg.canceled):
             QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
@@ -155,7 +155,7 @@ class Test_SideViewWMS:
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         with qtbot.wait_signal(self.wms_control.image_displayed):
             QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
         assert self.window.getView().plotter.image is not None

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -147,10 +147,13 @@ class Test_SideViewWMS:
         self.window.hide()
         shutil.rmtree(self.tempdir)
 
-    def query_server(self, url):
+    def query_server(self, url, qtbot):
         QtTest.QTest.keyClicks(self.wms_control.multilayers.cbWMS_URL, url)
         QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
-        wait_until_signal(self.wms_control.cpdlg.canceled)
+        with qtbot.wait_signal(self.wms_control.cpdlg.canceled):
+            cancel_button = self.window.cpdlg.findChildren(QtWidgets.QPushButton,
+                                                        "cancelButtonName")  # the actual button will go
+            QtTest.QTest.mouseClick(cancel_button, QtCore.Qt.LeftButton)
 
     def test_server_getmap(self, qtbot):
         """

--- a/tests/_test_msui/test_topview.py
+++ b/tests/_test_msui/test_topview.py
@@ -221,7 +221,7 @@ class Test_TopViewWMS:
         self.window.hide()
         shutil.rmtree(self.tempdir)
 
-    def query_server(self, url, qtbot):
+    def query_server(self, qtbot, url):
         QtTest.QTest.keyClicks(self.wms_control.multilayers.cbWMS_URL, url)
         with qtbot.wait_signal(self.wms_control.cpdlg.canceled):
             QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
@@ -230,7 +230,7 @@ class Test_TopViewWMS:
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         with qtbot.wait_signal(self.wms_control.image_displayed):
             QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
         assert self.window.getView().map.image is not None

--- a/tests/_test_msui/test_topview.py
+++ b/tests/_test_msui/test_topview.py
@@ -222,18 +222,18 @@ class Test_TopViewWMS:
         self.window.hide()
         shutil.rmtree(self.tempdir)
 
-    def query_server(self, url):
+    def query_server(self, url, qtbot):
         QtTest.QTest.keyClicks(self.wms_control.multilayers.cbWMS_URL, url)
-        QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
-        wait_until_signal(self.wms_control.cpdlg.canceled)
+        with qtbot.wait_signal(self.wms_control.cpdlg.canceled):
+            QtTest.QTest.mouseClick(self.wms_control.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
 
-    def test_server_getmap(self):
+    def test_server_getmap(self, qtbot):
         """
         assert that a getmap call to a WMS server displays an image
         """
         self.query_server(self.url)
-        QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
-        wait_until_signal(self.wms_control.image_displayed)
+        with qtbot.wait_signal(self.wms_control.image_displayed):
+            QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
         assert self.window.getView().map.image is not None
         self.window.getView().set_settings({})
         self.window.getView().clear_figure()

--- a/tests/_test_msui/test_topview.py
+++ b/tests/_test_msui/test_topview.py
@@ -35,7 +35,6 @@ from PyQt5 import QtWidgets, QtCore, QtTest
 from mslib.msui import flighttrack as ft
 from mslib.msui.msui import MSUIMainWindow
 from mslib.msui.mpl_qtwidget import _DEFAULT_SETTINGS_TOPVIEW
-from tests.utils import wait_until_signal
 
 
 class Test_MSS_TV_MapAppearanceDialog:

--- a/tests/_test_msui/test_topview.py
+++ b/tests/_test_msui/test_topview.py
@@ -230,7 +230,7 @@ class Test_TopViewWMS:
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         with qtbot.wait_signal(self.wms_control.image_displayed):
             QtTest.QTest.mouseClick(self.wms_control.btGetMap, QtCore.Qt.LeftButton)
         assert self.window.getView().map.image is not None

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -106,40 +106,45 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a message box informs about server troubles
         """
+        mock_url = f"{self.scheme}://{self.host}:{self.port-1}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(f"{self.scheme}://{self.host}:{self.port-1}")
+            self.query_server(mock_url)
             mock_critical.assert_called_once()
 
     def test_no_schema(self):
         """
         assert that a message box informs about server troubles
         """
+        mock_url = f"{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(f"{self.host}:{self.port}")
+            self.query_server(mock_url)
             mock_critical.assert_called_once()
 
     def test_invalid_schema(self):
         """
         assert that a message box informs about server troubles
         """
+        mock_url = f"hppd://{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(f"hppd://{self.host}:{self.port}")
+            self.query_server(mock_url)
             mock_critical.assert_called_once()
 
     def test_invalid_url(self):
         """
         assert that a message box informs about server troubles
         """
+        mock_url = f"{self.scheme}://???{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(f"{self.scheme}://???{self.host}:{self.port}")
+            self.query_server(mock_url)
             mock_critical.assert_called_once()
 
     def test_connection_error(self):
         """
         assert that a message box informs about server troubles
         """
+        mock_url = f"{self.scheme}://.....{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(f"{self.scheme}://.....{self.host}:{self.port}")
+            self.query_server(mock_url)
             mock_critical.assert_called_once()
 
     @pytest.mark.skip("Breaks other tests in this class because of a lingering message box, for some reason")

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -111,40 +111,40 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
             self.query_server(qtbot, mock_url)
             mock_critical.assert_called_once()
 
-    def test_no_schema(self):
+    def test_no_schema(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
         mock_url = f"{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(mock_url)
+            self.query_server(qtbot, mock_url)
             mock_critical.assert_called_once()
 
-    def test_invalid_schema(self):
+    def test_invalid_schema(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
         mock_url = f"hppd://{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(mock_url)
+            self.query_server(qtbot, mock_url)
             mock_critical.assert_called_once()
 
-    def test_invalid_url(self):
+    def test_invalid_url(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
         mock_url = f"{self.scheme}://???{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(mock_url)
+            self.query_server(qtbot, mock_url)
             mock_critical.assert_called_once()
 
-    def test_connection_error(self):
+    def test_connection_error(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
         mock_url = f"{self.scheme}://.....{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(mock_url)
+            self.query_server(qtbot, mock_url)
             mock_critical.assert_called_once()
 
     @pytest.mark.skip("Breaks other tests in this class because of a lingering message box, for some reason")
@@ -183,7 +183,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(self, qtbot, self.url)
 
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
@@ -196,7 +196,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(self, qtbot, self.url)
 
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
@@ -218,7 +218,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that changing between servers still allows image retrieval
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(self, qtbot, self.url)
 
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as qm_critical:
             with qtbot.wait_signal(self.window.cpdlg.canceled):

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -87,12 +87,13 @@ class WMSControlWidgetSetup:
         self.window.hide()
         shutil.rmtree(self.tempdir)
 
-    def query_server(self, url, qtbot):
+    def query_server(self, qtbot, url):
         while len(self.window.multilayers.cbWMS_URL.currentText()) > 0:
             QtTest.QTest.keyClick(self.window.multilayers.cbWMS_URL, QtCore.Qt.Key_Backspace)
         QtTest.QTest.keyClicks(self.window.multilayers.cbWMS_URL, url)
         with qtbot.wait_signal(self.window.cpdlg.canceled):
             QtTest.QTest.mouseClick(self.window.multilayers.btGetCapabilities, QtCore.Qt.LeftButton)
+
 
 class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
     @pytest.fixture(autouse=True)
@@ -164,7 +165,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that an aborted getmap call does not change the displayed image
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         QtTest.QTest.keyClick(self.window.pdlg, QtCore.Qt.Key_Enter)
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
@@ -177,7 +178,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
 
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
@@ -190,7 +191,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
 
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
@@ -212,7 +213,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that changing between servers still allows image retrieval
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
 
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as qm_critical:
             with qtbot.wait_signal(self.window.cpdlg.canceled):
@@ -240,7 +241,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that multilayers get created, handled and drawn properly
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
@@ -322,7 +323,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that singlelayer mode behaves as expected
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
@@ -384,7 +385,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
 
     @mock.patch("mslib.msui.wms_control.WMSMapFetcher.moveToThread")
     def test_server_no_thread(self, mockthread, qtbot):
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
@@ -417,7 +418,7 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
 
@@ -429,11 +430,12 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that drawing a layer through code doesn't fail for vsec
         """
-        self.query_server(self.url)
+        self.query_server(self.url, qtbot)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         with qtbot.wait_signal(self.window.image_displayed):
             server.child(0).draw()
+
 
 class TestWMSControlWidgetSetupSimple:
     xml = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -35,7 +35,6 @@ import urllib
 from PyQt5 import QtCore, QtTest
 from mslib.msui import flighttrack as ft
 import mslib.msui.wms_control as wc
-from tests.utils import wait_until_signal
 
 
 class HSecViewMockup(mock.Mock):

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -106,45 +106,40 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a message box informs about server troubles
         """
-        mock_url = f"{self.scheme}://{self.host}:{self.port-1}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(qtbot, mock_url)
+            self.query_server(qtbot, f"{self.scheme}://{self.host}:{self.port-1}")
             mock_critical.assert_called_once()
 
     def test_no_schema(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
-        mock_url = f"{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(qtbot, mock_url)
+            self.query_server(qtbot, f"{self.host}:{self.port}")
             mock_critical.assert_called_once()
 
     def test_invalid_schema(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
-        mock_url = f"hppd://{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(qtbot, mock_url)
+            self.query_server(qtbot, f"hppd://{self.host}:{self.port}")
             mock_critical.assert_called_once()
 
     def test_invalid_url(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
-        mock_url = f"{self.scheme}://???{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(qtbot, mock_url)
+            self.query_server(qtbot, f"{self.scheme}://???{self.host}:{self.port}")
             mock_critical.assert_called_once()
 
     def test_connection_error(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
-        mock_url = f"{self.scheme}://.....{self.host}:{self.port}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(qtbot, mock_url)
+            self.query_server(qtbot, f"{self.scheme}://.....{self.host}:{self.port}")
             mock_critical.assert_called_once()
 
     @pytest.mark.skip("Breaks other tests in this class because of a lingering message box, for some reason")
@@ -171,9 +166,9 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert that an aborted getmap call does not change the displayed image
         """
         self.query_server(qtbot, self.url)
-        QtTest.QTest.keyClick(self.window.pdlg, QtCore.Qt.Key_Enter)
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
+            QtTest.QTest.keyClick(self.window.pdlg, QtCore.Qt.Key_Enter)
         assert self.view.draw_image.call_count == 0
         assert self.view.draw_legend.call_count == 0
         assert self.view.draw_metadata.call_count == 0

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -148,8 +148,8 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
             mock_critical.assert_called_once()
 
     @pytest.mark.skip("Breaks other tests in this class because of a lingering message box, for some reason")
-    def test_forward_backward_clicks(self):
-        self.query_server(self.url)
+    def test_forward_backward_clicks(self, qtbot):
+        self.query_server(qtbot, self.url)
         self.window.init_time_back_click()
         self.window.init_time_fwd_click()
         self.window.valid_time_fwd_click()
@@ -170,7 +170,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that an aborted getmap call does not change the displayed image
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         QtTest.QTest.keyClick(self.window.pdlg, QtCore.Qt.Key_Enter)
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
@@ -246,7 +246,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that multilayers get created, handled and drawn properly
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
@@ -283,8 +283,8 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
 
-    def test_filter_handling(self):
-        self.query_server(self.url)
+    def test_filter_handling(self, qtbot):
+        self.query_server(qtbot, self.url)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
@@ -328,7 +328,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that singlelayer mode behaves as expected
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
@@ -358,11 +358,11 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert self.view.draw_legend.call_count == 1
         assert self.view.draw_metadata.call_count == 1
 
-    def test_multilayer_syncing(self):
+    def test_multilayer_syncing(self, qtbot):
         """
         assert that synced layers share their options
         """
-        self.query_server(self.url)
+        self.query_server(qtbot, self.url)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
@@ -390,7 +390,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
 
     @mock.patch("mslib.msui.wms_control.WMSMapFetcher.moveToThread")
     def test_server_no_thread(self, mockthread, qtbot):
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         self.window.cbAutoUpdate.setCheckState(False)
@@ -423,7 +423,7 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
 
@@ -435,7 +435,7 @@ class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that drawing a layer through code doesn't fail for vsec
         """
-        self.query_server(self.url, qtbot)
+        self.query_server(qtbot, self.url)
         server = self.window.multilayers.listLayers.findItems(f"{self.url}/",
                                                               QtCore.Qt.MatchFixedString)[0]
         with qtbot.wait_signal(self.window.image_displayed):

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -102,13 +102,13 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         yield
         self._teardown()
 
-    def test_no_server(self):
+    def test_no_server(self, qtbot):
         """
         assert that a message box informs about server troubles
         """
         mock_url = f"{self.scheme}://{self.host}:{self.port-1}"
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as mock_critical:
-            self.query_server(mock_url)
+            self.query_server(qtbot, mock_url)
             mock_critical.assert_called_once()
 
     def test_no_schema(self):

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -183,7 +183,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self, qtbot, self.url)
+        self.query_server(qtbot, self.url)
 
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
@@ -196,7 +196,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that a getmap call to a WMS server displays an image
         """
-        self.query_server(self, qtbot, self.url)
+        self.query_server(qtbot, self.url)
 
         with qtbot.wait_signal(self.window.image_displayed):
             QtTest.QTest.mouseClick(self.window.btGetMap, QtCore.Qt.LeftButton)
@@ -218,7 +218,7 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         """
         assert that changing between servers still allows image retrieval
         """
-        self.query_server(self, qtbot, self.url)
+        self.query_server(qtbot, self.url)
 
         with mock.patch("PyQt5.QtWidgets.QMessageBox.critical") as qm_critical:
             with qtbot.wait_signal(self.window.cpdlg.canceled):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -46,10 +46,6 @@ def test_qWait_is_not_used_in_tests(request):
         if str(test_file) == request.fspath:
             # Skip the current file
             continue
-        if str(test_file.relative_to(request.config.rootdir)) == "tests/utils.py":
-            # Skip tests/utils.py
-            # This skip can be removed once wait_until_signal is no longer used
-            continue
         assert (
             "qWait(" not in test_file.read_text()
         ), "qWait is mentioned in {}".format(test_file.relative_to(request.config.rootdir))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,10 +26,8 @@
     limitations under the License.
 """
 import requests
-import time
 import fs
 
-from PyQt5 import QtTest
 from urllib.parse import urljoin
 from mslib.mscolab.server import register_user
 from flask import json
@@ -173,29 +171,6 @@ def is_url_response_ok(url):
         return response.status_code == 200
     except:  # noqa: E722
         return False
-
-
-def wait_until_signal(signal, timeout=5):
-    """
-    Blocks the calling thread until the signal emits or the timeout expires.
-    """
-    init_time = time.time()
-    finished = False
-
-    def done(*args):
-        nonlocal finished
-        finished = True
-
-    signal.connect(done)
-    while not finished and time.time() - init_time < timeout:
-        QtTest.QTest.qWait(100)
-
-    try:
-        signal.disconnect(done)
-    except TypeError:
-        pass
-    finally:
-        return finished
 
 
 class ExceptionMock:


### PR DESCRIPTION
**Purpose of PR?**: This issue concerns a potential race condition when using the `wait_until_signal` function for Qt testing.  The function has a limitation where it only starts listening for a specific signal after the code that should emit that signal has been called. so, we'll Replace occurrences of `tests.utils.wait_until_signal` with `qtbot.wait_signal`. Because `wait_signal` is a context manager from pytest-qt that does not have this issue.

Fixes #2156 
