### PR TITLE
Fixed issues with call to Super class

### DIFF
--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -249,13 +249,11 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # Open the master again, this time as a classic CDF instance. This will avoid
         # calling methods of the CDFMF subclass when querying the master file.
         cdfm = netCDF4.Dataset(master)
-
         if_unlimited_dim = any(dim.isunlimited() for dim in cdfm.dimensions.values())
         if not if_unlimited_dim:
             self.cdf = [cdfm]
         else:
             super().__init__(files)
-
         # copy attributes from master.
         self.__dict__.update(cdfm.__dict__)
 

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -249,6 +249,14 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # Open the master again, this time as a classic CDF instance. This will avoid
         # calling methods of the CDFMF subclass when querying the master file.
         cdfm = netCDF4.Dataset(master)
+
+        if_unlimited_dim = False
+        if_unlimited_dim = any(dim.isunlimited() for dim in cdfm.dimensions.values())
+        if not if_unlimited_dim:
+            self.cdf = [cdfm]
+        else:
+            super().__init__(files, exclude=exclude, require_dim_num=require_dim_num)
+            
         # copy attributes from master.
         self.__dict__.update(cdfm.__dict__)
 

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -315,7 +315,7 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         self._files = files  # list of cdf file names in the set
         self._dims = cdfm.dimensions
         self._vars = {k: v for k, v in cdfm.variables.items() if k not in exclude}
-        self._cdfOrigin = {k: (master,cdfm) for k in self._vars}
+        self._cdfOrigin = {k: (master, cdfm) for k in self._vars}
 
         self._file_format = []
         for dset in self._cdf:

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -200,7 +200,6 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
 
     def __init__(self, files, exclude=None, skip_dim_check=None,
                  require_dim_num=False):
-        super().__init__(files)
         """
         Open a Dataset spanning multiple files sharing common dimensions but
         containing different record variables, making it look as if it was a
@@ -238,7 +237,6 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         """
         # Open the master file in the base class, so that the CDFMF instance
         # can be used like a CDF instance.
-
         exclude = exclude or []
         skip_dim_check = skip_dim_check or []
         if isinstance(files, str):
@@ -251,7 +249,6 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         cdfm = netCDF4.Dataset(master)
         if_unlimited_dim = any(dim.isunlimited() for dim in cdfm.dimensions.values())
         if not if_unlimited_dim:
-            super().__init__()
             self._cdf = [cdfm]
             self._isopen = True
         else:

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -200,7 +200,7 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
 
     def __init__(self, files, exclude=None, skip_dim_check=None,
                  require_dim_num=False):
-        super().__init__(files, exclude=exclude, require_dim_num=require_dim_num)
+        super().__init__(files)
         """
         Open a Dataset spanning multiple files sharing common dimensions but
         containing different record variables, making it look as if it was a
@@ -250,13 +250,12 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # calling methods of the CDFMF subclass when querying the master file.
         cdfm = netCDF4.Dataset(master)
 
-        if_unlimited_dim = False
         if_unlimited_dim = any(dim.isunlimited() for dim in cdfm.dimensions.values())
         if not if_unlimited_dim:
             self.cdf = [cdfm]
         else:
-            super().__init__(files, exclude=exclude, require_dim_num=require_dim_num)
-            
+            super().__init__(files)
+
         # copy attributes from master.
         self.__dict__.update(cdfm.__dict__)
 

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -200,6 +200,7 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
 
     def __init__(self, files, exclude=None, skip_dim_check=None,
                  require_dim_num=False):
+        super().__init__(files, exclude=exclude, require_dim_num=require_dim_num)
         """
         Open a Dataset spanning multiple files sharing common dimensions but
         containing different record variables, making it look as if it was a

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -266,8 +266,6 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # Create the following:
         #   cdf       list of Dataset instances
         #   cdfVar    dictionary indexed by the variable names
-        cdf = [cdfm]
-        self._cdf = cdf  # Store this now, because dim() method needs it
         cdfVar = {}
         cdfOrigin = {}
         for vName, v in cdfm.variables.items():

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -251,7 +251,9 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         cdfm = netCDF4.Dataset(master)
         if_unlimited_dim = any(dim.isunlimited() for dim in cdfm.dimensions.values())
         if not if_unlimited_dim:
-            self.cdf = [cdfm]
+            super().__init__()
+            self._cdf = [cdfm]
+            self._isopen = True
         else:
             super().__init__(files)
         # copy attributes from master.

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -266,6 +266,7 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # Create the following:
         #   cdf       list of Dataset instances
         #   cdfVar    dictionary indexed by the variable names
+        cdf = []
         cdfVar = {}
         cdfOrigin = {}
         for vName, v in cdfm.variables.items():

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -248,8 +248,8 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # calling methods of the CDFMF subclass when querying the master file.
         cdfm = netCDF4.Dataset(master)
         if_unlimited_dim = any(dim.isunlimited() for dim in cdfm.dimensions.values())
-        if not if_unlimited_dim: 
-        # copy attributes from master.
+        if not if_unlimited_dim:
+            # copy attributes from master.
             self.__dict__.update(cdfm.__dict__)
         # Get names of master dimensions.
             masterDims = list(cdfm.dimensions.keys())
