### PR TITLE
Fix heading underline length in mslib.utils.config

### DIFF
--- a/mslib/mscolab/__init__.py
+++ b/mslib/mscolab/__init__.py
@@ -2,7 +2,7 @@
 """
 
     mslib.mscolab
-    ~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~
 
     init module of mscolab
 

--- a/mslib/mscolab/chat_manager.py
+++ b/mslib/mscolab/chat_manager.py
@@ -2,7 +2,7 @@
 """
 
     mslib.mscolab.chat_manager
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Code to handle socket connections in mscolab
 

--- a/mslib/mscolab/conf.py
+++ b/mslib/mscolab/conf.py
@@ -2,7 +2,7 @@
 """
 
     mslib.mscolab.conf.py.example
-    ~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     config for mscolab.
 

--- a/mslib/mscolab/seed.py
+++ b/mslib/mscolab/seed.py
@@ -2,7 +2,7 @@
 """
 
     mslib.mscolab.seed
-    ~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~
 
     Seeder utility for database
 

--- a/mslib/mscolab/utils.py
+++ b/mslib/mscolab/utils.py
@@ -2,7 +2,7 @@
 """
 
     mslib.mscolab._tests.utils
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Utility functions for mscolab
 

--- a/mslib/msui/airdata_dockwidget.py
+++ b/mslib/msui/airdata_dockwidget.py
@@ -2,7 +2,7 @@
 """
 
     mslib.msui.airdata_dockwidget
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Control to load airports and airspaces into the top view.
 

--- a/mslib/msui/editor.py
+++ b/mslib/msui/editor.py
@@ -2,7 +2,7 @@
 """
 
     mslib.msui.editor
-    ~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~
 
     config editor for msui_settings.json.
 

--- a/mslib/msui/linearview.py
+++ b/mslib/msui/linearview.py
@@ -2,7 +2,7 @@
 """
 
     mslib.msui.linearview
-    ~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~
 
     Linear view module of the msui
 

--- a/mslib/msui/mscolab.py
+++ b/mslib/msui/mscolab.py
@@ -2,7 +2,7 @@
 """
 
     mslib.msui.mscolab
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~
 
     Window to display authentication and operation details for mscolab
 

--- a/mslib/msui/mscolab_admin_window.py
+++ b/mslib/msui/mscolab_admin_window.py
@@ -2,7 +2,7 @@
 """
 
     mslib.msui.mscolab_admin_window
-    ~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Mscolab operation window, to display chat, file change
 

--- a/mslib/msui/mscolab_chat.py
+++ b/mslib/msui/mscolab_chat.py
@@ -2,7 +2,7 @@
 """
 
     mslib.msui.mscolab_operation
-    ~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Mscolab operation window, to display chat, file change
 

--- a/mslib/msui/mscolab_exceptions.py
+++ b/mslib/msui/mscolab_exceptions.py
@@ -3,7 +3,7 @@
 """
 
     mslib.msui.mscolab_exceptions
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Exceptions
 

--- a/mslib/msui/mscolab_version_history.py
+++ b/mslib/msui/mscolab_version_history.py
@@ -2,7 +2,7 @@
 """
 
     mslib.msui.mscolab_change_history
-    ~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     Mscolab change history window to display the change history of the flight path so that users
     can revert back to a previous version

--- a/mslib/msui/mss.py
+++ b/mslib/msui/mss.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
     mslib.msui.mss
-    ~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~
 
     Mission Support System Python/Qt Rename Message
 

--- a/mslib/msui/multilayers.py
+++ b/mslib/msui/multilayers.py
@@ -1,6 +1,6 @@
 """
     mslib.msui.multilayers
-    ~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~
 
     This module contains classes for object oriented managing of WMS layers.
     Improves upon the old method of loading each layer on UI changes,

--- a/mslib/msui/socket_control.py
+++ b/mslib/msui/socket_control.py
@@ -2,7 +2,7 @@
 """
 
     mslib.msui.socket_control
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
 
     client socket connection handler
 

--- a/mslib/utils/airdata.py
+++ b/mslib/utils/airdata.py
@@ -2,7 +2,7 @@
 """
 
     mslib.utils.airdata
-    ~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~
 
     Functions for getting and downloading airspaces and airports.
 

--- a/mslib/utils/config.py
+++ b/mslib/utils/config.py
@@ -2,7 +2,7 @@
 """
 
     mslib.utils.config
-    ~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~
 
     Collection of functions all around config handling.
 

--- a/mslib/utils/coordinate.py
+++ b/mslib/utils/coordinate.py
@@ -2,7 +2,7 @@
 """
 
     mslib.utils.coordinate
-    ~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~
 
     Collection of functions all around coordinates, locations and positions.
 

--- a/mslib/utils/loggerdef.py
+++ b/mslib/utils/loggerdef.py
@@ -2,7 +2,7 @@
 """
 
     mslib.utils.loggerdef
-    ~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~
 
     This module sets the logging level and prevent code repetition.
 

--- a/mslib/utils/netCDF4tools.py
+++ b/mslib/utils/netCDF4tools.py
@@ -2,7 +2,7 @@
 """
 
     mslib.utils.netCDF4tools
-    ~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~
 
     Some useful functions for handling NetCDF files with the netCDF4 library.
 


### PR DESCRIPTION
Corrected the underline to match the heading length as required by Sphinx documentation style. This fixes part of issue #2812.
