### PR TITLE
test : remove double used function calls in test

### DIFF
--- a/tests/_test_mscolab/test_server.py
+++ b/tests/_test_mscolab/test_server.py
@@ -236,13 +236,13 @@ class Test_Server:
             fm, user = self._save_content(operation, self.userdata)
             time.sleep(1)
             fm.save_file(operation.id, "content2", user)
-            all_changes = fm.get_all_changes(operation.id, user)
             # the newest change is on index 0, because it has a recent created_at time
             response = test_client.get('/get_all_changes', data={"token": token,
                                                                  "op_id": operation.id})
             assert response.status_code == 200
             data = json.loads(response.data.decode('utf-8'))
-            assert len(data["changes"]) == 2
+            all_changes = data["changes"]
+            assert len(all_changes) == 2
             assert all_changes[0]["id"] == 2
             assert all_changes[0]["id"] > all_changes[1]["id"]
             assert all_changes[0]["created_at"] > all_changes[1]["created_at"]


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2254 
Refactor tests to remove double-used function calls


**Checklist:**
- [X] Bug fix. Fixes #2254 
- [ ] New feature (Non-API breaking changes that adds functionality)
- [X] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->