### PR TITLE
Fix: Update classifiers field to be a list as per PEP-301

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -13835,8 +13835,8 @@ packages:
   timestamp: 1732915114536
 - pypi: .
   name: open-mss
-  version: 10.0.1
-  sha256: 4924815185aeaeb6892a2df38a6cdcfcd00da1a22fe0c67412382ecd77266882
+  version: 10.1.0
+  sha256: 056900f3a0da5ccc53b992cdc95c767c45ea9de9cb7dd064de8500ad7b7cc465
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2024.10.24-h5888daf_0.conda
   sha256: 7e1d3ad55d4ad3ddf826e205d4603b9ed40c5e655a9dfd66b56f459d7ba14db3

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     version=__version__,  # noqa
     description="MSS - Mission Support System",
     long_description=long_description,
-    classifiers="Development Status :: 5 - Production/Stable",
+    classifiers=["Development Status :: 5 - Production/Stable",],
     keywords="mslib",
     maintainer="Reimar Bauer",
     maintainer_email="rb.proj@gmail.com",


### PR DESCRIPTION
**Purpose of PR?**:  
Fixes #2761  
This PR updates the `classifiers` field in `setup.py` to be a list, as required by PEP-301.  

**Does this PR introduce a breaking change?**  
No, this is a metadata fix and does not impact functionality.  

**If the changes in this PR are manually verified, list down the scenarios covered:**  
- Verified that `setup.py` now correctly uses a list for `classifiers`.  
- Ensured that package installation remains unaffected.  

**Additional information for reviewer?**  
This update aligns the `setup.py` file with PEP-301, ensuring compliance with Python packaging standards.  

**Does this PR result in some Documentation changes?**  
No documentation changes are required.  

**Checklist:**  
- [x] Bug fix. Fixes #2761  
- [ ] New feature (Non-API breaking changes that add functionality)  
- [x] PR Title follows the convention of `<type>: <subject>`  
- [x] Commit has unit tests (Not applicable)  
