### PR TITLE
Fix sequences after migrating data to PostgreSQL

### DIFF
--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -110,6 +110,34 @@ your database MSColab will abort. Please follow the documentation for a manual d
                     )
                     target_connection.execute(stmt.values(row))
             target_connection.commit()
+            if target_engine.name == "postgresql":
+                # Fix the databases auto-increment sequences, if it is a PostgreSQL database
+                # For reference, see: https://wiki.postgresql.org/wiki/Fixing_Sequences
+                logging.info("Using a PostgreSQL database, will fix up sequences")
+                cur = target_connection.execute(sqlalchemy.text(r"""
+SELECT
+    'SELECT SETVAL(' ||
+    quote_literal(quote_ident(sequence_namespace.nspname) || '.' || quote_ident(class_sequence.relname)) ||
+    ', COALESCE(MAX(' ||quote_ident(pg_attribute.attname)|| '), 1) ) FROM ' ||
+    quote_ident(table_namespace.nspname)|| '.'||quote_ident(class_table.relname)|| ';'
+FROM pg_depend
+    INNER JOIN pg_class AS class_sequence
+        ON class_sequence.oid = pg_depend.objid
+            AND class_sequence.relkind = 'S'
+    INNER JOIN pg_class AS class_table
+        ON class_table.oid = pg_depend.refobjid
+    INNER JOIN pg_attribute
+        ON pg_attribute.attrelid = class_table.oid
+            AND pg_depend.refobjsubid = pg_attribute.attnum
+    INNER JOIN pg_namespace as table_namespace
+        ON table_namespace.oid = class_table.relnamespace
+    INNER JOIN pg_namespace AS sequence_namespace
+        ON sequence_namespace.oid = class_sequence.relnamespace
+ORDER BY sequence_namespace.nspname, class_sequence.relname;
+"""))
+                for stmt, in cur.all():
+                    target_connection.execute(sqlalchemy.text(stmt))
+                target_connection.commit()
         logging.info("Data migration finished")
 
     # Upgrade to the latest database revision

--- a/tests/_test_mscolab/test_migrations.py
+++ b/tests/_test_mscolab/test_migrations.py
@@ -129,5 +129,9 @@ def test_upgrade_from(revision, iterations, mscolab_app, tmp_path):
             del actual_data_after_downgrade["alembic_version"]  # expected data doesn't have the revision table
             # Check that after a downgrade the data is definitely the same
             assert expected_data == actual_data_after_downgrade
+
+            # Try to add a new user after the migration
+            flask_migrate.upgrade(directory=migrations_path)
+            assert mslib.mscolab.seed.add_user('test123@test456', 'test123', 'test456')
     finally:
         mscolab_settings.SQLALCHEMY_DB_URI_TO_MIGRATE_FROM = None


### PR DESCRIPTION
When inserting rows into PostgreSQL tables and explicitly setting values for e.g. auto-increment columns, like the IDs, the associated sequences aren't automatically updated. This means that without explicitly fixing the sequences PostgreSQL would try to insert new rows with existing values for the IDs, failing in the process due to unique constraints.

This issue doesn't affect MariaDB nor SQLite. The former automatically updates auto-increment counters on insert, the latter simply uses the last rows ID as a starting point.

This change also extends the tests to try adding a new user after the migration, which should catch this kind of issue.

**Purpose of PR?**:

Fixes #2465.

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->