### PR TITLE
Fix tests failing due to socketio connection issues

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -28,6 +28,7 @@ import mock
 import multiprocessing
 import time
 import urllib
+import socketio
 import mslib.mswms.mswms
 import eventlet
 import eventlet.wsgi
@@ -107,7 +108,14 @@ def mscolab_session_managers(mscolab_session_app):
     return sockio, cm, fm
 
 
-@pytest.fixture(scope="session")
+# TODO: Having this fixture be autouse is a crutch. It seems like if it is not autouse some tests can bring the pytest
+# processes objects into a state in which the MSColab server will have trouble starting the Flask-SocketIO server once
+# it is forked. With autouse the fork happens first, before any test runs. After that, the pytest process can no longer
+# affect the now-running server, thus mitigating the issue. This is my understanding at time of writing.
+#
+# This issue would also be avoided if the background server process wasn't started with multiprocessing and a fork, but
+# with a real subprocess, which would solve some other issues (e.g. testing on Windows) as well.
+@pytest.fixture(scope="session", autouse=True)
 def mscolab_session_server(mscolab_session_app, mscolab_session_managers):
     """Session-scoped fixture that provides a running MSColab server.
 
@@ -115,6 +123,11 @@ def mscolab_session_server(mscolab_session_app, mscolab_session_managers):
     handles per-test cleanup as well.
     """
     with _running_eventlet_server(mscolab_session_app) as url:
+        # Wait until the Flask-SocketIO server is ready for connections
+        sio = socketio.Client()
+        sio.connect(url, retry=True)
+        sio.disconnect()
+        del sio
         yield url
 
 


### PR DESCRIPTION
**Purpose of PR?**:

The tests started to fail more often after the changes to test_sockets_manager.py made it no longer request the mscolab_server fixture.

~Presumably this delayed the startup of said fixture, leading to a race condition in other tests where the running server instance is not yet ready to accept SocketIO connections. This was hidden previously because the fixture simply had more time to get started.~

Presumably this delayed the startup of said fixture to a point in time at which the pytest processes MSColab server objects were no longer in a state in which they could be properly started in a forked process. Making the fixture be autouse'd to set it up early fixes this issue for now.

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->