### PR TITLE
Reconfigured tutorial videos for RTFD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,7 +226,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     html_style = 'css/mss.css'
 else:
     htmls_static_path = ['_static']
-    html_css_files = ['mss.css']
+    html_css_files = ['css/mss.css']
     html_context = {
         'display_github': False,  # Add 'Edit on Bitbucket' link instead of 'View page source'
         'last_updated': True,

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,8 +14,8 @@ dependencies:
       - markdown
       - xstatic
       - defusedxml
-      - sphinx_rtd_theme>=0.2.1
-      - sphinxcontrib-video
+      - sphinx_rtd_theme
+      - sphinxcontrib-video>=0.2.1
       - sphinx
       - fs
       - netCDF4

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,7 +14,7 @@ dependencies:
       - markdown
       - xstatic
       - defusedxml
-      - sphinx_rtd_theme
+      - sphinx_rtd_theme>=0.2.1
       - sphinxcontrib-video
       - sphinx
       - fs

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -9,7 +9,7 @@ a `public share <https://fz-juelich.sciebo.de/s/IzNGi24Ki68iV7t#pdfviewer>`_
 Get familiar by some videos about the Mission Support System (MSS).
 
 
-  .. video:: _static/mp4/tutorial_waypoints.mp4
+  .. video:: videos/mp4/tutorial_waypoints.mp4
      :autoplay:
      :loop:
      :alt: This is the waypoints tutorial,i.e., whenever we are going to plan

--- a/docs/tutorials/tutorial_hexagoncontrol.rst
+++ b/docs/tutorials/tutorial_hexagoncontrol.rst
@@ -3,7 +3,7 @@ Table View and Hexagon Flight Patterns
 
 For tomographic imaging, a hexagonal flight pattern can be integrated by a docking widget of Table View
 
-   .. video:: ../_static/mp4/tutorial_hexagoncontrol.mp4
+   .. video:: ../videos/mp4/tutorial_hexagoncontrol.mp4
      :alt: Top View windows is opened (CTRL+H).
            We select the "global (cyl)" for the world map.
            Zooming in for the required region.

--- a/docs/tutorials/tutorial_introduction_topview.rst
+++ b/docs/tutorials/tutorial_introduction_topview.rst
@@ -3,7 +3,7 @@ Top View and Selecting of Layers
 
 Selection and display of different data in the Top View with the help of the layer chooser.
 
-  .. video:: ../_static/mp4/tutorial_wms.mp4
+  .. video:: ../videos/mp4/tutorial_wms.mp4
      :alt: When we open the Top View (CTRL+H) of the map, the Web Map Service is already opened by default.
            It collects its data from the server: "open-mss dot org" that provides demodata for the meteorological or
            atmospheric information as layer lists.

--- a/docs/tutorials/tutorial_kml.rst
+++ b/docs/tutorials/tutorial_kml.rst
@@ -3,7 +3,7 @@ Top View and KML Data
 
 es can be displayed in the Top View. Color and line width can be adjusted.
 
-  .. video:: ../_static/mp4/tutorial_kml.mp4
+  .. video:: ../videos/mp4/tutorial_kml.mp4
      :alt: Open the TopView (CTRL+H)
            After clicking on "(select to open control)", click on KML OVERLAY. The UI will look as shown.
            KML files can be used to show the geographical boundary which helps in planning the WAY POINTS.

--- a/docs/tutorials/tutorial_mscolab.rst
+++ b/docs/tutorials/tutorial_mscolab.rst
@@ -5,7 +5,7 @@ Using the different views of the MSUI with a fictitious flight path and demo dat
 In comparison to the standalone mode of the MSUI an example setup of users is
 shown on a MSColab server and the possibilities of interactions.
 
-  .. video:: ../_static/mp4/tutorial_mscolab.mp4
+  .. video:: ../videos/mp4/tutorial_mscolab.mp4
      :alt: MSColab stores data in an online server, and can be used to access the data remotely as also working in a
            team where everyone contributes his part. It is used for collaborating with the users as a team together
            and working on a shared MSColab operation.

--- a/docs/tutorials/tutorial_msui_views.rst
+++ b/docs/tutorials/tutorial_msui_views.rst
@@ -4,7 +4,7 @@ Introduction to MSUI
 Using the different views of the MSUI with a fictitious flight path and demo data.
 
 
-  .. video:: ../_static/mp4//tutorial_views.mp4
+  .. video:: ../videos/mp4/tutorial_views.mp4
      :alt: Lets look at the tutorial of the various views required for flight planning:
            Top View (CTRL+H), Side View (CTRL+V), Linear View (CTRL+L) and Table View (CTRL+T).
            At first, lets open Top View and Side View.

--- a/docs/tutorials/tutorial_performance_settings.rst
+++ b/docs/tutorials/tutorial_performance_settings.rst
@@ -3,7 +3,7 @@ Table View and Aircraft Performance Data
 
 The range-specific data of an aircraft can be taken into account in Tableview for flight planning.
 
-  .. video:: ../_static/mp4/tutorial_performancesettings.mp4
+  .. video:: ../videos/mp4/tutorial_performancesettings.mp4
      :alt: This is the Performance Settings dockwidget opened in the Table View (CTRL+T) of the MSS software
            where by putting and changing some parameters, we can evaluate the performance of the aircraft.
            Parameters like Flight Altitude, Aviation fuel, Aircraft weight, Maximum take off weight

--- a/docs/tutorials/tutorial_remotesensing.rst
+++ b/docs/tutorials/tutorial_remotesensing.rst
@@ -4,7 +4,7 @@ Top View and Remotesensing Tools
 In order to be able to take into account the viewing angle and solar level for measuring instruments, the remotesensing tools are used
 
 
-  .. video:: ../_static/mp4/tutorial_remotesensing.mp4
+  .. video:: ../videos/mp4/tutorial_remotesensing.mp4
      :alt: This is the Remote Sensing Section of the Top View.
            It shows the position and angle of the flight from any particular object in the sky.
            Azimuth is the forward direction line of the flight. If we go above tHE AZIMUTH, angle is in positive,

--- a/docs/tutorials/tutorial_satellitetrack.rst
+++ b/docs/tutorials/tutorial_satellitetrack.rst
@@ -4,7 +4,7 @@ Top View and  Satellite Overflight
 To combine a flight path with a satellite overflight, the remotesensing widget is used.
 
 
-  .. video:: ../_static/mp4/tutorial_satellitetrack.mp4
+  .. video:: ../videos/mp4/tutorial_satellitetrack.mp4
      :alt: This is Satellite Tracking Prediction System that can be used to check the accuracy of the path
            travelled by a Satellite by the help of data collected from different space agencies and planning
            a flight accordingly.

--- a/docs/tutorials/tutorial_waypoints.rst
+++ b/docs/tutorials/tutorial_waypoints.rst
@@ -3,7 +3,7 @@ Top View Drawing Waypoints
 
 Waypoints for a flight path are defined, shifted and deleted.
 
-  .. video:: ../_static/mp4/tutorial_waypoints.mp4
+  .. video:: ../videos/mp4/tutorial_waypoints.mp4
      :alt: This is the waypoints tutorial,i.e., whenever we are going to plan
            a flight track, we have to place the waypoints in some places and,
            form a flight path.


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2454 

There are some ongoing changes on RTFD, https://about.readthedocs.com/blog/2024/07/addons-by-default/
I had not thought that this will make a difference for us.  
But the UI is much more comfortable now. It was simple to add this branch hidden to the config.
https://mss.readthedocs.io/en/i2454/tutorial.html

Currently locally a sphinx build does differently for the used videos. I added a workaround for this.
Important is that we can render videos on RTFD.

