### PR TITLE
fix: exception improved

### DIFF
--- a/mslib/msui/constants.py
+++ b/mslib/msui/constants.py
@@ -37,8 +37,9 @@ MSUI_CONFIG_PATH = os.getenv("MSUI_CONFIG_PATH", os.path.join(HOME, ".config", "
 if '://' in MSUI_CONFIG_PATH:
     try:
         _fs = fs.open_fs(MSUI_CONFIG_PATH)
-    except fs.errors.CreateFailed:
         _fs.makedirs(MSUI_CONFIG_PATH)
+    except fs.errors.CreateFailed:
+        logging.error('FS url "%s" create dir nor supported', MSUI_CONFIG_PATH)
     except fs.opener.errors.UnsupportedProtocol:
         logging.error('FS url "%s" not supported', MSUI_CONFIG_PATH)
 else:


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2274

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

behaviour can be checked by 

```
import logging
import fs

def test_fs_path_not_existing():
    test_path = ("ftp://ftp.de.debian.org/debian/.config/msui", "foo://ftp.de.debian.org/debian/.config/msui")
    for fsurl in test_path:
        try:
            _fs = fs.open_fs(fsurl)
            _fs.makedirs(fsurl)
        except fs.errors.CreateFailed:
            logging.error('FS url "%s" create dir nor supported', fsurl)
            assert "_fs" not in locals()

        except fs.opener.errors.UnsupportedProtocol:
            logging.error('FS url "%s" not supported', fsurl)
            assert "_fs" not in locals()
```


**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [X] Bug fix. Fixes #2274
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->