### PR TITLE
fix: link to new feature in about msui section

### DIFF
--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -410,7 +410,7 @@ class MSUI_AboutDialog(QtWidgets.QDialog, ui_ab.Ui_AboutMSUIDialog):
         self.setupUi(self)
         self.lblVersion.setText(f"Version: {__version__}")
         self.lblNewVersion.setText(f"{release_info.check_for_new_release()[0]}")
-        self.milestone_url = f'https://github.com/Open-MSS/MSS/issues?q=is%3Aclosed+milestone%3A{__version__[:-1]}'
+        self.milestone_url = f'https://github.com/Open-MSS/MSS/issues?q=is%3Aclosed+milestone%3A{__version__}'
         self.lblChanges.setText(f'<a href="{self.milestone_url}">New Features and Changes</a>')
         blub = QtGui.QPixmap(python_powered())
         self.lblPython.setPixmap(blub)

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -409,8 +409,7 @@ class MSUI_AboutDialog(QtWidgets.QDialog, ui_ab.Ui_AboutMSUIDialog):
         super().__init__(parent)
         self.setupUi(self)
         self.lblVersion.setText(f"Version: {__version__}")
-        self.lblNewVersion.setText(f"{release_info.check_for_new_release()[0]}")
-        self.milestone_url = f'https://github.com/Open-MSS/MSS/issues?q=is%3Aclosed+milestone%3A{__version__[:-1]}'
+        self.milestone_url = f'https://github.com/Open-MSS/MSS/issues?q=is%3Aclosed+milestone%3A{__version__}'
         self.lblChanges.setText(f'<a href="{self.milestone_url}">New Features and Changes</a>')
         blub = QtGui.QPixmap(python_powered())
         self.lblPython.setPixmap(blub)


### PR DESCRIPTION
**Purpose of PR?**: This PR fixes the milestone link in the About section. Previously, the link was incomplete because the milestone version was incorrectly formatted (for example: "9.2." instead of "9.2.0"). This fix ensures that the correct milestone version is used in the link.

Bug fix:
Fixes #2685

