### PR TITLE
Fix creation logic for MSUI_CONFIG_PATH

### DIFF
--- a/mslib/msui/constants.py
+++ b/mslib/msui/constants.py
@@ -34,17 +34,8 @@ import logging
 # ToDo refactor to generic functions, keep only constants
 HOME = os.path.expanduser(f"~{os.path.sep}")
 MSUI_CONFIG_PATH = os.getenv("MSUI_CONFIG_PATH", os.path.join(HOME, ".config", "msui"))
-if '://' in MSUI_CONFIG_PATH:
-    try:
-        _fs = fs.open_fs(MSUI_CONFIG_PATH)
-    except fs.errors.CreateFailed:
-        _fs.makedirs(MSUI_CONFIG_PATH)
-    except fs.opener.errors.UnsupportedProtocol:
-        logging.error('FS url "%s" not supported', MSUI_CONFIG_PATH)
-else:
-    _dir = os.path.expanduser(MSUI_CONFIG_PATH)
-    if not os.path.exists(_dir):
-        os.makedirs(_dir)
+# Make sure that MSUI_CONFIG_PATH exists
+_ = fs.open_fs(MSUI_CONFIG_PATH, create=True)
 
 GRAVATAR_DIR_PATH = fs.path.join(MSUI_CONFIG_PATH, "gravatars")
 


### PR DESCRIPTION
Fixes #2274.

Simpler alternative proposal to #2341.

This works under the assumption that this block of code is just intended to make sure that MSUI_CONFIG_PATH exists (which is the only logical thing I could make out of it).

The distinction between when the variable contains `://` and when it does not (which is flawed anyway, since a normal path is allowed to contain that) is not necessary, because `fs.open_fs` can just handle both (it treats the case without `<scheme>://` as `osfs://`).