### PR TITLE
Added Python 3.12 compatibility support

### DIFF
--- a/.github/workflows/testing-all-oses.yml
+++ b/.github/workflows/testing-all-oses.yml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-13", "macos-14", "ubuntu-latest"]
+        env: ["dev", "py312"]
+        python-version: [3.12]
     steps:
     - uses: actions/checkout@v4
     - uses: prefix-dev/setup-pixi@v0.8.7

--- a/pixi.toml
+++ b/pixi.toml
@@ -51,7 +51,7 @@ pyjwt = "*"
 pymysql = ">=0.9.3"
 pyqt = ">=5.15.0"
 pysaml2 = "*"
-python = "<3.12"
+python = ">=3.8"
 python-engineio = ">=4"
 python-slugify = "*"
 python-socketio = ">=5"
@@ -118,7 +118,11 @@ pyautogui = "*"
 pyscreeze = "*"
 python-mss = "*"
 
+[feature.py312.dependencies]
+python = "3.12.*"
+
 [environments]
 addons = ["addons"]
 dev = ["dev"]
 tutorials = ["tutorials"]
+py312 = ["py312"]


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2738 

- Updated py version pinning in`pixi.toml`.
- Did the setup of env. for `py3.12` and also added them for ci testing
- Ran test suite to check the version compatibility.