### PR TITLE
fix: log warning instead of error for performance setting

### DIFF
--- a/mslib/utils/config.py
+++ b/mslib/utils/config.py
@@ -580,8 +580,8 @@ def load_settings_qsettings(tag, default_settings=None):
     try:
         settings = q_settings.value(tag)
     except Exception as ex:
-        logging.error("Problems reloading stored %s settings (%s: %s). Switching to default",
-                      tag, type(ex), ex)
+        logging.warning("Problems reloading stored %s settings (%s: %s). Switching to default",
+                        tag, type(ex), ex)
     if isinstance(settings, dict):
         default_settings.update(settings)
     return default_settings

--- a/mslib/utils/migration/config_before_eight.py
+++ b/mslib/utils/migration/config_before_eight.py
@@ -497,8 +497,8 @@ def load_settings_qsettings(tag, default_settings=None, ignore_test=False):
     try:
         settings = q_settings.value(tag)
     except Exception as ex:
-        logging.error("Problems reloading stored %s settings (%s: %s). Switching to default",
-                      tag, type(ex), ex)
+        logging.warning("Problems reloading stored %s settings (%s: %s). Switching to default",
+                        tag, type(ex), ex)
     if isinstance(settings, dict):
         default_settings.update(settings)
     return default_settings

--- a/mslib/utils/migration/config_before_nine.py
+++ b/mslib/utils/migration/config_before_nine.py
@@ -494,8 +494,8 @@ def load_settings_qsettings(tag, default_settings=None, ignore_test=False):
     try:
         settings = q_settings.value(tag)
     except Exception as ex:
-        logging.error("Problems reloading stored %s settings (%s: %s). Switching to default",
-                      tag, type(ex), ex)
+        logging.warning("Problems reloading stored %s settings (%s: %s). Switching to default",
+                        tag, type(ex), ex)
     if isinstance(settings, dict):
         default_settings.update(settings)
     return default_settings


### PR DESCRIPTION
**Purpose of PR?**:  This PR fixes issue by changing the error log to a warning when reloading stored performance settings fails.

Bug Fix:
Fixes #2700

