### PR TITLE
fix: remove user credential from keyring

### DIFF
--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -39,8 +39,6 @@ from sqlalchemy.exc import IntegrityError
 from mslib.utils.verify_waypoint_data import verify_waypoint_data
 from mslib.mscolab.models import db, Operation, Permission, User, Change, Message
 from mslib.mscolab.conf import mscolab_settings
-from mslib.utils.auth import del_password_from_keyring
-from mslib.utils.config import config_loader
 
 
 class FileManager:
@@ -235,8 +233,6 @@ class FileManager:
                 # Delete profile image if it exists
                 if user.profile_image_path:
                     self.delete_user_profile_image(user.profile_image_path)
-                mscolab_server_url = config_loader(dataset="default_MSCOLAB")
-                del_password_from_keyring(service_name=mscolab_server_url[0], username=user.emailid)
                 db.session.delete(user)
                 db.session.commit()
             user_query = User.query.filter_by(id=user.id).first()

--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -39,6 +39,8 @@ from sqlalchemy.exc import IntegrityError
 from mslib.utils.verify_waypoint_data import verify_waypoint_data
 from mslib.mscolab.models import db, Operation, Permission, User, Change, Message
 from mslib.mscolab.conf import mscolab_settings
+from mslib.utils.auth import del_password_from_keyring
+from mslib.utils.config import config_loader
 
 
 class FileManager:
@@ -233,6 +235,8 @@ class FileManager:
                 # Delete profile image if it exists
                 if user.profile_image_path:
                     self.delete_user_profile_image(user.profile_image_path)
+                mscolab_server_url = config_loader(dataset="default_MSCOLAB")
+                del_password_from_keyring(service_name=mscolab_server_url[0], username=user.emailid)
                 db.session.delete(user)
                 db.session.commit()
             user_query = User.query.filter_by(id=user.id).first()

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -937,7 +937,11 @@ class MSUIMscolab(QtCore.QObject):
         if reply == QMessageBox.No:
             return
         try:
+            auth_name = config_loader(dataset="MSCOLAB_auth_user_name")
             del_password_from_keyring(self.mscolab_server_url, self.email)
+            if auth_name:
+                del_password_from_keyring(f"MSCOLAB_AUTH_{self.mscolab_server_url}", auth_name)
+            modify_config_file({"MSCOLAB_auth_user_name": None})
             response = self.conn.request_post("delete_own_account")
         except requests.exceptions.RequestException as ex:
             raise MSColabConnectionError(f"Some error occurred ({ex})! Please reconnect.")

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -939,9 +939,7 @@ class MSUIMscolab(QtCore.QObject):
         try:
             auth_name = config_loader(dataset="MSCOLAB_auth_user_name")
             del_password_from_keyring(self.mscolab_server_url, self.email)
-            if auth_name:
-                del_password_from_keyring(f"MSCOLAB_AUTH_{self.mscolab_server_url}", auth_name)
-            modify_config_file({"MSCOLAB_auth_user_name": None})
+            del_password_from_keyring(f"MSCOLAB_AUTH_{self.mscolab_server_url}", auth_name)
             response = self.conn.request_post("delete_own_account")
         except requests.exceptions.RequestException as ex:
             raise MSColabConnectionError(f"Some error occurred ({ex})! Please reconnect.")

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -61,7 +61,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtWidgets import QDialog, QFileDialog, QMessageBox
 from PyQt5.QtGui import QPixmap
 
-from mslib.utils.auth import get_password_from_keyring, save_password_to_keyring
+from mslib.utils.auth import get_password_from_keyring, save_password_to_keyring, del_password_from_keyring
 from mslib.utils.verify_user_token import verify_user_token as _verify_user_token
 from mslib.utils.verify_waypoint_data import verify_waypoint_data
 from mslib.utils.qt import get_open_filename, get_save_filename, dropEvent, dragEnterEvent, show_popup
@@ -937,6 +937,7 @@ class MSUIMscolab(QtCore.QObject):
         if reply == QMessageBox.No:
             return
         try:
