### PR TITLE
fix: update abstract base class to include missing parameter

### DIFF
--- a/mslib/mswms/dataaccess.py
+++ b/mslib/mswms/dataaccess.py
@@ -118,7 +118,7 @@ class NWPDataAccess(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _determine_filename(self, variable, vartype, init_time, valid_time, reload= False):
+    def _determine_filename(self, variable, vartype, init_time, valid_time, reload=False):
         """
         Must be overwritten in subclass. Determines the filename
         (without path) of the variable <variable> at the forecast

--- a/mslib/mswms/dataaccess.py
+++ b/mslib/mswms/dataaccess.py
@@ -118,7 +118,7 @@ class NWPDataAccess(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _determine_filename(self, variable, vartype, init_time, valid_time, reload=False):
+    def _determine_filename(self, variable, vartype, init_time, valid_time, reload=True):
         """
         Must be overwritten in subclass. Determines the filename
         (without path) of the variable <variable> at the forecast

--- a/mslib/mswms/dataaccess.py
+++ b/mslib/mswms/dataaccess.py
@@ -118,7 +118,7 @@ class NWPDataAccess(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _determine_filename(self, variable, vartype, init_time, valid_time):
+    def _determine_filename(self, variable, vartype, init_time, valid_time, reload= False):
         """
         Must be overwritten in subclass. Determines the filename
         (without path) of the variable <variable> at the forecast

--- a/tests/_test_mswms/test_dataaccess.py
+++ b/tests/_test_mswms/test_dataaccess.py
@@ -90,6 +90,22 @@ class Test_DefaultDataAccess:
                     datetime(2012, 10, 18, 12, 0),
                     datetime(2012, 10, 19, 0, 0)])
 
+    def test_determine_filename_reload(self):
+        variable = "air_pressure"
+        vartype = "ml"
+        init_time = datetime(2012, 10, 17, 12, 0)
+        valid_time = datetime(2012, 10, 17, 18, 0)
+
+        self.dut._filetree = {vartype: {init_time: {variable: {}}}}
+
+        def fake_setup():
+            self.dut._filetree[vartype][init_time][variable][valid_time] = "expected_filename.nc"
+
+        self.dut.setup = mock.MagicMock(side_effect=fake_setup)
+
+        filename = self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=True)
+        assert filename == "expected_filename.nc"
+
 
 class Test_CachedDataAccess(Test_DefaultDataAccess):
     """

--- a/tests/_test_mswms/test_dataaccess.py
+++ b/tests/_test_mswms/test_dataaccess.py
@@ -30,6 +30,7 @@ import os
 from datetime import datetime
 
 import mock
+import pytest
 
 from mslib.mswms.dataaccess import DefaultDataAccess, CachedDataAccess
 from tests.constants import DATA_DIR
@@ -108,13 +109,8 @@ class Test_DefaultDataAccess:
         self.dut.setup.assert_called_once()
 
         self.dut._filetree = {vartype: {init_time: {variable: {}}}}
-        exception_was_raised = False
-        try:
+        with pytest.raises(ValueError):
             self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=False)
-        except ValueError:
-            exception_was_raised = True
-
-        assert exception_was_raised, "Expected ValueError was not raised when reload=False"
 
 
 class Test_CachedDataAccess(Test_DefaultDataAccess):

--- a/tests/_test_mswms/test_dataaccess.py
+++ b/tests/_test_mswms/test_dataaccess.py
@@ -97,20 +97,35 @@ class Test_DefaultDataAccess:
         init_time = datetime(2012, 10, 17, 12, 0)
         valid_time = datetime(2012, 10, 17, 18, 0)
 
-        self.dut._filetree = {vartype: {init_time: {variable: {}}}}
-
-        def fake_setup():
-            self.dut._filetree[vartype][init_time][variable][valid_time] = "expected_filename.nc"
-
-        self.dut.setup = mock.MagicMock(side_effect=fake_setup)
-
-        filename = self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=True)
-        assert filename == "expected_filename.nc"
-        self.dut.setup.assert_called_once()
-
-        self.dut._filetree = {vartype: {init_time: {variable: {}}}}
+        # call with reload=False, expect an error
+        self.dut._filetree = {}
         with pytest.raises(ValueError):
             self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=False)
+
+        # with reload=True test data being loaded
+        filename = self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=True)
+        file_path = os.path.join(DATA_DIR, filename)
+        assert os.path.exists(file_path), f"Expected file {file_path} to exist"
+
+        # remove a file, with reload =False, it is still returned
+        backup_path = file_path + ".bak"
+        os.rename(file_path, backup_path)
+        old_filename = self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=False)
+        assert old_filename == filename
+
+        # with reload=True, removed file not returned
+        with pytest.raises(ValueError):
+            self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=True)
+
+        # add file, with reload=False file is not returned
+        os.rename(backup_path, file_path)
+
+        updated_filename = self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=False)
+        assert updated_filename == filename
+
+        # with reload=True, added file is returned
+        restored_filename = self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=True)
+        assert restored_filename == filename
 
 
 class Test_CachedDataAccess(Test_DefaultDataAccess):

--- a/tests/_test_mswms/test_dataaccess.py
+++ b/tests/_test_mswms/test_dataaccess.py
@@ -105,6 +105,16 @@ class Test_DefaultDataAccess:
 
         filename = self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=True)
         assert filename == "expected_filename.nc"
+        self.dut.setup.assert_called_once()
+
+        self.dut._filetree = {vartype: {init_time: {variable: {}}}}
+        exception_was_raised = False
+        try:
+            self.dut._determine_filename(variable, vartype, init_time, valid_time, reload=False)
+        except ValueError:
+            exception_was_raised = True
+
+        assert exception_was_raised, "Expected ValueError was not raised when reload=False"
 
 
 class Test_CachedDataAccess(Test_DefaultDataAccess):


### PR DESCRIPTION
**Purpose of PR?**: Updates the abstract base class signature of _determine_filename to include a default reload parameter, aligning it with its implementations and usage in have_data.


Bug fix
Fixes #2745 

