### PR TITLE
Stop ignoring some test files

### DIFF
--- a/.github/workflows/testing-all-oses.yml
+++ b/.github/workflows/testing-all-oses.yml
@@ -48,6 +48,4 @@ jobs:
       # I have no idea yet on why this happens and how to fix it.
       # Even a module level skip is not enough, they need to be completely ignored.
       # TODO: fix those tests and drop the ignores
-      run: micromamba run -n ci env QT_QPA_PLATFORM=offscreen pytest -v -n logical --durations=20 --cov=mslib
-        --ignore=tests/_test_msui/test_sideview.py --ignore=tests/_test_msui/test_topview.py --ignore=tests/_test_msui/test_wms_control.py
-        tests
+      run: micromamba run -n ci env QT_QPA_PLATFORM=offscreen pytest -v -n logical --durations=20 --cov=mslib tests


### PR DESCRIPTION
This PR is to keep an eye on if some other fix allows us to re-enable the test files that are skipped here: https://github.com/Open-MSS/MSS/blob/daf8f2ae64f9907c9e27114660659a5f5d1cb6d5/.github/workflows/testing-all-oses.yml#L52