### PR TITLE
fix:  _icon call args to match parent signature 

### DIFF
--- a/mslib/msui/mpl_qtwidget.py
+++ b/mslib/msui/mpl_qtwidget.py
@@ -980,7 +980,7 @@ class NavigationToolbar(NavigationToolbar2QT):
         if os.path.exists(myname):
             return QtGui.QIcon(myname)
         else:
-            return super()._icon(name, *args)
+            return super()._icon(name)
 
     def _zoom_pan_handler(self, event):
         """


### PR DESCRIPTION
**Purpose of PR?**: Removes extra arguments from the super()._icon call to match the parent method's expected signature.


Bug Fix
Fixes #2747 

