### PR TITLE
timeout in fixture resolved

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -201,8 +201,11 @@ def _running_eventlet_server(app):
     process = ctx.Process(target=eventlet.wsgi.server, args=(socket, app), daemon=True)
     try:
         process.start()
-        while not is_url_response_ok(urllib.parse.urljoin(url, "index")):
-            time.sleep(0.5)
+        retry_time = 0
+        sleep_time = 0.5
+        while not is_url_response_ok(urllib.parse.urljoin(url, "index")) and retry_time < 5:
+            time.sleep(sleep_time)
+            retry_time += sleep_time
         yield url
     finally:
         process.terminate()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -206,6 +206,8 @@ def _running_eventlet_server(app):
         while not is_url_response_ok(urllib.parse.urljoin(url, "index")) and retry_time < 5:
             time.sleep(sleep_time)
             retry_time += sleep_time
+        if not is_url_response_ok(urllib.parse.urljoin(url, "index")):
+            raise RuntimeError(f"Server did not start within 5 seconds at {url}")
         yield url
     finally:
         process.terminate()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -201,13 +201,15 @@ def _running_eventlet_server(app):
     process = ctx.Process(target=eventlet.wsgi.server, args=(socket, app), daemon=True)
     try:
         process.start()
-        retry_time = 0
-        sleep_time = 0.5
-        while not is_url_response_ok(urllib.parse.urljoin(url, "index")) and retry_time < 5:
+        start_time = time.time()
+        sleep_time = 0.01
+        while not is_url_response_ok(urllib.parse.urljoin(url, "index")):
+            if (time.time() - start_time) > 5:
+                raise RuntimeError(f"Server did not start within 5 seconds at {url}")
             time.sleep(sleep_time)
-            retry_time += sleep_time
-        if not is_url_response_ok(urllib.parse.urljoin(url, "index")):
-            raise RuntimeError(f"Server did not start within 5 seconds at {url}")
+            sleep_time *= 2
+            if sleep_time > 1:
+                sleep_time = 1
         yield url
     finally:
         process.terminate()


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2928

**Does this PR introduce a breaking change?**
adds a timeout into a fixture for starting the eventlet_server



**Checklist:**
- [X] Bug fix. Fixes #2928 
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

