### PR TITLE
add future to environment of RTFD

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -21,6 +21,7 @@ dependencies:
       - netCDF4
       - PyQt5
       - owslib
+      - future
   - basemap >=1.3.3
   - pint
   - python <3.12


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2378 

We should later find a better solution than this, maybe latest tag. 

MSS gets not installed on RTFD so we can't import but the repo is cloned.