### PR TITLE
autoplot plots use layout definitions

### DIFF
--- a/docs/mssautoplot.rst
+++ b/docs/mssautoplot.rst
@@ -25,6 +25,9 @@ The CLI tool has the following parameters:
 +--------------+-------+----------------------------------------------------------------------+
 | ``--etime``  | TEXT  |   Ending time for downloading multiple plots with a fixed interval.  |
 +--------------+-------+----------------------------------------------------------------------+
+| ``--raw``    | BOOL  |   Saves the raw image with its projection in topview.                |
++--------------+-------+----------------------------------------------------------------------+
+
 
 A short description of how to start the program is given by the ``--help`` option.
 
@@ -50,6 +53,13 @@ For downloading plots of multiple flight tracks, specify the flight track and it
 3. ``mssautoplot --cpath mssautoplot.json --stime="2019-09-01T00:00:00" --etime="2019-09-02T00:00:00" --intv=6``
 
 The above command will download plots of the with/without flight track from start time "2019-09-01T00:00:00" to end time "2019-09-02T00:00:00". The user would need to compulsorily specify the init_time and time in mss_autoplot.json inorder to use this functionality.
+
+
+4. ``mssautoplot --cpath mssautoplot.json --raw=True``
+
+This command stores the data of topview as PNG for overlays without axis, titles etc.
+This could be used in systems like PLANET. You may want to set large values in the layout
+of topview in the mssautoplot.json.
 
 
 Settings file

--- a/mslib/msui/mpl_qtwidget.py
+++ b/mslib/msui/mpl_qtwidget.py
@@ -100,14 +100,17 @@ mpl_logger = configure_mpl_logger()
 
 
 class ViewPlotter:
-    def __init__(self, fig=None, ax=None, settings_tag=None, settings=None):
+    def __init__(self, fig=None, ax=None, settings_tag=None, settings=None, layout=None):
         # setup Matplotlib Figure and Axis
         self.fig, self.ax = fig, ax
         self.settings = settings
         self.settings_tag = settings_tag
         if self.fig is None:
             assert ax is None
-            self.fig = figure.Figure(facecolor="w")  # 0.75
+            if layout is not None:
+                self.fig = figure.Figure(facecolor="w", figsize=(layout[0] / 100, layout[1] / 100))  # 0.75
+            else:
+                self.fig = figure.Figure(facecolor="w")
         if self.ax is None:
             self.ax = self.fig.add_subplot(111, zorder=99)
 
@@ -179,7 +182,8 @@ class ViewPlotter:
 
 class TopViewPlotter(ViewPlotter):
     def __init__(self, fig=None, ax=None, settings=None):
-        super().__init__(fig, ax, settings_tag="topview", settings=_DEFAULT_SETTINGS_TOPVIEW)
+        super().__init__(fig, ax, settings_tag="topview", settings=_DEFAULT_SETTINGS_TOPVIEW,
+                         layout=config_loader(dataset="layout")["topview"])
         self.map = None
         self.legimg = None
         self.legax = None
@@ -397,7 +401,8 @@ class SideViewPlotter(ViewPlotter):
             numlabels = config_loader(dataset='num_labels')
         if num_interpolation_points is None:
             num_interpolation_points = config_loader(dataset='num_interpolation_points')
-        super().__init__(fig, ax, settings_tag="sideview", settings=_DEFAULT_SETTINGS_SIDEVIEW)
+        super().__init__(fig, ax, settings_tag="sideview", settings=_DEFAULT_SETTINGS_SIDEVIEW,
+                         layout=config_loader(dataset="layout")["sideview"])
         self.load_settings()
         self.set_settings(settings)
 
@@ -667,7 +672,8 @@ class LinearViewPlotter(ViewPlotter):
         """
         if numlabels is None:
             numlabels = config_loader(dataset='num_labels')
-        super().__init__(settings_tag="linearview", settings=_DEFAULT_SETTINGS_LINEARVIEW)
+        super().__init__(settings_tag="linearview", settings=_DEFAULT_SETTINGS_LINEARVIEW,
+                         layout=config_loader(dataset="layout")["linearview"])
         self.load_settings()
 
         # Sets the default values of plot sizes from MissionSupportDefaultConfig.

--- a/mslib/utils/mssautoplot.py
+++ b/mslib/utils/mssautoplot.py
@@ -226,6 +226,11 @@ class Plotting:
                 raise SystemExit("Invalid SECTION and/or CRS")
             self.params["basemap"].update(self.config["predefined_map_sections"][section]["map"])
             self.bbox_units = self.params["bbox"]
+            self.layout = self.config["layout"]["topview"]
+        if self.__class__.__name__ == "SideViewPlotting":
+            self.layout = self.config["layout"]["sideview"]
+        if self.__class__.__name__ == "LinearViewPlotting":
+            self.layout = self.config["layout"]["linearview"]
         if filename != "" and filename == flight:
             self.read_operation(flight, msc_url, msc_auth_password, username, password)
         elif filename != "":

--- a/mslib/utils/mssautoplot.py
+++ b/mslib/utils/mssautoplot.py
@@ -197,7 +197,7 @@ def get_op_id(msc_url, token, op_name):
 
 
 class Plotting:
-    def __init__(self, cpath, msc_url=None, msc_auth_password=None, username=None, password=None, pdlg=None):
+    def __init__(self, cpath, msc_url=None, msc_auth_password=None, username=None, password=None, pdlg=None, raw=False):
         """
         Initialize the Plotting object with the provided parameters.
 
