### PR TITLE
Autoplot - solving the parent problem in topview, linearview, sideview

### DIFF
--- a/mslib/msui/linearview.py
+++ b/mslib/msui/linearview.py
@@ -87,7 +87,7 @@ class MSUILinearViewWindow(MSUIMplViewWindow, ui.Ui_LinearWindow):
     vtime_vals = QtCore.pyqtSignal([list])
     itemSecs_selected = QtCore.pyqtSignal(str)
 
-    def __init__(self, parent=None, model=None, _id=None, config_settings=None, tutorial_mode=False):
+    def __init__(self, parent=None, mainwindow=None, model=None, _id=None, config_settings=None, tutorial_mode=False):
         """
         Set up user interface, connect signal/slots.
         """
@@ -115,8 +115,9 @@ class MSUILinearViewWindow(MSUIMplViewWindow, ui.Ui_LinearWindow):
 
         # Connect slots and signals.
         # ==========================
-
-        parent.refresh_signal_connect.connect(self.refresh_signal_send.emit)
+        # ToDo review 2026 after EOL of Win 10 if we can use parent again
+        if mainwindow is not None:
+            mainwindow.refresh_signal_connect.connect(self.refresh_signal_send.emit)
 
         # Tool opener.
         self.cbTools.currentIndexChanged.connect(lambda ind: self.openTool(

--- a/mslib/msui/linearview.py
+++ b/mslib/msui/linearview.py
@@ -121,7 +121,7 @@ class MSUILinearViewWindow(MSUIMplViewWindow, ui.Ui_LinearWindow):
 
         # Tool opener.
         self.cbTools.currentIndexChanged.connect(lambda ind: self.openTool(
-            index=ind, parent=parent, config_settings=config_settings))
+            index=ind, parent=mainwindow, config_settings=config_settings))
         self.lvoptionbtn.clicked.connect(self.open_settings_dialog)
 
         self.openTool(WMS + 1)

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -934,7 +934,7 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
         view_window = None
         if _type == "topview":
             # Top view.
