### PR TITLE
fix: set pinning of numpy<2.0

### DIFF
--- a/localbuild/meta.yaml
+++ b/localbuild/meta.yaml
@@ -86,6 +86,7 @@ requirements:
     - flask-login
     - pysaml2
     - libxmlsec1  # [not win]
+    - numpy <2.0
   run_constrained:
     - menuinst >=2.0.2
 


### PR DESCRIPTION

**Purpose of PR?**: Pinning of numpy < 2.0 as a temporary fix for compatibility issues in mpl_pathinteractor.py. 

Bug fix:
Fixes #2483 
