### PR TITLE
Add documentation for view_resoring feature

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ Topics
    tutorial
    gallery/index
    funding
+   view_resoring
 
 
 Indices and tables

--- a/docs/view_resoring.rst
+++ b/docs/view_resoring.rst
@@ -1,0 +1,12 @@
+View Resoring
+=============
+
+The `view_resoring` feature allows users to restore a previously saved view or layout configuration
+within the Mission Support System (MSS). This feature helps users quickly return to a saved
+visualization setup without manually reconfiguring the view.
+
+**Example Usage**
+
+After saving a view configuration, you can restore it using:
+
+


### PR DESCRIPTION
This PR adds a new page in the documentation (view_resoring.rst) describing how users can restore previously saved views in MSS.
Includes example usage and background on the GSoC 2024 feature update.