### PR TITLE
Autoplot show message when not used correctly

### DIFF
--- a/mslib/msui/autoplot_dockwidget.py
+++ b/mslib/msui/autoplot_dockwidget.py
@@ -47,6 +47,7 @@ class AutoplotDockWidget(QWidget, Ui_AutoplotDockWidget):
     update_op_flight_treewidget = QtCore.pyqtSignal(str, str)
 
     def __init__(self, parent=None, parent2=None, view=None, config_settings=None):
+        # ToDo refactor, reduce complexity
         super().__init__()
         self.setupUi(self)
 
@@ -296,7 +297,8 @@ class AutoplotDockWidget(QWidget, Ui_AutoplotDockWidget):
 
             if len(indices_to_remove) > 0:
                 QMessageBox.information(self, "WARNING",
-                                        f"{', '.join(names_not_available)} not loaded into MSUI. Load first!"
+                                        f"{', '.join(names_not_available)} not loaded into MSUI. Load first!\n"
+                                        f"Take care also to load get_apabilities of the WMS servers listed!"
                 )
 
             parent.refresh_signal_emit.emit()

--- a/mslib/msui/wms_control.py
+++ b/mslib/msui/wms_control.py
@@ -705,15 +705,18 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
             self.valid_time_changed()
 
         layer = self.multilayers.get_current_layer()
-        crs = layer.get_allowed_crs()
-        if crs and \
-           self.parent() is not None and \
-           self.parent().parent() is not None:
-            logging.debug("Layer offers '%s' projections.", crs)
-            extra = [_code for _code in crs if _code.startswith("EPSG")]
-            extra = [_code for _code in sorted(extra) if _code[5:] in basemap.epsg_dict]
-            logging.debug("Selected '%s' for Combobox.", extra)
-            self.parent().parent().update_predefined_maps(extra)
+        if layer is not None:
+            crs = layer.get_allowed_crs()
+            if crs and \
+               self.parent() is not None and \
+               self.parent().parent() is not None:
+                logging.debug("Layer offers '%s' projections.", crs)
+                extra = [_code for _code in crs if _code.startswith("EPSG")]
+                extra = [_code for _code in sorted(extra) if _code[5:] in basemap.epsg_dict]
+                logging.debug("Selected '%s' for Combobox.", extra)
+                self.parent().parent().update_predefined_maps(extra)
+        else:
+            logging.debug("layer is None")
 
     def style_changed_now(self, style):
         self.styles_changed.emit(style)
@@ -1354,7 +1357,8 @@ class WMSControlWidget(QtWidgets.QWidget, ui.Ui_WMSDockWidget):
             if valid_time is not None:
                 self.dteValidTime.setDateTime(valid_time)
 
-        if self.multilayers.threads == 0 and not self.layerChangeInProgress:
+        if (self.multilayers.get_current_layer() is not None and self.multilayers.threads == 0
+                and not self.layerChangeInProgress):
             self.multilayers.get_current_layer().set_vtime(self.cbValidTime.currentText())
             self.multilayers.carry_parameters["vtime"] = self.cbValidTime.currentText()
 


### PR DESCRIPTION
**Purpose of PR?**:

Avoid a crash when a mssautoplot.json file is loaded before the corresponding operations or fligt tracks are added to MSUI. 

You can try this on a fresh start of msui, loading topview, autoplot, selecting mssautoplot.json, clicking on an entry.

The data in the tree widget gets now  reduced to those matching in the interface. The crash of requesting WMS data before get_capabilties is catched too. In a future vesion it should be possible to call get_capabilties on loading the mssautoplot.json.