### PR TITLE
Fix leftover directories after tests

### DIFF
--- a/mslib/msui/constants.py
+++ b/mslib/msui/constants.py
@@ -35,7 +35,9 @@ import logging
 HOME = os.path.expanduser(f"~{os.path.sep}")
 MSUI_CONFIG_PATH = os.getenv("MSUI_CONFIG_PATH", os.path.join(HOME, ".config", "msui"))
 # Make sure that MSUI_CONFIG_PATH exists
-_ = fs.open_fs(MSUI_CONFIG_PATH, create=True)
+_fs = fs.open_fs(MSUI_CONFIG_PATH, create=True)
+# MSUI does not actually support any PyFilesystem2 fs that is not available as a local path
+MSUI_CONFIG_SYSPATH = _fs.getsyspath("")
 
 GRAVATAR_DIR_PATH = fs.path.join(MSUI_CONFIG_PATH, "gravatars")
 

--- a/mslib/msui/constants.py
+++ b/mslib/msui/constants.py
@@ -30,6 +30,7 @@
 import fs
 import os
 import logging
+import platformdirs
 
 # ToDo refactor to generic functions, keep only constants
 HOME = os.path.expanduser(f"~{os.path.sep}")
@@ -38,6 +39,8 @@ MSUI_CONFIG_PATH = os.getenv("MSUI_CONFIG_PATH", os.path.join(HOME, ".config", "
 _fs = fs.open_fs(MSUI_CONFIG_PATH, create=True)
 # MSUI does not actually support any PyFilesystem2 fs that is not available as a local path
 MSUI_CONFIG_SYSPATH = _fs.getsyspath("")
+
+MSUI_CACHE_PATH = platformdirs.user_cache_path("msui", "mss")
 
 GRAVATAR_DIR_PATH = fs.path.join(MSUI_CONFIG_PATH, "gravatars")
 

--- a/mslib/utils/config.py
+++ b/mslib/utils/config.py
@@ -32,7 +32,6 @@ import json
 import logging
 import fs
 import os
-import tempfile
 
 from mslib.utils import FatalUserError
 from mslib.msui import constants
@@ -149,8 +148,7 @@ class MSUIDefaultConfig:
     WMS_preload = []
 
     # WMS image cache settings:
-    # this changes on any start of msui, use ths msui_settings.json when you want a persistent path
-    wms_cache = os.path.join(tempfile.TemporaryDirectory().name, "msui_wms_cache")
+    wms_cache = str(constants.MSUI_CACHE_PATH / "wms_cache")
 
     # Maximum size of the cache in bytes.
     wms_cache_max_size_bytes = 20 * 1024 * 1024

--- a/mslib/utils/config.py
+++ b/mslib/utils/config.py
@@ -25,8 +25,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-
-import sys
 from PyQt5 import QtCore
 
 import copy
@@ -457,7 +455,7 @@ def config_loader(dataset=None, default=False):
         return user_options
 
 
-def save_settings_qsettings(tag, settings, ignore_test=False):
+def save_settings_qsettings(tag, settings):
     """
     Saves a dictionary settings to disk.
 
@@ -467,10 +465,8 @@ def save_settings_qsettings(tag, settings, ignore_test=False):
     """
     assert isinstance(tag, str)
     assert isinstance(settings, dict)
-    if not ignore_test and ("pytest" in sys.modules):
-        return settings
     # ToDo we have to verify if we can all switch to this definition, not having 3 different
-    q_settings = QtCore.QSettings(os.path.join(constants.MSUI_CONFIG_PATH, "msui-core.conf"),
+    q_settings = QtCore.QSettings(os.path.join(constants.MSUI_CONFIG_SYSPATH, "msui-core.conf"),
                                   QtCore.QSettings.IniFormat)
 
     file_path = q_settings.fileName()
@@ -482,7 +478,7 @@ def save_settings_qsettings(tag, settings, ignore_test=False):
     return settings
 
 
-def load_settings_qsettings(tag, default_settings=None, ignore_test=False):
+def load_settings_qsettings(tag, default_settings=None):
     """
     Loads a dictionary of settings from disk. May supply a dictionary of default settings
     to return in case the settings file is not present or damaged. The default_settings one will
@@ -496,12 +492,10 @@ def load_settings_qsettings(tag, default_settings=None, ignore_test=False):
     if default_settings is None:
         default_settings = {}
     assert isinstance(default_settings, dict)
-    if not ignore_test and "pytest" in sys.modules:
-        return default_settings
 
     settings = {}
 
-    q_settings = QtCore.QSettings(os.path.join(constants.MSUI_CONFIG_PATH, "msui-core.conf"),
+    q_settings = QtCore.QSettings(os.path.join(constants.MSUI_CONFIG_SYSPATH, "msui-core.conf"),
                                   QtCore.QSettings.IniFormat)
     file_path = q_settings.fileName()
     logging.debug("loading settings for %s from %s", tag, file_path)

--- a/tests/_test_utils/test_config.py
+++ b/tests/_test_utils/test_config.py
@@ -49,12 +49,12 @@ class TestSettingsSave:
 
     def test_save_settings(self):
         settings = {'foo': 'bar'}
-        config.save_settings_qsettings(self.tag, settings, ignore_test=True)
+        config.save_settings_qsettings(self.tag, settings)
 
     def test_load_settings(self):
         settings = {'foo': 'bar'}
-        config.save_settings_qsettings(self.tag, settings, ignore_test=True)
-        settings = config.load_settings_qsettings(self.tag, ignore_test=True)
+        config.save_settings_qsettings(self.tag, settings)
+        settings = config.load_settings_qsettings(self.tag)
         assert isinstance(settings, dict)
         assert settings["foo"] == "bar"
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -27,6 +27,7 @@
 
 import os
 import fs
+import tempfile
 from fs.tempfs import TempFS
 
 try:
@@ -59,6 +60,9 @@ MSUI_CONFIG_PATH = OSFS_URL
 # MSUI_CONFIG_PATH = SERVER_CONFIG_FS.getsyspath("") would use a none osfs path
 os.environ["MSUI_CONFIG_PATH"] = MSUI_CONFIG_PATH
 SERVER_CONFIG_FILE_PATH = fs.path.join(SERVER_CONFIG_FS.getsyspath(""), SERVER_CONFIG_FILE)
+
+_xdg_cache_home_temporary_directory = tempfile.TemporaryDirectory()
+os.environ["XDG_CACHE_HOME"] = _xdg_cache_home_temporary_directory.name
 
 # we keep DATA_DIR until we move netCDF4 files to pyfilesystem2
 DATA_DIR = DATA_FS.getsyspath("")


### PR DESCRIPTION
**Purpose of PR?**:

- Fix osfs:/ directory leftover in CWD after tests
- Fix leftover directories in /tmp after tests
    
    The way wms_cache was set previously made it so that after each tests
    run there would be one or more directories leftover in /tmp. This also
    happened for each start of MSUI. This change makes MSUI use the
    platform-specific cache directory of the user instead and sets
    XDG_CACHE_HOME to isolate those between test runs.

Fixes #2148.

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->