### PR TITLE
Add 'toml' package to docs build environment for RTD

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -21,6 +21,9 @@ dependencies:
       - PyQt5
       - owslib
       - future
+      - sphinx-rtd-theme
+      - any-other-pip-packages
   - basemap >=1.3.3
   - pint
   - python <3.12
+  - toml


### PR DESCRIPTION
The ReadTheDocs build was failing with a ModuleNotFoundError for 'toml'. Updating docs/environment.yml ensures the dependency is installed during the docs build.

**Purpose of PR?**:

Fixes #

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->