### PR TITLE
Fix: update classifiers field to be a list as per PEP-301

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     version=__version__,  # noqa
     description="MSS - Mission Support System",
     long_description=long_description,
-    classifiers="Development Status :: 5 - Production/Stable",
+    classifiers=["Development Status :: 5 - Production/Stable",],
     keywords="mslib",
     maintainer="Reimar Bauer",
     maintainer_email="rb.proj@gmail.com",


### PR DESCRIPTION
**Purpose of PR**:
- Updated `classifiers` field in `setup.py` to be a list, as required by PEP-301.

**Does this PR introduce a breaking change?**
- No, this is a minor fix.

**If the changes in this PR are manually verified, list down the scenarios covered**:
- Verified that the `setup.py` file correctly follows PEP-301 format.

**Additional information for reviewer**:
- No additional information.

**Does this PR result in some Documentation changes?**
- No.

**Checklist:**
- [x] Bug fix. Fixes formatting issue in `setup.py`.
- [x] PR Title follows the convention of `<type>: <subject>`.
