### PR TITLE
Fixing Issue (data_dir configuration have to start with ~ #2702)

### DIFF
--- a/mslib/utils/config.py
+++ b/mslib/utils/config.py
@@ -587,6 +587,28 @@ def load_settings_qsettings(tag, default_settings=None):
     return default_settings
 
 
+def validate_data_dir(path):
+    """
+    Validates that the data_dir path starts with a tilde (~) or a filesystem URL.
+    
+    Args:
+        path: The data_dir path to validate
+        
+    Returns:
+        bool: True if valid, False otherwise
+    """
+    # Check if path starts with ~ (tilde)
+    if path.startswith('~'):
+        return True
+    
+    # Check if path is a valid filesystem URL (e.g., file://, s3://, etc.)
+    # Using fs.path.isurl method to check for valid FS URLs
+    if fs.path.isurl(path):
+        return True
+        
+    return False
+
+
 def merge_dict(existing_dict, new_dict):
     """
     Merge two dictionaries by comparing all the options from
@@ -641,6 +663,11 @@ def merge_dict(existing_dict, new_dict):
             data, match = compare_data(existing_dict[key], new_dict[key])
             if match:
                 existing_dict[key] = data
+                
+                # Add special validation for data_dir
+                if key == "data_dir" and not validate_data_dir(data):
+                    logging.warning(f"Invalid data_dir format: {data}. Must start with '~' or a filesystem URL.")
+                    existing_dict[key] = existing_dict.get("data_dir", "~/mssdata")
 
     # add filepicker default to import and export plugins if missing
     for plugin_type in ["import_plugins", "export_plugins"]:


### PR DESCRIPTION
data_dir configuration have to start with ~ or a filesystem URL #2702

**Purpose of PR?**:
Fixes #2702

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Setting data_dir with valid prefix (~ or filesystem URL) works correctly
- Setting data_dir with invalid prefix shows a warning and falls back to default
- Verifying that changes to data_dir take effect after application restart

**Additional information for reviewer?** :
This PR adds validation to ensure the data_dir configuration starts with a tilde (~) or a filesystem URL as documented in the MSS docs. When an invalid format is detected, a warning is logged and the default value is used.

**Does this PR results in some Documentation changes?**
No, the requirement is already documented in https://mss.readthedocs.io/en/stable/usage.html

**Checklist:**
- [x] Bug fix. Fixes #2702
- [ ] New feature (Non-API breaking changes that adds functionality)
- [x] PR Title follows the convention of `type: description`
- [x] Commit has unit tests