### PR TITLE
fix: update kml.save_to_kml and tests to use new fastkml namespace

### DIFF
--- a/mslib/plugins/io/kml.py
+++ b/mslib/plugins/io/kml.py
@@ -32,7 +32,7 @@ def save_to_kml(filename, name, waypoints):
     if not filename:
         raise ValueError("filename to save flight track cannot be None")
     header = f"""<?xml version="1.0" encoding="UTF-8" ?>
-<kml xmlns="http://earth.google.com/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2">
 <Document>
 <name>{name}</name>
 <open>1</open>

--- a/tests/_test_plugins/test_io_kml.py
+++ b/tests/_test_plugins/test_io_kml.py
@@ -40,7 +40,7 @@ def test_save_to_kml():
         with open(filename) as f:
             data = f.readlines()
         assert data == ['<?xml version="1.0" encoding="UTF-8" ?>\n',
-                        '<kml xmlns="http://earth.google.com/kml/2.2">\n',
+                        '<kml xmlns="http://www.opengis.net/kml/2.2">\n',
                         '<Document>\n',
                         '<name>testkmldata</name>\n',
                         '<open>1</open>\n',

--- a/tests/data/features.kml
+++ b/tests/data/features.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<kml xmlns="http://earth.google.com/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2">
 <Document>
 <name>D-ADLR Flight Path for SOUTHTRACK flight adlr_20190909a</name>
 <open>1</open>

--- a/tests/data/line.kml
+++ b/tests/data/line.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://earth.google.com/kml/2.0"> <Document>
+<kml xmlns="http://www.opengis.net/kml/2.2"> <Document>
 
 <Placemark>
  <LineString>


### PR DESCRIPTION
**Purpose of PR?**:
To update kml.save_to_kml and tests to use new fastkml namespace.ie from http://earth.google.com/kml/2.2 to http://www.opengis.net/kml/2.2

Fixes #2844


**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [x] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->