### PR TITLE
pin xstatic upper bound

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -66,7 +66,7 @@ unicodecsv = "*"
 validate_email = "*"
 websocket-client = "*"
 werkzeug = ">=2.2.3, <3.0.0"
-xstatic = "*"
+xstatic = "<2.0.0"
 xstatic-bootstrap = "*"
 xstatic-jquery = "*"
 


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2804 

xstatic 2.0.0 is not released yet but its in the pipeline.  Likly with our next major we have to set 2.0.0 as the lower bound.