@@ -300,8 +300,8 @@ class Plotting:
 
 
 class TopViewPlotting(Plotting):
-    def __init__(self, cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg):
-        super(TopViewPlotting, self).__init__(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg)
+    def __init__(self, cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg, raw=False):
+        super(TopViewPlotting, self).__init__(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg, raw)
         self.pdlg = pdlg
         self.myfig = qt.TopViewPlotter()
         self.myfig.fig.canvas.draw()
@@ -313,6 +313,7 @@ class TopViewPlotting(Plotting):
         self.password = msc_password
         self.msc_auth = msc_auth_password
         self.url = msc_url
+        self.raw = raw
 
     def setup(self):
         pass
@@ -356,17 +357,20 @@ class TopViewPlotting(Plotting):
         img = wms.getmap(**kwargs)
         image_io = io.BytesIO(img.read())
         img = PIL.Image.open(image_io)
-        self.myfig.draw_image(img)
         t = str(time)
         date_time = re.sub(r'\W+', '', t)
         plot_filename = slugify(f"{flight}_{layer}_{section}_{date_time}_{no_of_plots}_{elevation}") + ".png"
-        self.myfig.fig.savefig(plot_filename)
+        if self.raw:
+            img.save(plot_filename)
+        else:
+            self.myfig.draw_image(img)
+            self.myfig.fig.savefig(plot_filename)
         print(f"The image is saved at: {os.getcwd()}/{plot_filename}")
 
 
 class SideViewPlotting(Plotting):
-    def __init__(self, cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg):
-        super(SideViewPlotting, self).__init__(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg)
+    def __init__(self, cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg, raw=False):
+        super(SideViewPlotting, self).__init__(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg, raw)
         self.pdlg = pdlg
         self.myfig = qt.SideViewPlotter()
         self.ax = self.myfig.ax
@@ -481,8 +485,8 @@ class SideViewPlotting(Plotting):
 
 class LinearViewPlotting(Plotting):
     # ToDo Implement access of MSColab
-    def __init__(self, cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg):
-        super(LinearViewPlotting, self).__init__(cpath, msc_url, msc_auth_password, msc_username, msc_password)
+    def __init__(self, cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg, raw=False):
+        super(LinearViewPlotting, self).__init__(cpath, msc_url, msc_auth_password, msc_username, msc_password, raw)
         self.pdlg = pdlg
         self.myfig = qt.LinearViewPlotter()
         self.ax = self.myfig.ax
@@ -584,8 +588,9 @@ class LinearViewPlotting(Plotting):
 @click.option('--intv', default=0, help='Time interval.')
 @click.option('--stime', default="", help='Starting time for downloading multiple plots with a fixed interval.')
 @click.option('--etime', default="", help='Ending time for downloading multiple plots with a fixed interval.')
+@click.option('--raw', default=False, help='Saves the raw image with its projection in topview')
 @click.pass_context
-def main(ctx, cpath, view, ftrack, itime, vtime, intv, stime, etime):
+def main(ctx, cpath, view, ftrack, itime, vtime, intv, stime, etime, raw):
     pdlg = None
 
     def close_process_dialog(pdlg):
@@ -623,13 +628,13 @@ def main(ctx, cpath, view, ftrack, itime, vtime, intv, stime, etime):
 
     # Choose view (top or side)
     if view == "top":
-        top_view = TopViewPlotting(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg)
+        top_view = TopViewPlotting(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg, raw)
         sec = "automated_plotting_hsecs"
     elif view == "side":
-        side_view = SideViewPlotting(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg)
+        side_view = SideViewPlotting(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg, raw)
         sec = "automated_plotting_vsecs"
     elif view == "linear":
-        linear_view = LinearViewPlotting(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg)
+        linear_view = LinearViewPlotting(cpath, msc_url, msc_auth_password, msc_username, msc_password, pdlg, raw)
         sec = "automated_plotting_lsecs"
     else:
         print("Invalid view")


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #1898

this uses now the layout definition in mssautoplot.json

```
"layout": {
        "topview": [
            916,
            702
        ],
        "sideview": [
            496,
            370
        ],
        "linearview": [
            913,
            557
        ],
        "tableview": [
            1236,
            424
        ],

```
currently verified with a topview example