### PR TITLE
a user archived operation uses sys.maxsize in days

### DIFF
--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -1710,7 +1710,8 @@ class MSUIMscolab(QtCore.QObject):
                 data = {
                     "token": self.token,
                     "op_id": self.active_op_id,
-                    "days": 31,
+                    # when a user archives an operation we set the max “natural” integer in days
+                    "days": sys.maxsize,
                 }
                 url = urljoin(self.mscolab_server_url, 'set_last_used')
                 try:


### PR DESCRIPTION
this should keep it archived also when a server sets the threshold to a few years

**Purpose of PR?**:

Fixes #2403 

