### PR TITLE
Fix docker image creation from develop branch

### DIFF
--- a/.github/workflows/testing-develop.yml
+++ b/.github/workflows/testing-develop.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
     - develop
+  workflow_dispatch:
 
 jobs:
   test-develop:

--- a/.github/workflows/testing-scheduled.yml
+++ b/.github/workflows/testing-scheduled.yml
@@ -15,11 +15,12 @@ jobs:
           workflow: testing-stable.yml
           ref: stable
 
-  test-develop-scheduled:
-    uses:
-      ./.github/workflows/testing.yml
-    with:
-      branch_name: develop
-      event_name: ${{ github.event_name }}
-    secrets:
-      PAT: ${{ secrets.PAT }}
+  trigger-testing-develop:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: benc-uk/workflow-dispatch@v1.2.2
+        with:
+          workflow: testing-develop.yml
+          ref: develop

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,9 +42,21 @@ jobs:
         source /opt/conda/etc/profile.d/mamba.sh
         mamba install -n mss-${{ inputs.branch_name }}-env pyvirtualdisplay
 
-    - name: Always rebuild dependencies for scheduled builds
-      if: ${{ inputs.event_name == 'schedule' && inputs.branch_name == 'stable' && env.triggerdockerbuild != 'yes' }}
+    - name: Always rebuild dependencies for scheduled builds (started from testing-scheduled.yml)
+      if: ${{ inputs.event_name == 'workflow_dispatch' }}
       run: echo "triggerdockerbuild=yes" >> $GITHUB_ENV
+
+    - name: Invoke dockertesting image creation
+      # The image creation is intentionally only triggered for push events because
+      # scheduled tests should just check that new dependency versions do not break the
+      # tests, but should not update the image.
+      if: ${{ inputs.event_name == 'push' && env.triggerdockerbuild == 'yes' && matrix.order == 'normal' }}
+      uses: benc-uk/workflow-dispatch@v1.2.2
+      with:
+        workflow: Update Image testing-${{ inputs.branch_name }}
+        repo: Open-MSS/dockertesting
+        ref: main
+        token: ${{ secrets.PAT }}
 
     - name: Reinstall dependencies if changed
       if: ${{ env.triggerdockerbuild == 'yes' }}
@@ -76,12 +88,3 @@ jobs:
         git config --global --add safe.directory /__w/MSS/MSS
         mamba install -n ${{ env.mamba-env }} coveralls
         mamba run --no-capture-output -n ${{ env.mamba-env }} coveralls --service=github
-
-    - name: Invoke dockertesting image creation
-      if: ${{ !cancelled() && inputs.event_name == 'push' && env.triggerdockerbuild == 'yes' && matrix.order == 'normal' }}
-      uses: benc-uk/workflow-dispatch@v1.2.2
-      with:
-        workflow: Update Image testing-${{ inputs.branch_name }}
-        repo: Open-MSS/dockertesting
-        ref: main
-        token: ${{ secrets.PAT }}


### PR DESCRIPTION
This changes the testing-develop.yml workflow to be triggered via workflow_dispatch, as is also already done for testing-stable.yml, and changes the logic in testing.yml to always rebuild the environment for runs triggered by workflow_dispatch, while only triggering image rebuilds on push events.

Part of a fix for #2258.