### PR TITLE
chore: fix docs URL in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Current release info
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6572620.svg)](https://doi.org/10.5281/zenodo.6572620)
 [![JuRSE Code Pick](https://img.shields.io/badge/JuRSE_Code_Pick-July_2024-blue)](https://www.fz-juelich.de/en/rse/jurse-community/jurse-code-of-the-month/july-2024)
 [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mss.svg)](https://anaconda.org/conda-forge/mss)
-[![DOCS](https://img.shields.io/badge/%F0%9F%95%AE-docs-green.svg)](http://mss.rtd.io)
+[![DOCS](https://img.shields.io/badge/%F0%9F%95%AE-docs-green.svg)](https://mss.rtfd.io)
 [![Conda Recipe](https://img.shields.io/badge/recipe-mss-green.svg)](https://anaconda.org/conda-forge/mss)
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mss.svg)](https://anaconda.org/conda-forge/mss)
 [![Coverage Status](https://coveralls.io/repos/github/Open-MSS/MSS/badge.svg?branch=develop)](https://coveralls.io/github/Open-MSS/MSS?branch=develop)


### PR DESCRIPTION
`rtd.io` is on longer (?) operational, according to [the project page](https://readthedocs.org/projects/mss/) the correct domain is either `rtfd.io` or the full `readthedocs.io`. Also switch to https.

**Purpose of PR?**:

Fix broken badge.

**Checklist:**
- [ ] Bug fix. Fixes #<too small to merit a separate issue>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [x] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->