### PR TITLE
enable use of autoplot without a keyring definition

### DIFF
--- a/mslib/utils/mssautoplot.py
+++ b/mslib/utils/mssautoplot.py
@@ -621,10 +621,19 @@ def main(ctx, cpath, view, ftrack, itime, vtime, intv, stime, etime, raw):
         pdlg.setValue(1)
 
     msc_url = config["mscolab_server_url"]
-    msc_auth_password = mslib.utils.auth.get_password_from_keyring(service_name=f"MSCOLAB_AUTH_{msc_url}",
-                                                                   username="mscolab")
-    msc_username = config["MSS_auth"][msc_url]
-    msc_password = mslib.utils.auth.get_password_from_keyring(service_name=msc_url, username=msc_username)
+    try:
+        msc_auth_password = mslib.utils.auth.get_password_from_keyring(service_name=f"MSCOLAB_AUTH_{msc_url}",
+                                                                       username="mscolab")
+    except KeyError:
+        msc_auth_password = None
+
+    try:
+        msc_username = config["MSS_auth"][msc_url]
+    except KeyError:
+        msc_username = None
+        msc_password = None
+    if msc_username is not None:
+        msc_password = mslib.utils.auth.get_password_from_keyring(service_name=msc_url, username=msc_username)
 
     # Choose view (top or side)
     if view == "top":


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2713
Without a mscolab server used, there is also no keyring initialized. The PR handles this usecase.

**Does this PR introduce a breaking change?**
No
**If the changes in this PR are manually verified, list down the scenarios covered:**:
- with a mscolab server definition
- without a mscolab server definition
- 
**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [X] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->