### PR TITLE
fix: removing redeclared names without usage 

### DIFF
--- a/mslib/msui/mpl_qtwidget.py
+++ b/mslib/msui/mpl_qtwidget.py
@@ -389,9 +389,6 @@ class SideViewPlotter(ViewPlotter):
     _pres_maj = np.concatenate([np.arange(top * 10, top, -top) for top in (10000, 1000, 100, 10)] + [[10]])
     _pres_min = np.concatenate([np.arange(top * 10, top, -top // 10) for top in (10000, 1000, 100, 10)] + [[10]])
 
-    _pres_maj = np.concatenate([np.arange(top * 10, top, -top) for top in (10000, 1000, 100, 10)] + [[10]])
-    _pres_min = np.concatenate([np.arange(top * 10, top, -top // 10) for top in (10000, 1000, 100, 10)] + [[10]])
-
     def __init__(self, fig=None, ax=None, settings=None, numlabels=None, num_interpolation_points=None):
         """
         Arguments:


### PR DESCRIPTION
**Purpose of PR?**: Removing unnecessary duplicate declaration of _pres_maj and _pres_min without usage.

Bug Fix:
Fixes #2742 

