### PR TITLE
feat(mscolab): Add config option to allow unsafe Werkzeug in development

### DIFF
--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -24,6 +24,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import fs
 import sys
 import functools
@@ -1018,7 +1019,8 @@ if mscolab_settings.USE_SAML2:
 
 def start_server(app, sockio, cm, fm, port=8083):
     create_files()
-    sockio.run(app, port=port, debug=mscolab_settings.DEBUG)
+    allow_unsafe = os.getenv("MSC_ALLOW_UNSAFE_WERKZEUG", "False").lower() in ("1", "true", "yes")
+    sockio.run(app, port=port, debug=mscolab_settings.DEBUG, allow_unsafe_werkzeug=allow_unsafe)
 
 
 def main():


### PR DESCRIPTION
**Purpose of PR?**: This PR introduces a configuration option to allow running the Werkzeug development server in a non-secure mode for testing and development purposes. It introduces an environment variable (MSC_ALLOW_UNSAFE_WERKZEUG) that, when set to True, will pass allow_unsafe_werkzeug=True to the Flask-SocketIO server. This prevents the RuntimeError when running the MSColab server in a development environment.

Fixes #2656 

**Checklist:**
- [X] Bug fix. Fixes #2656 
- [X] New feature (Non-API breaking changes that adds functionality)
- [X] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->