### PR TITLE
Refactor contour styling to fix MatplotlibDeprecationWarning

### DIFF
--- a/docs/samples/config/mswms/mss_chem_plots.py
+++ b/docs/samples/config/mswms/mss_chem_plots.py
@@ -93,9 +93,10 @@ class HS_MSSChemStyle(MPLBasemapHorizontalSectionStyle):
                                colors=cont_colour, linestyles=cont_style, linewidths=cont_lw)
             cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fmt='%i')
             if pe:
-                plt.setp(cs_pv.collections, path_effects=[patheffects.withStroke(linewidth=cont_lw + 2,
-                                                                                 foreground="w")])
-                plt.setp(cs_pv_lab, path_effects=[patheffects.withStroke(linewidth=1, foreground="w")])
+                for i in cs_pv.collections:
+                    i.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
+                for label in cs_pv_lab:
+                    label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
 
         # define position of the colorbar and the orientation of the ticks
         if self.crs.lower() == "epsg:77774020":

--- a/docs/samples/config/mswms/mss_chem_plots.py
+++ b/docs/samples/config/mswms/mss_chem_plots.py
@@ -93,8 +93,7 @@ class HS_MSSChemStyle(MPLBasemapHorizontalSectionStyle):
                                colors=cont_colour, linestyles=cont_style, linewidths=cont_lw)
             cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fmt='%i')
             if pe:
-                for i in cs_pv.collections:
-                    i.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
+                cs_pv.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
                 for label in cs_pv_lab:
                     label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
 

--- a/docs/samples/config/mswms/mss_chem_plots.py
+++ b/docs/samples/config/mswms/mss_chem_plots.py
@@ -253,11 +253,11 @@ class VS_MSSChemStyle(AbstractVerticalSectionStyle):
             else:
                 cs_pv = ax.contour(curtain_lat, curtain_p, self.data[cont_data], cont_levels,
                                    colors=cont_colour, linestyles=cont_style, linewidths=cont_lw)
-                plt.setp(cs_pv.collections,
-                         path_effects=[patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
                 cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fontsize=8, fmt='%i')
-                plt.setp(cs_pv_lab, path_effects=[patheffects.withStroke(linewidth=1, foreground="w")])
-
+                if pe:
+                    cs_pv.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
+                    for label in cs_pv_lab:
+                        label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
         # Pressure decreases with index, i.e. orography is stored at the
         # zero-p-index (data field is flipped in mss_plot_driver.py if
         # pressure increases with index).

--- a/docs/samples/config/mswms/mss_chem_plots.py
+++ b/docs/samples/config/mswms/mss_chem_plots.py
@@ -94,8 +94,7 @@ class HS_MSSChemStyle(MPLBasemapHorizontalSectionStyle):
             cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fmt='%i')
             if pe:
                 cs_pv.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
-                for label in cs_pv_lab:
-                    label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
+                plt.setp(cs_pv_lab, path_effects=[patheffects.withStroke(linewidth=1, foreground="w")])
 
         # define position of the colorbar and the orientation of the ticks
         if self.crs.lower() == "epsg:77774020":
@@ -256,8 +255,7 @@ class VS_MSSChemStyle(AbstractVerticalSectionStyle):
                 cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fontsize=8, fmt='%i')
                 if pe:
                     cs_pv.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
-                    for label in cs_pv_lab:
-                        label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
+                    plt.setp(cs_pv_lab, path_effects=[patheffects.withStroke(linewidth=1, foreground="w")])
         # Pressure decreases with index, i.e. orography is stored at the
         # zero-p-index (data field is flipped in mss_plot_driver.py if
         # pressure increases with index).

--- a/mslib/mswms/mpl_hsec_styles.py
+++ b/mslib/mswms/mpl_hsec_styles.py
@@ -110,8 +110,7 @@ class HS_GenericStyle(MPLBasemapHorizontalSectionStyle):
                                colors=cont_colour, linestyles=cont_style, linewidths=cont_lw)
             cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fmt='%.0f')
             if pe:
-                for i in cs_pv.collections:
-                    i.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
+                cs_pv.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
                 for label in cs_pv_lab:
                     label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
 

