### PR TITLE
import to mscolab uses the filename as version name

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -479,7 +479,6 @@ using a local meta.yaml recipe::
   $ mamba activate mssbuildtest
   $ mamba install -c local mss
 
-
 Take care on removing alpha builds, or increase the build number for a new version.
 
 

--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -392,7 +392,7 @@ class FileManager:
                           "id": permission.u_id})
         return users
 
-    def save_file(self, op_id, content, user, comment=""):
+    def save_file(self, op_id, content, user, version_name=None, comment=""):
         """
         op_id: operation-id,
         content: content of the file to be saved
@@ -427,7 +427,7 @@ class FileManager:
                 repo.index.add(['main.ftml'])
                 cm = repo.index.commit("committing changes")
                 # change db table
-                change = Change(op_id, user.id, cm.hexsha)
+                change = Change(op_id, user.id, cm.hexsha, version_name=version_name)
                 db.session.add(change)
                 db.session.commit()
                 return True

--- a/mslib/mscolab/sockets_manager.py
+++ b/mslib/mscolab/sockets_manager.py
@@ -275,13 +275,14 @@ class SocketsManager:
         op_id = json_req['op_id']
         content = json_req['content']
         comment = json_req.get('comment', "")
+        version_name = json_req.get('version_name', None)
         messageText = json_req.get('messageText')
         user = User.verify_auth_token(json_req['token'])
         if user is not None:
             # when the socket connection is expired this in None and also on wrong tokens
             perm = self.permission_check_emit(user.id, int(op_id))
             # if permission is correct and file saved properly
-            if perm and self.fm.save_file(int(op_id), content, user, comment):
+            if perm and self.fm.save_file(int(op_id), content, user, version_name=version_name, comment=comment):
                 # send service message
                 message_ = f"[service message] **{user.username}** saved changes. {messageText}"
                 new_message = self.cm.add_message(user, message_, str(op_id), message_type=MessageType.SYSTEM_MESSAGE)

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -1905,14 +1905,13 @@ class MSUIMscolab(QtCore.QObject):
         self.reload_view_windows()
 
     @verify_user_token
-    def handle_waypoints_changed(self, _1=None, _2=None, _3=None):
+    def handle_waypoints_changed(self, _1=None, _2=None, _3=None, version_name=None):
         logging.debug("handle_waypoints_changed")
         if self.ui.workLocallyCheckbox.isChecked():
             self.waypoints_model.save_to_ftml(self.local_ftml_file)
         else:
             xml_content = self.waypoints_model.get_xml_content()
-            self.conn.save_file(self.token, self.active_op_id, xml_content, comment=None,
-                                messageText=self.lastChangeMessage)
+            self.conn.save_file(self.token, self.active_op_id, xml_content, version_name=version_name, comment=None)
             # Reset the last change message to make sure that it is used only once
             self.lastChangeMessage = ""
 
@@ -1964,7 +1963,7 @@ class MSUIMscolab(QtCore.QObject):
         self.waypoints_model.dataChanged.disconnect(self.handle_waypoints_changed)
         self.waypoints_model = model
         self.waypoints_model.changeMessageSignal.connect(self.handle_change_message)
-        self.handle_waypoints_changed()
+        self.handle_waypoints_changed(version_name=file_name)
         self.waypoints_model.dataChanged.connect(self.handle_waypoints_changed)
         self.reload_view_windows()
         show_popup(self.ui, "Import Success", f"The file - {file_name}, was imported successfully!", 1)

--- a/mslib/msui/socket_control.py
+++ b/mslib/msui/socket_control.py
@@ -203,7 +203,7 @@ class ConnectionManager(QtCore.QObject):
         # Emit an event to notify the server of the operation selection.
         self.sio.emit('operation-selected', {'token': self.token, 'op_id': op_id})
 
-    def save_file(self, token, op_id, content, comment=None, messageText=""):
+    def save_file(self, token, op_id, content, comment=None, version_name=None, messageText=""):
         # ToDo refactor API
         if verify_user_token(self.mscolab_server_url, self.token):
             logging.debug("saving file")
@@ -212,6 +212,7 @@ class ConnectionManager(QtCore.QObject):
                           "token": self.token,
                           "content": content,
                           "comment": comment,
+                          "version_name": version_name,
                           "messageText": messageText})
         else:
             # this triggers disconnect


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2025

We can set the import filename for the name of the revisions.

![use_importname_for_revision](https://github.com/user-attachments/assets/0b6c230f-8b48-4eb3-9b60-4e4d3516a332)
