### PR TITLE
fix: link to new feature in about section

### DIFF
--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -410,7 +410,7 @@ class MSUI_AboutDialog(QtWidgets.QDialog, ui_ab.Ui_AboutMSUIDialog):
         self.setupUi(self)
         self.lblVersion.setText(f"Version: {__version__}")
         self.lblNewVersion.setText(f"{release_info.check_for_new_release()[0]}")
-        self.milestone_url = f'https://github.com/Open-MSS/MSS/issues?q=is%3Aclosed+milestone%3A{__version__[:-1]}'
+        self.milestone_url = f'https://github.com/Open-MSS/MSS/issues?q=is%3Aclosed+milestone%3A{__version__}'
         self.lblChanges.setText(f'<a href="{self.milestone_url}">New Features and Changes</a>')
         blub = QtGui.QPixmap(python_powered())
         self.lblPython.setPixmap(blub)

--- a/tests/_test_msui/test_msui.py
+++ b/tests/_test_msui/test_msui.py
@@ -87,7 +87,7 @@ class Test_MSS_AboutDialog:
     def test_milestone_url(self):
         with urlopen(self.window.milestone_url) as f:
             text = f.read()
-        pattern = f'value="is:closed milestone:{__version__[:-1]}"'
+        pattern = f'value="is:closed milestone:{__version__}"'
         assert pattern in text.decode('utf-8')
 
 

--- a/tests/_test_msui/test_msui.py
+++ b/tests/_test_msui/test_msui.py
@@ -41,6 +41,7 @@ from tests.utils import ExceptionMock
 from mslib.utils.config import read_config_file
 import re
 
+
 def test_main():
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with mock.patch("mslib.msui.msui.argparse.ArgumentParser.parse_args",
@@ -89,7 +90,8 @@ class Test_MSS_AboutDialog:
             text = f.read().decode("utf-8")
         expected_version = __version__
         pattern = rf'value="is:closed milestone:{re.escape(expected_version)}"'
-        assert re.search(pattern,text), f"Expected milestone format not found: {expected_version}"
+        assert re.search(pattern, text), f"Expected milestone format not found: {expected_version}"
+
 
 class Test_MSS_ShortcutDialog:
     @pytest.fixture(autouse=True)

--- a/tests/_test_msui/test_msui.py
+++ b/tests/_test_msui/test_msui.py
@@ -39,7 +39,7 @@ from mslib.msui import msui
 from mslib.msui import msui_mainwindow as msui_mw
 from tests.utils import ExceptionMock
 from mslib.utils.config import read_config_file
-
+import re
 
 def test_main():
     with pytest.raises(SystemExit) as pytest_wrapped_e:
@@ -86,10 +86,10 @@ class Test_MSS_AboutDialog:
 
     def test_milestone_url(self):
         with urlopen(self.window.milestone_url) as f:
-            text = f.read()
-        pattern = f'value="is:closed milestone:{__version__}"'
-        assert pattern in text.decode('utf-8')
-
+            text = f.read().decode("utf-8")
+        expected_version = __version__
+        pattern = rf'value="is:closed milestone:{re.escape(expected_version)}"'
+        assert re.search(pattern,text), f"Expected milestone format not found: {expected_version}"
 
 class Test_MSS_ShortcutDialog:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
**Purpose of PR?**: This PR fixes the milestone link in the About section. Previously, the link was incomplete because the milestone version was incorrectly formatted (for example: "9.2." instead of "9.2.0"). This fix ensures that the correct milestone version is used in the link.

Bug fix:
Fixes #2685 

