### PR TITLE
storing mscolab_server_url in users settings

### DIFF
--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -297,7 +297,9 @@ class MSColab_ConnectDialog(QDialog, ui_conn.Ui_MSColabConnectDialog):
                         QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
                     if ret == QMessageBox.Yes:
                         url_list = [self.mscolab_server_url] + url_list
-                        modify_config_file({"default_MSCOLAB": url_list})
+                        modify_config_file({"default_MSCOLAB": url_list,
+                                            "mscolab_server_url": self.mscolab_server_url})
+
 
                 # Fill Email and Password fields from config
                 self.loginEmailLe.setText(

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -300,7 +300,6 @@ class MSColab_ConnectDialog(QDialog, ui_conn.Ui_MSColabConnectDialog):
                         modify_config_file({"default_MSCOLAB": url_list,
                                             "mscolab_server_url": self.mscolab_server_url})
 
-
                 # Fill Email and Password fields from config
                 self.loginEmailLe.setText(
                     config_loader(dataset="MSS_auth").get(self.mscolab_server_url))

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -925,7 +925,7 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
         """
         edit = editor.ConfigurationEditorWindow(self)
         # ToDo This does not include changes by modify_config_file
-        # We call it late but this needs solved better
+        # We call it late but this needs a better solution
         self.config_for_gui = edit.last_saved
         # automated_plotting_* parameters must be stored or loaded by the mssautoplot.json file
         self.config_for_gui["automated_plotting_flights"].clear()

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -930,7 +930,6 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
         # update some vars which can have changed
         self.config_for_gui["mscolab_server_url"] = config_loader(dataset="mscolab_server_url")
         self.config_for_gui["default_MSCOLAB"] = config_loader(dataset="default_MSCOLAB")
-        self.config_for_gui["default_MSCOLAB"] = config_loader(dataset="default_MSCOLAB")
         self.config_for_gui["MSS_auth"] = config_loader(dataset="MSS_auth")
         # automated_plotting_* parameters must be stored or loaded by the mssautoplot.json file
         self.config_for_gui["automated_plotting_flights"].clear()

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -927,6 +927,11 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
         # ToDo This does not include changes by modify_config_file
         # We call it late but this needs a better solution
         self.config_for_gui = edit.last_saved
+        # update some vars which can have changed
+        self.config_for_gui["mscolab_server_url"] = config_loader(dataset="mscolab_server_url")
+        self.config_for_gui["default_MSCOLAB"] = config_loader(dataset="default_MSCOLAB")
+        self.config_for_gui["default_MSCOLAB"] = config_loader(dataset="default_MSCOLAB")
+        self.config_for_gui["MSS_auth"] = config_loader(dataset="MSS_auth")
         # automated_plotting_* parameters must be stored or loaded by the mssautoplot.json file
         self.config_for_gui["automated_plotting_flights"].clear()
         self.config_for_gui["automated_plotting_hsecs"].clear()

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -450,14 +450,6 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
         self.config_editor = None
         self.local_active = True
         self.new_flight_track_counter = 0
-        edit = editor.ConfigurationEditorWindow(self)
-        # ToDo review if this can replace of other config_loader() calls
-        self.config_for_gui = edit.last_saved
-        # automated_plotting_* parameters must be stored or loaded by the mssautoplot.json file
-        self.config_for_gui["automated_plotting_flights"].clear()
-        self.config_for_gui["automated_plotting_hsecs"].clear()
-        self.config_for_gui["automated_plotting_vsecs"].clear()
-        self.config_for_gui["automated_plotting_lsecs"].clear()
 
         # Reference to the flight track that is currently displayed in the views.
         self.active_flight_track = None
@@ -931,6 +923,16 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
            a new instance of the view and adds a QActiveViewsListWidgetItem to
            the list of open views (self.listViews).
         """
+        edit = editor.ConfigurationEditorWindow(self)
+        # ToDo This does not include changes by modify_config_file
+        # We call it late but this needs solved better
+        self.config_for_gui = edit.last_saved
+        # automated_plotting_* parameters must be stored or loaded by the mssautoplot.json file
+        self.config_for_gui["automated_plotting_flights"].clear()
+        self.config_for_gui["automated_plotting_hsecs"].clear()
+        self.config_for_gui["automated_plotting_vsecs"].clear()
+        self.config_for_gui["automated_plotting_lsecs"].clear()
+
         layout = config_loader(dataset="layout")
         view_window = None
         if _type == "topview":


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2705 

While working on this, I realized that we need to update parts of the in-memory configuration based on changes made to the file for the next startup.

The mscolab_server_url is required by the AutoPlot docking widget. However, self.config_for_gui may be initialized before the MSColab server has updated its data, leading to discrepancies between what's stored and what's used.

Moving the initialization of self.config_for_gui into create_view increases the likelihood that the MSColab URL will have been updated. 

the modify_config_file changes needs to be reapplied

So we update always the by modify_config_file changed values from the stored configuration by the config_loader.