--- a/mslib/mswms/mpl_hsec_styles.py
+++ b/mslib/mswms/mpl_hsec_styles.py
@@ -110,9 +110,10 @@ class HS_GenericStyle(MPLBasemapHorizontalSectionStyle):
                                colors=cont_colour, linestyles=cont_style, linewidths=cont_lw)
             cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fmt='%.0f')
             if pe:
-                plt.setp(cs_pv.collections, path_effects=[
-                    patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
-                plt.setp(cs_pv_lab, path_effects=[patheffects.withStroke(linewidth=1, foreground="w")])
+                for i in cs_pv.collections:
+                    i.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
+                for label in cs_pv_lab:
+                    label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
 
         # define position of the colorbar and the orientation of the ticks
         if self.crs.lower() == "epsg:77774020":

--- a/mslib/mswms/mpl_hsec_styles.py
+++ b/mslib/mswms/mpl_hsec_styles.py
@@ -111,8 +111,7 @@ class HS_GenericStyle(MPLBasemapHorizontalSectionStyle):
             cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fmt='%.0f')
             if pe:
                 cs_pv.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
-                for label in cs_pv_lab:
-                    label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
+                plt.setp(cs_pv_lab, path_effects=[patheffects.withStroke(linewidth=1, foreground="w")])
 
         # define position of the colorbar and the orientation of the ticks
         if self.crs.lower() == "epsg:77774020":

--- a/mslib/mswms/mpl_vsec_styles.py
+++ b/mslib/mswms/mpl_vsec_styles.py
@@ -88,8 +88,7 @@ class VS_GenericStyle(AbstractVerticalSectionStyle):
                                    colors=cont_colour, linestyles=cont_style, linewidths=cont_lw)
                 cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fontsize=8, fmt='%.0f')
                 if pe:
-                    for i in cs_pv.collections:
-                        i.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
+                    cs_pv.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
                     for label in cs_pv_lab:
                         label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
         # Pressure decreases with index, i.e. orography is stored at the

--- a/mslib/mswms/mpl_vsec_styles.py
+++ b/mslib/mswms/mpl_vsec_styles.py
@@ -89,8 +89,7 @@ class VS_GenericStyle(AbstractVerticalSectionStyle):
                 cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fontsize=8, fmt='%.0f')
                 if pe:
                     cs_pv.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
-                    for label in cs_pv_lab:
-                        label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
+                    plt.setp(cs_pv_lab, path_effects=[patheffects.withStroke(linewidth=1, foreground="w")])
         # Pressure decreases with index, i.e. orography is stored at the
         # zero-p-index (data field is flipped in mss_plot_driver.py if
         # pressure increases with index).

--- a/mslib/mswms/mpl_vsec_styles.py
+++ b/mslib/mswms/mpl_vsec_styles.py
@@ -88,10 +88,10 @@ class VS_GenericStyle(AbstractVerticalSectionStyle):
                                    colors=cont_colour, linestyles=cont_style, linewidths=cont_lw)
                 cs_pv_lab = ax.clabel(cs_pv, colors=cont_label_colour, fontsize=8, fmt='%.0f')
                 if pe:
-                    plt.setp(cs_pv.collections,
-                             path_effects=[patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
-                    plt.setp(cs_pv_lab, path_effects=[patheffects.withStroke(linewidth=1, foreground="w")])
-
+                    for i in cs_pv.collections:
+                        i.set_path_effects([patheffects.withStroke(linewidth=cont_lw + 2, foreground="w")])
+                    for label in cs_pv_lab:
+                        label.set_path_effects([patheffects.withStroke(linewidth=1, foreground="w")])
         # Pressure decreases with index, i.e. orography is stored at the
         # zero-p-index (data field is flipped in mss_plot_driver.py if
         # pressure increases with index).


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2728 
Changes done:
- Fixed deprecated use of `.collections` in contour plotting for matplotlib>=3.8 to prevent `MatplotlibDeprecationWarning`.
- Updated `_plot_style()` to use `ContourSet.set_path_effects()` directly.
- updated contour styling files of styles and plots.
- Verified existing plot behavior remains unchanged by test cases passing.