-            view_window = topview.MSUITopViewWindow(parent=self, mainwindow=self, model=model,
+            view_window = topview.MSUITopViewWindow(mainwindow=self, model=model,
                                                     active_flighttrack=self.active_flight_track,
                                                     mscolab_server_url=self.mscolab.mscolab_server_url,
                                                     token=self.mscolab.token, tutorial_mode=self.tutorial_mode,
@@ -945,7 +945,7 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
                 view_window.mpl.setFixedSize(layout['topview'][0], layout['topview'][1])
         elif _type == "sideview":
             # Side view.
-            view_window = sideview.MSUISideViewWindow(model=model, tutorial_mode=self.tutorial_mode, parent=self,
+            view_window = sideview.MSUISideViewWindow(mainwindow=self, model=model, tutorial_mode=self.tutorial_mode,
                                                       config_settings=self.config_for_gui)
             view_window.refresh_signal_emit.connect(self.refresh_signal_connect.emit)
             view_window.mpl.resize(layout['sideview'][0], layout['sideview'][1])
@@ -957,8 +957,8 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
             view_window.centralwidget.resize(layout['tableview'][0], layout['tableview'][1])
         elif _type == "linearview":
             # Linear view.
-            view_window = linearview.MSUILinearViewWindow(model=model, tutorial_mode=self.tutorial_mode,
-                                                          parent=self, config_settings=self.config_for_gui)
+            view_window = linearview.MSUILinearViewWindow(mainwindow=self, model=model, tutorial_mode=self.tutorial_mode,
+                                                          config_settings=self.config_for_gui)
             view_window.refresh_signal_emit.connect(self.refresh_signal_connect.emit)
             view_window.mpl.resize(layout['linearview'][0], layout['linearview'][1])
             if layout["immutable"]:

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -957,7 +957,8 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
             view_window.centralwidget.resize(layout['tableview'][0], layout['tableview'][1])
         elif _type == "linearview":
             # Linear view.
-            view_window = linearview.MSUILinearViewWindow(mainwindow=self, model=model, tutorial_mode=self.tutorial_mode,
+            view_window = linearview.MSUILinearViewWindow(mainwindow=self, model=model,
+                                                          tutorial_mode=self.tutorial_mode,
                                                           config_settings=self.config_for_gui)
             view_window.refresh_signal_emit.connect(self.refresh_signal_connect.emit)
             view_window.mpl.resize(layout['linearview'][0], layout['linearview'][1])

--- a/mslib/msui/sideview.py
+++ b/mslib/msui/sideview.py
@@ -297,7 +297,7 @@ class MSUISideViewWindow(MSUIMplViewWindow, ui.Ui_SideViewWindow):
 
         # Tool opener.
         self.cbTools.currentIndexChanged.connect(lambda ind: self.openTool(
-            index=ind, parent=parent, config_settings=config_settings))
+            index=ind, parent=mainwindow, config_settings=config_settings))
         self.openTool(WMS + 1)
 
     def __del__(self):

--- a/mslib/msui/sideview.py
+++ b/mslib/msui/sideview.py
@@ -260,7 +260,7 @@ class MSUISideViewWindow(MSUIMplViewWindow, ui.Ui_SideViewWindow):
     vtime_vals = QtCore.pyqtSignal([list])
     itemSecs_selected = QtCore.pyqtSignal(str)
 
-    def __init__(self, parent=None, model=None, _id=None, config_settings=None, tutorial_mode=False):
+    def __init__(self, parent=None, mainwindow=None, model=None, _id=None, config_settings=None, tutorial_mode=False):
         """
         Set up user interface, connect signal/slots.
         """
@@ -288,8 +288,9 @@ class MSUISideViewWindow(MSUIMplViewWindow, ui.Ui_SideViewWindow):
 
         # Connect slots and signals.
         # ==========================
-
-        parent.refresh_signal_connect.connect(self.refresh_signal_send.emit)
+        # ToDo review 2026 after EOL of Win 10 if we can use parent again
+        if mainwindow is not None:
+            mainwindow.refresh_signal_connect.connect(self.refresh_signal_send.emit)
 
         # Buttons to set sideview options.
         self.btOptions.clicked.connect(self.open_settings_dialog)

--- a/mslib/msui/topview.py
+++ b/mslib/msui/topview.py
@@ -204,6 +204,7 @@ class MSUITopViewWindow(MSUIMplViewWindow, ui.Ui_TopViewWindow):
         logging.debug(_id)
         self.settings_tag = "topview"
         self.tutorial_mode = tutorial_mode
+        # ToDo review 2026 after EOL of Win 10 if we can use parent again
         self.mainwindow_signal_login_mscolab = mainwindow.signal_login_mscolab
         self.mainwindow_signal_logout_mscolab = mainwindow.signal_logout_mscolab
         self.mainwindow_signal_listFlighttrack_doubleClicked = mainwindow.signal_listFlighttrack_doubleClicked
@@ -249,8 +250,9 @@ class MSUITopViewWindow(MSUIMplViewWindow, ui.Ui_TopViewWindow):
 
         # Connect slots and signals.
         # ==========================
-
-        parent.refresh_signal_connect.connect(self.refresh_signal_send.emit)
+        # ToDo review 2026 after EOL of Win 10 if we can use parent again
+        if mainwindow is not None:
+            mainwindow.refresh_signal_connect.connect(self.refresh_signal_send.emit)
 
         # Map controls.
         self.btMapRedraw.clicked.connect(self.mpl.canvas.redraw_map)
@@ -264,7 +266,7 @@ class MSUITopViewWindow(MSUIMplViewWindow, ui.Ui_TopViewWindow):
 
         # Tool opener.
         self.cbTools.currentIndexChanged.connect(lambda ind: self.openTool(
-            index=ind, parent=parent, config_settings=config_settings))
+            index=ind, parent=mainwindow, config_settings=config_settings))
 
         if mainwindow is not None:
             # Update flighttrack


### PR DESCRIPTION
**Purpose of PR?**:

Fixes a regression in the new code which happens on win 10. When we use parent then topview, sideview, linearview widgets are not shown in the taskbar.
