### PR TITLE
DateTime elements have seconds precision, optimized for fractions

### DIFF
--- a/mslib/mscolab/chat_manager.py
+++ b/mslib/mscolab/chat_manager.py
@@ -64,7 +64,7 @@ class ChatManager:
         if timestamp is None:
             timestamp = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
         else:
-            timestamp = datetime.datetime.strptime(timestamp, "%Y-%m-%d, %H:%M:%S %z")
+            timestamp = datetime.datetime.strptime(timestamp, "%Y-%m-%d, %H:%M:%S.%f %z")
         messages = Message.query \
             .filter(Message.op_id == op_id) \
             .filter(Message.reply_id.is_(None)) \

--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -399,7 +399,7 @@ class FileManager:
             'comment': change.comment,
             'version_name': change.version_name,
             'username': change.user.username,
-            'created_at': change.created_at.strftime("%Y-%m-%d, %H:%M:%S %z")
+            'created_at': change.created_at.strftime("%Y-%m-%d, %H:%M:%S.%f %z")
         }, changes))
 
     def get_change_content(self, ch_id, user):

--- a/mslib/mscolab/models.py
+++ b/mslib/mscolab/models.py
@@ -37,7 +37,7 @@ from mslib.mscolab.message_type import MessageType
 
 
 class AwareDateTime(sqlalchemy.types.TypeDecorator):
-    impl = sqlalchemy.types.TIMESTAMP
+    impl = sqlalchemy.types.DateTime
     cache_ok = True
 
     def process_bind_param(self, value, dialect):

--- a/mslib/mscolab/models.py
+++ b/mslib/mscolab/models.py
@@ -37,7 +37,7 @@ from mslib.mscolab.message_type import MessageType
 
 
 class AwareDateTime(sqlalchemy.types.TypeDecorator):
-    impl = sqlalchemy.types.DateTime
+    impl = sqlalchemy.types.TIMESTAMP
     cache_ok = True
 
     def process_bind_param(self, value, dialect):

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -369,7 +369,7 @@ def messages():
     user = g.user
     op_id = request.args.get("op_id", request.form.get("op_id", None))
     if fm.is_member(user.id, op_id):
-        timestamp = request.args.get("timestamp", request.form.get("timestamp", "1970-01-01, 00:00:00.000 +00:00"))
+        timestamp = request.args.get("timestamp", request.form.get("timestamp", "1970-01-01, 00:00:00.000000 +00:00"))
         chat_messages = cm.get_messages(op_id, timestamp)
         return jsonify({"messages": chat_messages})
     return "False"

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -369,7 +369,7 @@ def messages():
     user = g.user
     op_id = request.args.get("op_id", request.form.get("op_id", None))
     if fm.is_member(user.id, op_id):
-        timestamp = request.args.get("timestamp", request.form.get("timestamp", "1970-01-01, 00:00:00 +00:00"))
+        timestamp = request.args.get("timestamp", request.form.get("timestamp", "1970-01-01, 00:00:00.000 +00:00"))
         chat_messages = cm.get_messages(op_id, timestamp)
         return jsonify({"messages": chat_messages})
     return "False"

--- a/mslib/mscolab/utils.py
+++ b/mslib/mscolab/utils.py
@@ -55,7 +55,7 @@ def get_message_dict(message):
         "message_type": message.message_type,
         "reply_id": message.reply_id,
         "replies": [],
-        "time": message.created_at.strftime("%Y-%m-%d, %H:%M:%S %z")
+        "time": message.created_at.strftime("%Y-%m-%d, %H:%M:%S.%f %z")
     }
 
 

--- a/mslib/msui/mscolab_chat.py
+++ b/mslib/msui/mscolab_chat.py
@@ -349,7 +349,8 @@ class MSColabChatWindow(QtWidgets.QMainWindow, ui.Ui_MscolabOperation):
         data = {
             "token": self.token,
             "op_id": self.op_id,
-            "timestamp": datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S %z")
+            "timestamp": datetime.datetime(1970, 1, 1,
+                                           tzinfo=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S.%f %z")
         }
         # returns an array of messages
         url = urljoin(self.mscolab_server_url, "messages")

--- a/mslib/msui/mscolab_version_history.py
+++ b/mslib/msui/mscolab_version_history.py
@@ -144,7 +144,7 @@ class MSColabVersionHistory(QtWidgets.QMainWindow, ui.Ui_MscolabVersionHistory):
                 changes = json.loads(r.text)["changes"]
                 self.changes.clear()
                 for change in changes:
-                    created_at = datetime.strptime(change["created_at"], "%Y-%m-%d, %H:%M:%S %z")
+                    created_at = datetime.strptime(change["created_at"], "%Y-%m-%d, %H:%M:%S.%f %z")
                     local_time = utc_to_local_datetime(created_at)
                     date = local_time.strftime('%d/%m/%Y')
                     time = local_time.strftime('%I:%M %p')

--- a/tests/_test_mscolab/test_files_api.py
+++ b/tests/_test_mscolab/test_files_api.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import time
 import fs
 import pytest
 
@@ -172,8 +171,6 @@ class Test_Files:
         with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="V11")
             assert self.fm.save_file(operation.id, "content1", self.user)
-            # we need to wait to get an updated created_at
-            time.sleep(1)
             assert self.fm.save_file(operation.id, "content2", self.user)
             all_changes = self.fm.get_all_changes(operation.id, self.user)
             # the newest change is on index 0, because it has a recent created_at time
@@ -186,9 +183,7 @@ class Test_Files:
         with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="V12", content='initial')
             assert self.fm.save_file(operation.id, "content1", self.user)
-            time.sleep(1)
             assert self.fm.save_file(operation.id, "content2", self.user)
-            time.sleep(1)
             assert self.fm.save_file(operation.id, "content3", self.user)
             all_changes = self.fm.get_all_changes(operation.id, self.user)
             previous_change = self.fm.get_change_content(all_changes[2]["id"], self.user)

--- a/tests/_test_mscolab/test_server.py
+++ b/tests/_test_mscolab/test_server.py
@@ -24,7 +24,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import time
 import pytest
 import json
 import io
@@ -234,7 +233,6 @@ class Test_Server:
         with self.app.test_client() as test_client:
             operation, token = self._create_operation(test_client, self.userdata)
             fm, user = self._save_content(operation, self.userdata)
-            time.sleep(1)
             fm.save_file(operation.id, "content2", user)
             # the newest change is on index 0, because it has a recent created_at time
             response = test_client.get('/get_all_changes', data={"token": token,
@@ -252,8 +250,6 @@ class Test_Server:
         with self.app.test_client() as test_client:
             operation, token = self._create_operation(test_client, self.userdata)
             fm, user = self._save_content(operation, self.userdata)
-            # we need to wait to get an updated created_at
-            time.sleep(1)
             fm.save_file(operation.id, "content2", user)
             all_changes = fm.get_all_changes(operation.id, user)
             response = test_client.get('/get_change_content', data={"token": token,

--- a/tests/_test_mscolab/test_sockets_manager.py
+++ b/tests/_test_mscolab/test_sockets_manager.py
@@ -191,11 +191,12 @@ class Test_Socket_Manager:
             assert messages[0]["text"] == "message from 1"
             assert len(messages) == 2
             assert messages[0]["u_id"] == self.user.id
-            timestamp = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S %z")
+            timestamp = datetime.datetime(1970, 1, 1,
+                                          tzinfo=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S.%f %z")
             messages = self.cm.get_messages(1, timestamp)
             assert len(messages) == 2
             assert messages[0]["u_id"] == self.user.id
-            timestamp = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S %z")
+            timestamp = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S.%f %z")
             messages = self.cm.get_messages(1, timestamp)
             assert len(messages) == 0
 
@@ -221,7 +222,8 @@ class Test_Socket_Manager:
         data = {
             "token": token,
             "op_id": self.operation.id,
-            "timestamp": datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S %z")
+            "timestamp": datetime.datetime(1970, 1, 1,
+                                           tzinfo=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S.%f %z")
         }
         # returns an array of messages
         url = urljoin(self.url, 'messages')
@@ -257,7 +259,8 @@ class Test_Socket_Manager:
         data = {
             "token": token,
             "op_id": self.operation.id,
-            "timestamp": datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S %z")
+            "timestamp": datetime.datetime(1970, 1, 1,
+                                           tzinfo=datetime.timezone.utc).strftime("%Y-%m-%d, %H:%M:%S.%f %z")
         }
         # returns an array of messages
         url = urljoin(self.url, 'messages')


### PR DESCRIPTION
Timestamp elements have milliseconds precision in SQLite, and microsecond precision in SAP HANA and PostgreSQL.
DateTime elements have seconds precision, that was the cause we need to wait a second.

**Purpose of PR?**:

Fixes #2245 

**Does this PR introduce a breaking change?**
Change to precission of Timestamps

https://cap.cloud.sap/docs/guides/databases-sqlite