+            del_password_from_keyring(self.mscolab_server_url, self.email)
             response = self.conn.request_post("delete_own_account")
         except requests.exceptions.RequestException as ex:
             raise MSColabConnectionError(f"Some error occurred ({ex})! Please reconnect.")

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -876,7 +876,7 @@ class Test_Mscolab:
         self._create_user(qtbot, "something", "something@something.org", "something")
         u_id = self.window.mscolab.user['id']
         self.window.mscolab.open_profile_window()
-        assert self.url + "something@something.org" in mslib.utils.auth.keyring.get_keyring().passwords
+        assert self.url + "something@something.org" in mslib.utils.auth.keyring.get_keyring().passwords # Uses 'TestKeyring' from conftest.py for verification.
         assert "MSCOLAB_AUTH_" + self.url, "something@something.org" in mslib.utils.auth.keyring.get_keyring().passwords
         QtTest.QTest.mouseClick(self.window.mscolab.profile_dialog.deleteAccountBtn, QtCore.Qt.LeftButton)
         assert self.window.listOperationsMSC.model().rowCount() == 0

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -876,10 +876,14 @@ class Test_Mscolab:
         self._create_user(qtbot, "something", "something@something.org", "something")
         u_id = self.window.mscolab.user['id']
         self.window.mscolab.open_profile_window()
+        assert self.url + "something@something.org" in mslib.utils.auth.keyring.get_keyring().passwords
+        assert "MSCOLAB_AUTH_" + self.url, "something@something.org" in mslib.utils.auth.keyring.get_keyring().passwords
         QtTest.QTest.mouseClick(self.window.mscolab.profile_dialog.deleteAccountBtn, QtCore.Qt.LeftButton)
         assert self.window.listOperationsMSC.model().rowCount() == 0
         assert self.window.usernameLabel.isVisible() is False
         assert self.window.connectBtn.isVisible() is True
+        assert self.url + "something@something.org" not in mslib.utils.auth.keyring.get_keyring().passwords
+        assert "MSCOLAB_AUTH_" + self.url, "something@something.org" not in mslib.utils.auth.keyring.get_keyring().passwords
         with self.app.app_context():
             assert User.query.filter_by(emailid='something').count() == 0
             assert Permission.query.filter_by(u_id=u_id).count() == 0

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -876,14 +876,20 @@ class Test_Mscolab:
         self._create_user(qtbot, "something", "something@something.org", "something")
         u_id = self.window.mscolab.user['id']
         self.window.mscolab.open_profile_window()
-        assert self.url + "something@something.org" in mslib.utils.auth.keyring.get_keyring().passwords # Uses 'TestKeyring' from conftest.py for verification.
+        # Uses 'TestKeyring' from conftest.py for verification.
+        assert self.url + "something@something.org" in mslib.utils.auth.keyring.get_keyring().passwords
         assert "MSCOLAB_AUTH_" + self.url, "something@something.org" in mslib.utils.auth.keyring.get_keyring().passwords
         QtTest.QTest.mouseClick(self.window.mscolab.profile_dialog.deleteAccountBtn, QtCore.Qt.LeftButton)
         assert self.window.listOperationsMSC.model().rowCount() == 0
         assert self.window.usernameLabel.isVisible() is False
         assert self.window.connectBtn.isVisible() is True
-        assert self.url + "something@something.org" not in mslib.utils.auth.keyring.get_keyring().passwords
-        assert "MSCOLAB_AUTH_" + self.url, "something@something.org" not in mslib.utils.auth.keyring.get_keyring().passwords
+        assert (
+            self.url + "something@something.org"
+            not in mslib.utils.auth.keyring.get_keyring().passwords
+        )
+        assert "MSCOLAB_AUTH_" + self.url, "something@something.org" not in (
+            mslib.utils.auth.keyring.get_keyring().passwords
+        )
         with self.app.app_context():
             assert User.query.filter_by(emailid='something').count() == 0
             assert Permission.query.filter_by(u_id=u_id).count() == 0


### PR DESCRIPTION
**Purpose of PR?**: User password is removed from keyring when account is deleted from MSColab. 

Fixes #2624