@@ -272,7 +272,7 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
             cdfOrigin[vName] = (master, cdfm)
         if len(cdfVar) == 0:
             raise IOError(f"master dataset '{master}' does not have any variable")
-        self._cdf =[cdfm]
+        self._cdf = [cdfm]
         self._isopen = True
         # Open each remaining file in read-only mode.
         # Make sure each file defines the same record variables as the master

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -314,8 +314,8 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # A local __setattr__() method is required for them.
         self._files = files  # list of cdf file names in the set
         self._dims = cdfm.dimensions
-        self._vars = {k:v for k,v in cdfm.variables.items() if k not in exclude}
-        self._cdfOrigin = {k:(master,cdfm) for k in self._vars}
+        self._vars = {k: v for k, v in cdfm.variables.items() if k not in exclude}
+        self._cdfOrigin = {k: (master,cdfm) for k in self._vars}
 
         self._file_format = []
         for dset in self._cdf:

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -248,16 +248,11 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # calling methods of the CDFMF subclass when querying the master file.
         cdfm = netCDF4.Dataset(master)
         if_unlimited_dim = any(dim.isunlimited() for dim in cdfm.dimensions.values())
-        if not if_unlimited_dim:
-            self._cdf = [cdfm]
-            self._isopen = True
-        else:
-            super().__init__(files)
+        if not if_unlimited_dim: 
         # copy attributes from master.
-        self.__dict__.update(cdfm.__dict__)
-
+            self.__dict__.update(cdfm.__dict__)
         # Get names of master dimensions.
-        masterDims = list(cdfm.dimensions.keys())
+            masterDims = list(cdfm.dimensions.keys())
         # Check that each dimension has a coordinate dimension
         for dimName in masterDims:
             if dimName not in cdfm.variables and dimName not in skip_dim_check:

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -241,7 +241,7 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         skip_dim_check = skip_dim_check or []
         if isinstance(files, str):
             files = sorted(glob.glob(files))
-
+        super().__init__(files)
         master = files[0]
 
         # Open the master again, this time as a classic CDF instance. This will avoid
@@ -266,7 +266,8 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # Create the following:
         #   cdf       list of Dataset instances
         #   cdfVar    dictionary indexed by the variable names
-        cdf = []
+        cdf = [cdfm]
+        self._cdf = cdf  # Store this now, because dim() method needs it
         cdfVar = {}
         cdfOrigin = {}
         for vName, v in cdfm.variables.items():
@@ -276,7 +277,8 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
             cdfOrigin[vName] = (master, cdfm)
         if len(cdfVar) == 0:
             raise IOError(f"master dataset '{master}' does not have any variable")
-
+        self._cdf =[cdfm]
+        self._isopen = True
         # Open each remaining file in read-only mode.
         # Make sure each file defines the same record variables as the master
         # and that the variables are defined in the same way (name, shape and type)
@@ -313,8 +315,8 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # A local __setattr__() method is required for them.
         self._files = files  # list of cdf file names in the set
         self._dims = cdfm.dimensions
-        self._vars = {k: v for k, v in cdfm.variables.items() if k not in exclude}
-        self._cdfOrigin = {k: (master, cdfm) for k in self._vars}
+        self._vars = cdfVar
+        self._cdfOrigin = cdfOrigin
 
         self._file_format = []
         for dset in self._cdf:

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -317,8 +317,8 @@ class MFDatasetCommonDims(netCDF4.MFDataset):
         # A local __setattr__() method is required for them.
         self._files = files  # list of cdf file names in the set
         self._dims = cdfm.dimensions
-        self._vars = cdfVar
-        self._cdfOrigin = cdfOrigin
+        self._vars = {k:v for k,v in cdfm.variables.items() if k not in exclude}
+        self._cdfOrigin = {k:(master,cdfm) for k in self._vars}
 
         self._file_format = []
         for dset in self._cdf:

--- a/mslib/utils/ogcwms.py
+++ b/mslib/utils/ogcwms.py
@@ -171,10 +171,9 @@ class WebMapService(wms111.WebMapService_1_1_1):
                  parse_remote_metadata=False, headers=None,
                  timeout=config_loader(dataset="WMS_request_timeout"),
                  auth=None):
+        """Initialize."""
         super().__init__(url, version, xml, username, password,
                          parse_remote_metadata, headers, timeout, auth)
-        """Initialize."""
-
         if auth:
             if username:
                 auth.username = username

--- a/mslib/utils/ogcwms.py
+++ b/mslib/utils/ogcwms.py
@@ -171,6 +171,8 @@ class WebMapService(wms111.WebMapService_1_1_1):
                  parse_remote_metadata=False, headers=None,
                  timeout=config_loader(dataset="WMS_request_timeout"),
                  auth=None):
+        super().__init__(url, version, xml, username, password,
+                         parse_remote_metadata, headers, timeout, auth)
         """Initialize."""
 
         if auth:


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2750

## fix: add missing super().__init__() calls  

This PR adds the missing `super().__init__()` calls in `MFDatasetCommonDims` and  
`WebMapService` to ensure proper parent class initialization.  
Ensured proper initialization of the parent class `netCDF4.MFDataset`, improving compatibility  
and following rules of OOPs (object-oriented principles).  