### PR TITLE
Fix #2885: Prevent crash on corrupted performance settings

### DIFF
--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -213,7 +213,11 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
         """
         Load settings from the file self.settingsfile.
         """
-        self.performance_settings = load_settings_qsettings(self.settings_tag, DEFAULT_PERFORMANCE)
+        settings = load_settings_qsettings(self.settings_tag, DEFAULT_PERFORMANCE)
+        # Ensure we have a dictionary. If QSettings returns a string/garbage, reset to default.
+        if not isinstance(settings, dict):
+            settings = DEFAULT_PERFORMANCE
+        self.performance_settings = settings
 
     def save_settings(self):
         """


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2885

This PR adds a type check to the `load_settings` method in `mslib/msui/flighttrack.py`. It ensures that `performance_settings` is always initialized as a dictionary. If the loaded configuration data is corrupted (e.g., loaded as a `str` instead of a `dict`), the application now safely falls back to `DEFAULT_PERFORMANCE` instead of crashing with a `TypeError`.

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Manually verified by temporarily modifying the code to force `performance_settings` to be a string ("corrupted data"). Confirmed that the application detected the invalid type, reverted to the default dictionary, and launched successfully without crashing.

**Additional information for reviewer?** :
_None_

**Does this PR results in some Documentation changes?**
No

**Checklist:**
- [x] Bug fix. Fixes #2885
- [ ] New feature (Non-API breaking changes that adds functionality)
- [x] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests