### PR TITLE
Fix: Multiple flightpath dockingwidget updates only local new flighpathes

### DIFF
--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -33,6 +33,7 @@ import fs.opener.errors
 import requests.exceptions
 import mock
 import pytest
+import random
 
 import mslib.utils.auth
 from mslib.mscolab.conf import mscolab_settings
@@ -433,30 +434,18 @@ class Test_Mscolab:
             assert len(self.window.get_active_views()) == 1
         qtbot.wait_until(assert_active_views)
         topview_0 = self.window.listViews.item(0)
+        assert topview_0.window.tv_window_exists is True
+        topview_0.window.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         # open multiple flightpath
         topview_0.window.cbTools.currentIndexChanged.emit(6)
 
         # activate all operation, this enables them in the docking widget too
-        for _ in range(4):
-            self._activate_operation_at_index(1)
-            self._activate_operation_at_index(2)
-            self._activate_operation_at_index(0)
-        # ToDo refactor to be able to activate/deactivate by the docking widget and that it can be checked
-
-        self._activate_flight_track_at_index(0)
-        with mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes):
-            topview_0.window.close()
-
-        def assert_window_closed():
-            ref = weakref.ref(topview_0.window)
-            assert ref() is None
-        qtbot.wait_until(assert_window_closed)
-
-        def assert_label_text():
-            # verify logged in
-            assert self.window.usernameLabel.text() == self.userdata[1]
-        qtbot.wait_until(assert_label_text)
+        for _ in range(6):
+            self._activate_operation_at_index(random.randint(0, 2))
+            self._activate_operation_at_index(random.randint(0, 2))
+            self._activate_operation_at_index(random.randint(0, 2))
+            self._activate_flight_track_at_index(0)
 
         self.window.mscolab.logout()
 
@@ -464,11 +453,11 @@ class Test_Mscolab:
             assert self.window.usernameLabel.text() == "User"
         qtbot.wait_until(assert_logout_text)
 
-        self._connect_to_mscolab(qtbot)
-        self._login(qtbot, emailid=self.userdata[0], password=self.userdata[2])
-        # verify logged in again
-        qtbot.wait_until(assert_label_text)
-        # ToDo verify all operations disabled again without a visual check
+        with pytest.raises(TypeError):
+            for _ in range(6):
+                self._activate_operation_at_index(random.randint(0, 2))
+                self._activate_operation_at_index(random.randint(0, 2))
+                self._activate_operation_at_index(random.randint(0, 2))
 
     @mock.patch("PyQt5.QtWidgets.QFileDialog.getSaveFileName",
                 return_value=(fs.path.join(mscolab_settings.MSCOLAB_DATA_DIR, 'test_export.ftml'),

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -26,7 +26,6 @@
 """
 import os
 import sys
-import weakref
 import fs
 import fs.errors
 import fs.opener.errors
@@ -433,9 +432,9 @@ class Test_Mscolab:
             # check 1 view opened
             assert len(self.window.get_active_views()) == 1
         qtbot.wait_until(assert_active_views)
+
         topview_0 = self.window.listViews.item(0)
         assert topview_0.window.tv_window_exists is True
-        topview_0.window.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
         # open multiple flightpath
         topview_0.window.cbTools.currentIndexChanged.emit(6)
@@ -443,21 +442,22 @@ class Test_Mscolab:
         # activate all operation, this enables them in the docking widget too
         for _ in range(6):
             self._activate_operation_at_index(random.randint(0, 2))
-            self._activate_operation_at_index(random.randint(0, 2))
-            self._activate_operation_at_index(random.randint(0, 2))
-            self._activate_flight_track_at_index(0)
+        self._activate_flight_track_at_index(0)
+
+        # Create the new operation
+        op_name = "fourth"
+        assert add_operation(op_name, "description")
+        assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+
+        for _ in range(4):
+            self._activate_operation_at_index(random.randint(0, 3))
+        self._activate_flight_track_at_index(0)
 
         self.window.mscolab.logout()
 
         def assert_logout_text():
             assert self.window.usernameLabel.text() == "User"
         qtbot.wait_until(assert_logout_text)
-
-        with pytest.raises(TypeError):
-            for _ in range(6):
-                self._activate_operation_at_index(random.randint(0, 2))
-                self._activate_operation_at_index(random.randint(0, 2))
-                self._activate_operation_at_index(random.randint(0, 2))
 
     @mock.patch("PyQt5.QtWidgets.QFileDialog.getSaveFileName",
                 return_value=(fs.path.join(mscolab_settings.MSCOLAB_DATA_DIR, 'test_export.ftml'),

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -415,15 +415,6 @@ class Test_Mscolab:
     def test_operation_while_switching_error(self, qtbot):
         """Test that operation switching trigger the KeyError"""
 
-        # more operations for the user
-        for op_name in ["second", "third"]:
-            assert add_operation(op_name, "description")
-            assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
-
-        self._connect_to_mscolab(qtbot)
-        modify_config_file({"MSS_auth": {self.url: self.userdata[0]}})
-        self._login(qtbot, emailid=self.userdata[0], password=self.userdata[2])
-
         # test after activating operation
         self._activate_operation_at_index(0)
         self.window.actionTopView.trigger()
@@ -435,23 +426,48 @@ class Test_Mscolab:
 
         topview_0 = self.window.listViews.item(0)
         assert topview_0.window.tv_window_exists is True
+        # topview_0.window.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+
+        # def assert_attribute():
+        #     assert topview_0.window.testAttribute(QtCore.Qt.WA_DeleteOnClose)
+        # qtbot.wait_until(assert_attribute)
 
         # open multiple flightpath
         topview_0.window.cbTools.currentIndexChanged.emit(6)
+
+        def assert_dock_loaded():
+            assert topview_0.window.docks[5] is not None
+        qtbot.wait_until(assert_dock_loaded)
+
+        # more operations for the user
+        for op_name in ["second", "third"]:
+            assert add_operation(op_name, "description")
+            assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+
+        self._connect_to_mscolab(qtbot)
+        modify_config_file({"MSS_auth": {self.url: self.userdata[0]}})
+        self._login(qtbot, emailid=self.userdata[0], password=self.userdata[2])
 
         # activate all operation, this enables them in the docking widget too
         for _ in range(6):
             self._activate_operation_at_index(random.randint(0, 2))
         self._activate_flight_track_at_index(0)
 
-        # Create the new operation
-        op_name = "fourth"
-        assert add_operation(op_name, "description")
-        assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+        # # Create the new operation
+        # op_name = "fourth"
+        # assert add_operation(op_name, "description")
+        # assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+        #
+        # for _ in range(4):
+        #     self._activate_operation_at_index(random.randint(0, 3))
+        # self._activate_flight_track_at_index(0)
 
-        for _ in range(4):
-            self._activate_operation_at_index(random.randint(0, 3))
-        self._activate_flight_track_at_index(0)
+        with mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes):
+            topview_0.window.close()
+
+        def assert_window_closed():
+            assert topview_0.window.tv_window_exists is False
+        qtbot.wait_until(assert_window_closed)
 
         self.window.mscolab.logout()
 

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -26,6 +26,7 @@
 """
 import os
 import sys
+import weakref
 import fs
 import fs.errors
 import fs.opener.errors
@@ -393,6 +394,64 @@ class Test_Mscolab:
         self._activate_operation_at_index(2)
         self._activate_operation_at_index(0)
         # ToDo refactor to be able to activate/deactivate by the docking widget and that it can be checked
+
+        def assert_label_text():
+            # verify logged in
+            assert self.window.usernameLabel.text() == self.userdata[1]
+        qtbot.wait_until(assert_label_text)
+
+        self.window.mscolab.logout()
+
+        def assert_logout_text():
+            assert self.window.usernameLabel.text() == "User"
+        qtbot.wait_until(assert_logout_text)
+
+        self._connect_to_mscolab(qtbot)
+        self._login(qtbot, emailid=self.userdata[0], password=self.userdata[2])
+        # verify logged in again
+        qtbot.wait_until(assert_label_text)
+        # ToDo verify all operations disabled again without a visual check
+
+    def test_operation_while_switching_error(self, qtbot):
+        """Test that operation switching trigger the KeyError"""
+
+        # more operations for the user
+        for op_name in ["second", "third"]:
+            assert add_operation(op_name, "description")
+            assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+
+        self._connect_to_mscolab(qtbot)
+        modify_config_file({"MSS_auth": {self.url: self.userdata[0]}})
+        self._login(qtbot, emailid=self.userdata[0], password=self.userdata[2])
+
+        # test after activating operation
+        self._activate_operation_at_index(0)
+        self.window.actionTopView.trigger()
+
+        def assert_active_views():
+            # check 1 view opened
+            assert len(self.window.get_active_views()) == 1
+        qtbot.wait_until(assert_active_views)
+        topview_0 = self.window.listViews.item(0)
+
+        # open multiple flightpath
+        topview_0.window.cbTools.currentIndexChanged.emit(6)
+
+        # activate all operation, this enables them in the docking widget too
+        for _ in range(4):
+            self._activate_operation_at_index(1)
+            self._activate_operation_at_index(2)
+            self._activate_operation_at_index(0)
+        # ToDo refactor to be able to activate/deactivate by the docking widget and that it can be checked
+
+        self._activate_flight_track_at_index(0)
+        with mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes):
+            topview_0.window.close()
+
+        def assert_window_closed():
+            ref = weakref.ref(topview_0.window)
+            assert ref() is None
+        qtbot.wait_until(assert_window_closed)
 
         def assert_label_text():
             # verify logged in
@@ -828,3 +887,12 @@ class Test_Mscolab:
         point = self.window.listOperationsMSC.visualItemRect(item).center()
         QtTest.QTest.mouseClick(self.window.listOperationsMSC.viewport(), QtCore.Qt.LeftButton, pos=point)
         QtTest.QTest.mouseDClick(self.window.listOperationsMSC.viewport(), QtCore.Qt.LeftButton, pos=point)
+
+    def _activate_flight_track_at_index(self, index):
+        # The main window must be on top
+        self.window.activateWindow()
+        # get the item by its index
+        item = self.window.listFlightTracks.item(index)
+        point = self.window.listFlightTracks.visualItemRect(item).center()
+        QtTest.QTest.mouseClick(self.window.listFlightTracks.viewport(), QtCore.Qt.LeftButton, pos=point)
+        QtTest.QTest.mouseDClick(self.window.listFlightTracks.viewport(), QtCore.Qt.LeftButton, pos=point)


### PR DESCRIPTION
**Purpose of PR?**:
I am able to reproduce the error (e.g., KeyError: 10, AttributeError: 'NoneType' object has no attribute 'all_waypoint_data') by creating or deleting operations, followed by attempting to switch operations. Sometimes the error does occurs but sometimes if i do sometime differently it doesn't occurs. In this PR i am trying to figure out the bug and fix it.

Fixes #2269 

**Checklist:**
- [X] Bug fix. Fixes #2269 
