### PR TITLE
sets a tmp dir for wms_cache

### DIFF
--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -496,8 +496,12 @@ class TestWMSControlWidgetSetupSimple:
 
     @pytest.fixture(autouse=True)
     def setup(self, qtbot):
+        wc.WMS_SERVICE_CACHE = {}
         self.view = HSecViewMockup()
-        self.window = wc.HSecWMSControlWidget(view=self.view)
+        self.tempdir = tempfile.mkdtemp()
+        if not os.path.exists(self.tempdir):
+            os.mkdir(self.tempdir)
+        self.window = wc.HSecWMSControlWidget(view=self.view, wms_cache=self.tempdir)
         self.window.show()
 
         # Remove all previous cached URLs
@@ -507,6 +511,10 @@ class TestWMSControlWidgetSetupSimple:
 
         yield
         self.window.hide()
+
+    def test_wms_cache_tmp(self):
+        assert self.window.wms_cache is not None
+        assert "tmp" in self.window.wms_cache
 
     def test_xml(self):
         testxml = self.xml.format("", self.srs_base, self.dimext_time + self.dimext_inittime + self.dimext_elevation)

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -495,10 +495,10 @@ class TestWMSControlWidgetSetupSimple:
         <Extent name="ELEVATION" default="900.0"> 500.0,600.0,700.0,900.0 </Extent>"""
 
     @pytest.fixture(autouse=True)
-    def setup(self, tmp_path_factory, qtbot):
+    def setup(self, tmp_path, qtbot):
         wc.WMS_SERVICE_CACHE = {}
         self.view = HSecViewMockup()
-        self.tempdir = tmp_path_factory.mktemp("TMP_WMS")
+        self.tempdir = tmp_path
         self.window = wc.HSecWMSControlWidget(view=self.view, wms_cache=self.tempdir)
         self.window.show()
 

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -512,7 +512,8 @@ class TestWMSControlWidgetSetupSimple:
 
     def test_wms_cache_tmp(self):
         assert self.window.wms_cache is not None
-        assert "TMP_WMS" in self.window.wms_cache
+        # wms_cache has an ending path separator
+        assert str(self.tempdir) == self.window.wms_cache[:-1]
 
     def test_xml(self):
         testxml = self.xml.format("", self.srs_base, self.dimext_time + self.dimext_inittime + self.dimext_elevation)

--- a/tests/_test_msui/test_wms_control.py
+++ b/tests/_test_msui/test_wms_control.py
@@ -495,12 +495,10 @@ class TestWMSControlWidgetSetupSimple:
         <Extent name="ELEVATION" default="900.0"> 500.0,600.0,700.0,900.0 </Extent>"""
 
     @pytest.fixture(autouse=True)
-    def setup(self, qtbot):
+    def setup(self, tmp_path_factory, qtbot):
         wc.WMS_SERVICE_CACHE = {}
         self.view = HSecViewMockup()
-        self.tempdir = tempfile.mkdtemp()
-        if not os.path.exists(self.tempdir):
-            os.mkdir(self.tempdir)
+        self.tempdir = tmp_path_factory.mktemp("TMP_WMS")
         self.window = wc.HSecWMSControlWidget(view=self.view, wms_cache=self.tempdir)
         self.window.show()
 
@@ -514,7 +512,7 @@ class TestWMSControlWidgetSetupSimple:
 
     def test_wms_cache_tmp(self):
         assert self.window.wms_cache is not None
-        assert "tmp" in self.window.wms_cache
+        assert "TMP_WMS" in self.window.wms_cache
 
     def test_xml(self):
         testxml = self.xml.format("", self.srs_base, self.dimext_time + self.dimext_inittime + self.dimext_elevation)


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2793

To ensure tests don't write to the user space, a wms_cache must be configured.
