### PR TITLE
Fix #2885: Prevent crash on corrupted performance settings

### DIFF
--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -213,7 +213,11 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
         """
         Load settings from the file self.settingsfile.
         """
-        self.performance_settings = load_settings_qsettings(self.settings_tag, DEFAULT_PERFORMANCE)
+        settings = load_settings_qsettings(self.settings_tag, DEFAULT_PERFORMANCE)
+        # Ensure we have a dictionary. If QSettings returns a string/garbage, reset to default.
+        if not isinstance(settings, dict):
+            settings = DEFAULT_PERFORMANCE
+        self.performance_settings = settings
 
     def save_settings(self):
         """

--- a/tests/_test_msui/test_flighttrack.py
+++ b/tests/_test_msui/test_flighttrack.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""
+
+    _tests._test_msui.test_flighttrack
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests for WaypointsTableModel corrupted performance settings handling
+
+    This file is part of MSS.
+
+    :copyright: Copyright 2024 by the MSS team, see AUTHORS.
+    :license: APACHE-2.0, see LICENSE for details.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+import os
+import json
+import tempfile
+
+from mslib.msui.flighttrack import WaypointsTableModel
+from mslib.msui.performance_settings import DEFAULT_PERFORMANCE
+
+
+class Test_WaypointsTableModel_CorruptedSettings:
+    """
+    Tests for handling corrupted performance settings in WaypointsTableModel.
+    Addresses issue #2885.
+    """
+
+    def test_load_settings_with_corrupted_performance_settings(self):
+        """
+        Test that load_settings handles corrupted performance_settings gracefully.
+
+        Fixes #2885: When performance_settings is loaded as a string (corrupted data)
+        instead of a dict, the application should fall back to DEFAULT_PERFORMANCE
+        instead of crashing with a TypeError.
+        """
+        # Create a temporary settings file with corrupted performance_settings
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            corrupted_data = {
+                "performance": {
+                    "performance_settings": "corrupted_string_data"
+                }
+            }
+            json.dump(corrupted_data, f)
+            temp_file = f.name
+
+        try:
+            # Temporarily override the settings file location
+            import mslib.utils.config as config_module
+
+            original_func = config_module.read_config_file
+
+            def mock_read_config(tag, default, settings_file=None):
+                if tag == "performance":
+                    with open(temp_file, 'r') as f:
+                        data = json.load(f)
+                        return data.get("performance", {}).get("performance_settings", default)
+                return default
+
+            config_module.read_config_file = mock_read_config
+
+            # Create a WaypointsTableModel instance
+            model = WaypointsTableModel(name="test_track")
+
+            # This should NOT raise a TypeError anymore
+            model.load_settings()
+
+            # Verify that performance_settings is now a dict (DEFAULT_PERFORMANCE)
+            assert isinstance(model.performance_settings, dict), \
+                "performance_settings should be a dict after handling corrupted data"
+
+            # Verify it was reset to DEFAULT_PERFORMANCE
+            assert model.performance_settings == DEFAULT_PERFORMANCE, \
+                "Should fall back to DEFAULT_PERFORMANCE when data is corrupted"
+
+        finally:
+            # Restore original function
+            config_module.read_config_file = original_func
+            # Clean up the temporary file
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+
+    def test_isinstance_check_with_various_types(self):
+        """
+        Test that the isinstance check correctly identifies dict vs non-dict types.
+
+        This verifies the core fix: if not isinstance(settings, dict)
+        """
+        # These should NOT be identified as dicts
+        assert not isinstance("corrupted_string", dict), \
+            "String should not pass isinstance dict check"
+        assert not isinstance(123, dict), \
+            "Integer should not pass isinstance dict check"
+        assert not isinstance([1, 2, 3], dict), \
+            "List should not pass isinstance dict check"
+        assert not isinstance(None, dict), \
+            "None should not pass isinstance dict check"
+        assert not isinstance((1, 2), dict), \
+            "Tuple should not pass isinstance dict check"
+
+        # This SHOULD be identified as a dict
+        assert isinstance({"key": "value"}, dict), \
+            "Dict should pass isinstance dict check"
+        assert isinstance({}, dict), \
+            "Empty dict should pass isinstance dict check"


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2885

This PR adds a type check to the `load_settings` method in `mslib/msui/flighttrack.py`. It ensures that `performance_settings` is always initialized as a dictionary. If the loaded configuration data is corrupted (e.g., loaded as a `str` instead of a `dict`), the application now safely falls back to `DEFAULT_PERFORMANCE` instead of crashing with a `TypeError` and added a unit test for the same.

**Does this PR introduce a breaking change?**

No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Manually verified by temporarily modifying the code to force `performance_settings` to be a string ("corrupted data"). Confirmed that the application detected the invalid type, reverted to the default dictionary, and launched successfully without crashing.

**Additional information for reviewer?** :
_None_

**Does this PR results in some Documentation changes?**
No

**Checklist:**
- [x] Bug fix. Fixes #2885
- [ ] New feature (Non-API breaking changes that adds functionality)
- [x] PR Title follows the convention of  `<type>: <subject>`
- [x] Commit has unit tests