### PR TITLE
fix: replacing set function call with set literal

### DIFF
--- a/mslib/msui/editor.py
+++ b/mslib/msui/editor.py
@@ -430,7 +430,7 @@ class ConfigurationEditorWindow(QtWidgets.QMainWindow, ui_conf.Ui_ConfigurationE
                     if root in removable_indexes:
                         removable_indexes[root].add(index.row())
                     else:
-                        removable_indexes[root] = set([index.row()])
+                        removable_indexes[root] = {index.row()}
                 else:
                     non_removable.append(index)
 

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -1647,7 +1647,7 @@ class MSUIMscolab(QtCore.QObject):
             operations = response["operations"]
             self.ui.filterCategoryCb.currentIndexChanged.disconnect(self.operation_category_handler)
             self.ui.filterCategoryCb.clear()
-            categories = set(["*ANY*"])
+            categories = {"*ANY*"}
             for operation in operations:
                 categories.add(operation["category"])
             categories.remove("*ANY*")

--- a/mslib/msui/mscolab_admin_window.py
+++ b/mslib/msui/mscolab_admin_window.py
@@ -88,7 +88,7 @@ class MSColabAdminWindow(QtWidgets.QMainWindow, ui.Ui_MscolabAdminWindow):
         self.load_import_operations()
         self.load_users_without_permission()
         self.load_users_with_permission()
-        categories = set(["ANY"])
+        categories = {"ANY"}
         for operation in self.operations:
             categories.add(operation["category"])
         categories.remove("ANY")

--- a/mslib/mswms/mpl_hsec.py
+++ b/mslib/mswms/mpl_hsec.py
@@ -116,12 +116,12 @@ class MPLBasemapHorizontalSectionStyle(AbstractHorizontalSectionStyle):
         Returns a list of the coordinate reference systems supported by
         this style.
         """
-        crs_list = set([
+        crs_list = {
             "EPSG:3031",  # WGS 84 / Antarctic Polar Stereographic
             "EPSG:3995",  # WGS 84 / Arctic Polar Stereographic
             "EPSG:3857",  # WGS 84 / Spherical Mercator
             "EPSG:4326",  # WGS 84 / cylindric
-            "MSS:stere"])
+            "MSS:stere"}
         for code in self.supported_epsg_codes():
             crs_list.add(f"EPSG:{code:d}")
         return sorted(crs_list)


### PR DESCRIPTION
**Purpose of PR?**: To replace set function calls set([ ]) with set literals { } eliminating unnecessary intermediate list construction 

Fixes #2744 

