### PR TITLE
Update setup.py for Python 3.12 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     version=__version__,  # noqa
     description="MSS - Mission Support System",
     long_description=long_description,
-    classifiers="Development Status :: 5 - Production/Stable",
+    classifiers=["Development Status :: 5 - Production/Stable","Programming Language :: Python :: 3.12",],
     keywords="mslib",
     maintainer="Reimar Bauer",
     maintainer_email="rb.proj@gmail.com",


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2738 

**Enhancement: Ensure Python 3.12 Compatibility**  

This PR verifies and updates MSS to support Python 3.12.  
- Tested MSS on Python 3.12.  
- Updated `setup.py` to include Python 3.12 version.
- Ran tests to ensure compatibility. 