### PR TITLE
fix: set pinning of numpy<2.0

### DIFF
--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -86,6 +86,7 @@ requirements:
     - flask-login
     - pysaml2
     - libxmlsec1  # [not win]
+    - numpy <2.0
   run_constrained:
     - menuinst >=2.0.2
 

--- a/mslib/msui/mpl_pathinteractor.py
+++ b/mslib/msui/mpl_pathinteractor.py
@@ -111,7 +111,7 @@ class WaypointsPath(mpath.Path):
            matplotlib.Path) at the given index.
         """
         self.vertices = np.insert(self.vertices, index,
-                                  np.asarray(vertex, np.float_), axis=0)
+                                  np.asarray(vertex, np.float64), axis=0)
         self.codes = np.insert(self.codes, index, code, axis=0)
 
     def index_of_closest_segment(self, x, y, eps=5):

--- a/requirements.d/development.txt
+++ b/requirements.d/development.txt
@@ -20,3 +20,4 @@ eventlet>0.30.2
 dnspython>=2.0.0, <2.3.0
 gsl==2.7.0
 boa
+numpy<2.0


### PR DESCRIPTION
**Purpose of PR?**: Pins NumPy to version below 2.0. Ensures compatibility.

Bug Fix:
Fixes #2483 




