### PR TITLE
2688 refactor kml dockwidget

### DIFF
--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -554,8 +554,7 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
                 _fs = fs.open_fs(_dirname)
                 try:
                     with _fs.open(_name, 'r') as kmlf:
-                        self.kml = kml.KML()  # creates fastkml object
-                        self.kml.from_string(kmlf.read().encode('utf-8'))
+                        self.kml = kml.KML.from_string(kmlf.read().encode('utf-8'))
                         if self.listWidget.item(index).text() in self.dict_files:  # just a precautionary check
                             if self.dict_files[self.listWidget.item(index).text()]["patch"] is not None:  # added before
                                 patch = KMLPatch(self.view.map, self.kml,


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2688 

Changes committed :
- Update fastkml KML parsing for compatibility with version >=1.0.0
- Replaced deprecated `.from_string()` usage and added encoding to ensure compatibility with fastkml 1.0.0.