### PR TITLE
Replace mutable github action tags with commit SHAs

### DIFF
--- a/.github/workflows/build_docs_gallery.yml
+++ b/.github/workflows/build_docs_gallery.yml
@@ -7,8 +7,8 @@ jobs:
   Test-MSS-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.8.4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: prefix-dev/setup-pixi@8eaba7c61d661f73d558b0b477156b7b62667fa4
       with:
         pixi-version: latest
         cache: true

--- a/.github/workflows/build_docs_gallery.yml
+++ b/.github/workflows/build_docs_gallery.yml
@@ -7,8 +7,8 @@ jobs:
   Test-MSS-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-    - uses: prefix-dev/setup-pixi@8eaba7c61d661f73d558b0b477156b7b62667fa4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: prefix-dev/setup-pixi@8eaba7c61d661f73d558b0b477156b7b62667fa4 # v0.8.4
       with:
         pixi-version: latest
         cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.8.4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: prefix-dev/setup-pixi@8eaba7c61d661f73d558b0b477156b7b62667fa4 # v0.8.4
       with:
         pixi-version: latest
         cache: true
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.8.4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: prefix-dev/setup-pixi@8eaba7c61d661f73d558b0b477156b7b62667fa4 # v0.8.4
       with:
         pixi-version: latest
         cache: true
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check for CRLF in the repository
       run: |
         files_with_crlf="$(git ls-files --eol | awk '$1 ~ "crlf"')"
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Check for whitespace issues in the repository
       # The two example.txt files need to be excluded because whitespace at EOL is part
       # of their format and they fail to parse otherwise.

--- a/.github/workflows/testing-all-oses.yml
+++ b/.github/workflows/testing-all-oses.yml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         os: ["macos-13", "macos-14", "ubuntu-latest"]
     steps:
-    - uses: actions/checkout@v4
-    - uses: prefix-dev/setup-pixi@v0.8.4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+    - uses: prefix-dev/setup-pixi@8eaba7c61d661f73d558b0b477156b7b62667fa4 # v0.8.4
       with:
         pixi-version: latest
         cache: true

--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         base_branch: ["develop", "stable"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ matrix.base_branch }}
       - name: Generate new lockfile
-        uses: prefix-dev/setup-pixi@v0.8.4
+        uses: prefix-dev/setup-pixi@8eaba7c61d661f73d558b0b477156b7b62667fa4 # v0.8.4
         with:
           pixi-version: latest
           run-install: false
@@ -28,7 +28,7 @@ jobs:
           set -o pipefail
           pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
       - name: Create or update pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
         with:
           token: ${{ secrets.PAT }}
           branch: automation/update-pixi-lockfile


### PR DESCRIPTION
**Purpose of PR?**:

parts #2736 

Changes done:
- Replaces all mutable `@v*` tags in GitHub Actions workflows with exact commit SHAs .
- Referencing tags like `actions/checkout@v4`) is vulnerable to supply chain attacks, as tags are mutable.