### PR TITLE
Fix docker image creation from stable branch

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,6 @@
 name: Pytest MSS
 
-on:                                                                                  
+on:
   workflow_call:
     inputs:
       xdist:
@@ -50,10 +50,21 @@ jobs:
         source /opt/conda/etc/profile.d/mamba.sh
         mamba install -n mss-${{ inputs.branch_name }}-env pyvirtualdisplay
 
-    - name: Always rebuild dependencies for scheduled builds
-      if: ${{ success() && inputs.event_name == 'schedule' && inputs.branch_name == 'stable' && env.triggerdockerbuild != 'yes' }}
-      run: |
-        echo "triggerdockerbuild=yes" >> $GITHUB_ENV
+    - name: Always rebuild dependencies for scheduled builds (started from testing-scheduled.yml)
+      if: ${{ inputs.event_name == 'workflow_dispatch' }}
+      run: echo "triggerdockerbuild=yes" >> $GITHUB_ENV
+
+    - name: Invoke dockertesting image creation
+      # The image creation is intentionally only triggered for push events because
+      # scheduled tests should just check that new dependency versions do not break the
+      # tests, but should not update the image.
+      if: ${{ inputs.event_name == 'push' && env.triggerdockerbuild == 'yes' && inputs.xdist == 'no' }}
+      uses: benc-uk/workflow-dispatch@v1.2.2
+      with:
+        workflow: Update Image testing-${{ inputs.branch_name }}
+        repo: Open-MSS/dockertesting
+        ref: main
+        token: ${{ secrets.PAT }}
 
     - name: Reinstall dependencies if changed
       if: ${{ success() && env.triggerdockerbuild == 'yes' }}
@@ -111,7 +122,7 @@ jobs:
 
     - name: Collect coverage
       if: ${{ success() && inputs.event_name == 'push' && inputs.branch_name == 'develop' && inputs.xdist == 'no'}}
-      env: 
+      env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE \
@@ -120,12 +131,3 @@ jobs:
         && mamba activate mss-${{ inputs.branch_name }}-env \
         && mamba install coveralls \
         && coveralls --service=github
-
-    - name: Invoke dockertesting image creation
-      if: ${{ always() && inputs.event_name == 'push' && env.triggerdockerbuild == 'yes' && inputs.xdist == 'no'}}
-      uses: benc-uk/workflow-dispatch@v1.2.2
-      with:
-        workflow: Update Image testing-${{ inputs.branch_name }}
-        repo: Open-MSS/dockertesting
-        ref: main
-        token: ${{ secrets.PAT }}


### PR DESCRIPTION
This changes the logic in testing.yml to always rebuild the environment for runs triggered by workflow_dispatch, while only triggering image rebuilds on push events.

Part of a fix for #2258.