### PR TITLE
Fixed typo error on mscolab.py

### DIFF
--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -82,7 +82,7 @@ def verify_user_token(func):
     @functools.wraps(func)
     def wrapper(self, *args, **vargs):
         if self.mscolab_server_url is None:
-            # in case of a forecd logout some QT events may still trigger MSCOLAB functions
+            # in case of a forced logout some QT events may still trigger MSCOLAB functions
             return
         verify_user_token.depth += 1
         try:


### PR DESCRIPTION
**Purpose of PR?**:


Fixes #2704 (Spelling typo)

**Does this PR introduce a breaking change?**  
No  

**If the changes in this PR are manually verified, list down the scenarios covered:**  

- Verified that the typo in the comment is corrected from **"forcd"** to **"forced"** in `mscolab.py`.  

**Additional information for reviewer?** :  
- This is a minor fix correcting a spelling mistake in a comment.  
- No changes in logic or functionality.  

**Does this PR result in some Documentation changes?**  
No  

**Checklist:**  
- [x] Bug fix. Fixes #2704  
- [ ] New feature (Non-API breaking changes that adds functionality)  
- [x] PR Title follows the convention of `<type>: <subject>`  
- [x] Commit has unit tests  

