### PR TITLE
Fix inconsistent SocketsManager objects

### DIFF
--- a/mslib/mscolab/mscolab.py
+++ b/mslib/mscolab/mscolab.py
@@ -45,15 +45,13 @@ from mslib.utils.qt import Worker, Updater
 
 
 def handle_start(args):
-    from mslib.mscolab.server import APP, initialize_managers, start_server
+    from mslib.mscolab.server import APP, sockio, cm, fm, start_server
     setup_logging(args)
     logging.info("MSS Version: %s", __version__)
     logging.info("Python Version: %s", sys.version)
     logging.info("Platform: %s (%s)", platform.platform(), platform.architecture())
     logging.info("Launching MSColab Server")
-
-    app, sockio, cm, fm = initialize_managers(APP)
-    start_server(app, sockio, cm, fm)
+    start_server(APP, sockio, cm, fm)
 
 
 def confirm_action(confirmation_prompt):

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -46,7 +46,7 @@ from flask.wrappers import Response
 
 from mslib.mscolab.conf import mscolab_settings, setup_saml2_backend
 from mslib.mscolab.models import Change, MessageType, User
-from mslib.mscolab.sockets_manager import setup_managers
+from mslib.mscolab.sockets_manager import _setup_managers
 from mslib.mscolab.utils import create_files, get_message_dict
 from mslib.utils import conditional_decorator
 from mslib.index import create_app
@@ -124,8 +124,8 @@ def confirm_token(token, expiration=3600):
     return email
 
 
-def initialize_managers(app):
-    sockio, cm, fm = setup_managers(app)
+def _initialize_managers(app):
+    sockio, cm, fm = _setup_managers(app)
     # initializing socketio and db
     app.wsgi_app = socketio.Middleware(socketio.server, app.wsgi_app)
     sockio.init_app(app)
@@ -133,7 +133,7 @@ def initialize_managers(app):
     return app, sockio, cm, fm
 
 
-_app, sockio, cm, fm = initialize_managers(APP)
+_app, sockio, cm, fm = _initialize_managers(APP)
 
 
 def check_login(emailid, password):

--- a/mslib/mscolab/sockets_manager.py
+++ b/mslib/mscolab/sockets_manager.py
@@ -262,7 +262,7 @@ class SocketsManager:
         socketio.emit("operation-deleted", json.dumps({"op_id": op_id}))
 
 
-def setup_managers(app):
+def _setup_managers(app):
     """
     takes app as parameter to extract config data,
     initializes ChatManager, FileManager, SocketManager and return them

--- a/tests/_test_mscolab/test_server.py
+++ b/tests/_test_mscolab/test_server.py
@@ -30,7 +30,7 @@ import io
 
 from mslib.mscolab.conf import mscolab_settings
 from mslib.mscolab.models import User, Operation
-from mslib.mscolab.server import initialize_managers, check_login, register_user
+from mslib.mscolab.server import check_login, register_user
 from mslib.mscolab.file_manager import FileManager
 from mslib.mscolab.seed import add_user, get_user
 
@@ -43,9 +43,9 @@ class Test_Server:
         with self.app.app_context():
             yield
 
-    def test_initialize_managers(self):
-        app, sockio, cm, fm = initialize_managers(self.app)
-        assert app.config['MSCOLAB_DATA_DIR'] == mscolab_settings.MSCOLAB_DATA_DIR
+    def test_initialized_managers(self, mscolab_managers):
+        sockio, cm, fm = mscolab_managers
+        assert self.app.config['MSCOLAB_DATA_DIR'] == mscolab_settings.MSCOLAB_DATA_DIR
         assert 'Create a Flask-SocketIO server.' in sockio.__doc__
         assert 'Class with handler functions for chat related functionalities' in cm.__doc__
         assert 'Class with handler functions for file related functionalities' in fm.__doc__

--- a/tests/_test_mscolab/test_sockets_manager.py
+++ b/tests/_test_mscolab/test_sockets_manager.py
@@ -43,7 +43,8 @@ class Test_Socket_Manager:
     @pytest.fixture(autouse=True)
     def setup(self, mscolab_app, mscolab_managers, mscolab_server):
         self.app = mscolab_app
-        _, self.cm, self.fm = mscolab_managers
+        sockio, self.cm, self.fm = mscolab_managers
+        self.sm = sockio.sm
         self.url = mscolab_server
         self.sockets = []
         self.userdata = 'UV10@uv10', 'UV10', 'uv10'
@@ -57,7 +58,6 @@ class Test_Socket_Manager:
         self.anotheruser = get_user(self.anotheruserdata[0])
         self.token = self.user.generate_auth_token()
         self.operation = get_operation(self.operation_name)
-        self.sm = SocketsManager(self.cm, self.fm)
         yield
         for sock in self.sockets:
             sock.disconnect()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -35,7 +35,7 @@ import eventlet.wsgi
 from PyQt5 import QtWidgets
 from contextlib import contextmanager
 from mslib.mscolab.conf import mscolab_settings
-from mslib.mscolab.server import APP, initialize_managers
+from mslib.mscolab.server import APP, sockio, cm, fm
 from mslib.mscolab.mscolab import handle_db_init, handle_db_reset
 from mslib.utils.config import modify_config_file
 from tests.utils import is_url_response_ok
@@ -104,7 +104,7 @@ def mscolab_session_managers(mscolab_session_app):
     This fixture should not be used in tests. Instead use :func:`mscolab_managers`,
     which handles per-test cleanup as well.
     """
-    return initialize_managers(mscolab_session_app)[1:]
+    return sockio, cm, fm
 
 
 @pytest.fixture(scope="session")
@@ -141,8 +141,7 @@ def mscolab_app(mscolab_session_app, reset_mscolab):
 def mscolab_managers(mscolab_session_managers, reset_mscolab):
     """Fixture that provides the MSColab managers and does cleanup actions.
 
-    :returns: A tuple (SocketIO, ChatManager, FileManager) as returned by
-        initialize_managers.
+    :returns: A tuple (SocketIO, ChatManager, FileManager).
     """
     return mscolab_session_managers
 


### PR DESCRIPTION
On import of mslib.mscolab.server initialize_managers was called once, hooking events up to handlers in a SocketsManager instance and initializing the Flask app with the Flask-SocketIO extension. Then, in handle_start, initialize_managers was called a second time, creating another SocketsManager object, overwriting the instance saved with the SocketIO object, and trying to initialize the Flask app with it again.

The last step does not work though, a Flask app can only be initialized once with each extension (i.e. the sockio.init_app(app) call can only be done once per Flask app object).

What this led to is that the Flask-SocketIO extension was using the first SocketsManager object to handle incoming events, while the server side was using the second SocketsManager object when it called methods on sockio.sm.

This changes the startup process to do the initialization just once.

This is more of a minimally-invasive band-aid to get it working for now; a proper fix would entail doing #2442 and getting the ability to build multiple app objects, IMO.