### PR TITLE
fix: refactoring kml dockwidget for fastkml >= 1.0.0

### DIFF
--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -554,7 +554,7 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                 _fs = fs.open_fs(_dirname)
                 try:
                     with _fs.open(_name, 'r') as kmlf:
-                        self.kml = kml.KML.from_string(kmlf.read().encode('utf-8'), {})
+                        self.kml = kml.KML.from_string(kmlf.read(), {})
                         if self.listWidget.item(index).text() in self.dict_files:  # just a precautionary check
                             if self.dict_files[self.listWidget.item(index).text()]["patch"] is not None:  # added before
                                 patch = KMLPatch(self.view.map, self.kml,

--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -553,7 +553,7 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                 _dirname, _name = os.path.split(self.listWidget.item(index).text())
                 _fs = fs.open_fs(_dirname)
                 try:
-                    with _fs.open(_name, 'r') as kmlf:
+                    with _fs.open(_name, 'r', encoding='utf-8') as kmlf:
                         self.kml = kml.KML.from_string(kmlf.read(), {})
                         if self.listWidget.item(index).text() in self.dict_files:  # just a precautionary check
                             if self.dict_files[self.listWidget.item(index).text()]["patch"] is not None:  # added before

--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -555,7 +555,7 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                 try:
                     with _fs.open(_name, 'r') as kmlf:
                         self.kml = kml.KML()  # creates fastkml object
-                        self.kml.from_string(kmlf.read().encode('utf-8'))
+                        self.kml = kml.KML.from_string(kmlf.read().encode('utf-8'))
                         if self.listWidget.item(index).text() in self.dict_files:  # just a precautionary check
                             if self.dict_files[self.listWidget.item(index).text()]["patch"] is not None:  # added before
                                 patch = KMLPatch(self.view.map, self.kml,

--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -555,7 +555,7 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                 try:
                     with _fs.open(_name, 'r') as kmlf:
                         self.kml = kml.KML()  # creates fastkml object
-                        self.kml = kml.KML.from_string(kmlf.read().encode('utf-8'))
+                        self.kml.from_string(kmlf.read().encode('utf-8'))
                         if self.listWidget.item(index).text() in self.dict_files:  # just a precautionary check
                             if self.dict_files[self.listWidget.item(index).text()]["patch"] is not None:  # added before
                                 patch = KMLPatch(self.view.map, self.kml,

--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -554,7 +554,7 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                 _fs = fs.open_fs(_dirname)
                 try:
                     with _fs.open(_name, 'r') as kmlf:
-                        self.kml = kml.KML.from_string(kmlf.read().encode('utf-8'))
+                        self.kml = kml.KML.from_string(kmlf.read().encode('utf-8'), {})
                         if self.listWidget.item(index).text() in self.dict_files:  # just a precautionary check
                             if self.dict_files[self.listWidget.item(index).text()]["patch"] is not None:  # added before
                                 patch = KMLPatch(self.view.map, self.kml,

--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -554,7 +554,6 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                 _fs = fs.open_fs(_dirname)
                 try:
                     with _fs.open(_name, 'r') as kmlf:
-                        self.kml = kml.KML()  # creates fastkml object
                         self.kml = kml.KML.from_string(kmlf.read().encode('utf-8'))
                         if self.listWidget.item(index).text() in self.dict_files:  # just a precautionary check
                             if self.dict_files[self.listWidget.item(index).text()]["patch"] is not None:  # added before


### PR DESCRIPTION
**Purpose of PR?**: update the KML dockingwidget in Open-MSS to be compatible with fastkml >= 1.0.0

Fixes #2688 
