### PR TITLE
add --yes flag to skip confirmation for mscolab db commands

### DIFF
--- a/docs/mscolab.rst
+++ b/docs/mscolab.rst
@@ -34,6 +34,15 @@ Steps to Run MSColab Server
   - To start the server run :code:`mscolab start`.
   - If you ever want to reset or add dummy data to your database you can use the commands :code:`mscolab db --reset` and :code:`mscolab db --seed` respectively.
 
+    Both commands support a :code:`--yes` (or :code:`-y`) flag to skip the interactive
+    confirmation prompt. This is useful for non-interactive usage such as CI pipelines
+    or tutorial scripts.
+
+    Examples::
+
+      mscolab db --reset --yes
+      mscolab db --seed --yes
+
 
 
 Notes for server administrators

--- a/mslib/mscolab/mscolab.py
+++ b/mslib/mscolab/mscolab.py
@@ -58,7 +58,10 @@ def handle_start(args=None):
     start_server(APP, sockio, cm, fm)
 
 
-def confirm_action(confirmation_prompt):
+def confirm_action(confirmation_prompt, assume_yes=False):
+    if assume_yes:
+        return True
+
     while True:
         confirmation = input(confirmation_prompt).lower()
         if confirmation == "n" or confirmation == "":
@@ -375,17 +378,27 @@ def main():
                                default=None)
 
     database_parser = subparsers.add_parser("db", help="Manage mscolab database")
-    database_parser = database_parser.add_mutually_exclusive_group(required=True)
-    database_parser.add_argument("--reset", help="Reset database", action="store_true")
-    database_parser.add_argument("--seed", help="Seed database", action="store_true")
-    database_parser.add_argument("--users_by_file", type=argparse.FileType('r'),
-                                 help="adds users into database, fileformat: suggested_username  name   <email>")
-    database_parser.add_argument("--delete_users_by_file", type=argparse.FileType('r'),
-                                 help="removes users from the database, fileformat: email")
-    database_parser.add_argument("--default_operation", help="adds all users into a default TEMPLATE operation",
-                                 action="store_true")
-    database_parser.add_argument("--add_all_to_all_operation", help="adds all users into all other operations",
-                                 action="store_true")
+
+    db_actions = database_parser.add_mutually_exclusive_group(required=True)
+    db_actions.add_argument("--reset", help="Reset database", action="store_true")
+    db_actions.add_argument("--seed", help="Seed database", action="store_true")
+    db_actions.add_argument("--users_by_file", type=argparse.FileType("r"),
+                            help="adds users into database, fileformat: suggested_username  name   <email>")
+    db_actions.add_argument("--delete_users_by_file", type=argparse.FileType("r"),
+                            help="removes users from the database, fileformat: email")
+    db_actions.add_argument("--default_operation",
+                            help="adds all users into a default TEMPLATE operation",
+                            action="store_true")
+    db_actions.add_argument("--add_all_to_all_operation",
+                            help="adds all users into all other operations",
+                            action="store_true")
+
+    database_parser.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Skip confirmation prompt"
+    )
+
     sso_conf_parser = subparsers.add_parser("sso_conf", help="single sign on process configurations")
     sso_conf_parser = sso_conf_parser.add_mutually_exclusive_group(required=True)
     sso_conf_parser.add_argument("--init_sso_crts",
@@ -419,19 +432,22 @@ def main():
     elif args.action == "db":
         if args.reset:
             confirmation = confirm_action("Are you sure you want to reset the database? This would delete "
-                                          "all your data! (y/[n]):")
+                                          "all your data! (y/[n]):",
+                assume_yes=args.yes)
             if confirmation is True:
                 with APP.app_context():
                     handle_db_reset()
         elif args.seed:
             confirmation = confirm_action("Are you sure you want to seed the database? Seeding will delete all your "
-                                          "existing data and replace it with seed data (y/[n]):")
+                                          "existing data and replace it with seed data (y/[n]):",
+                assume_yes=args.yes)
             if confirmation is True:
                 with APP.app_context():
                     handle_db_seed()
         elif args.users_by_file is not None:
             # fileformat: suggested_username  name   <email>
-            confirmation = confirm_action("Are you sure you want to add users to the database? (y/[n]):")
+            confirmation = confirm_action("Are you sure you want to add users to the database? (y/[n]):",
+                assume_yes=args.yes)
             if confirmation is True:
                 for line in args.users_by_file.readlines():
                     info = line.split()
@@ -442,19 +458,22 @@ def main():
                     add_user(emailid, username, password, fullname)
         elif args.default_operation:
             confirmation = confirm_action(
-                "Are you sure you want to add users to the default TEMPLATE operation? (y/[n]):")
+                "Are you sure you want to add users to the default TEMPLATE operation? (y/[n]):",
+                assume_yes=args.yes)
             if confirmation is True:
                 # adds all users as collaborator on the operation TEMPLATE if not added, command can be repeated
                 add_all_users_default_operation(access_level='admin')
         elif args.add_all_to_all_operation:
             confirmation = confirm_action(
-                "Are you sure you want to add users to the ALL operations? (y/[n]):")
+                "Are you sure you want to add users to the ALL operations? (y/[n]):",
+                assume_yes=args.yes)
             if confirmation is True:
                 # adds all users to all Operations
                 add_all_users_to_all_operations()
         elif args.delete_users_by_file:
             confirmation = confirm_action(
-                "Are you sure you want to delete a user? (y/[n]):")
+                "Are you sure you want to delete a user? (y/[n]):",
+                assume_yes=args.yes)
             if confirmation is True:
                 # deletes users from the db
                 for email in args.delete_users_by_file.readlines():

--- a/mslib/mscolab/mscolab.py
+++ b/mslib/mscolab/mscolab.py
@@ -431,22 +431,25 @@ def main():
 
     elif args.action == "db":
         if args.reset:
-            confirmation = confirm_action("Are you sure you want to reset the database? This would delete "
-                                          "all your data! (y/[n]):",
+            confirmation = confirm_action(
+                "Are you sure you want to reset the database? This would delete "
+                "all your data! (y/[n]):",
                 assume_yes=args.yes)
             if confirmation is True:
                 with APP.app_context():
                     handle_db_reset()
         elif args.seed:
-            confirmation = confirm_action("Are you sure you want to seed the database? Seeding will delete all your "
-                                          "existing data and replace it with seed data (y/[n]):",
+            confirmation = confirm_action(
+                "Are you sure you want to seed the database? Seeding will delete all your "
+                "existing data and replace it with seed data (y/[n]):",
                 assume_yes=args.yes)
             if confirmation is True:
                 with APP.app_context():
                     handle_db_seed()
         elif args.users_by_file is not None:
             # fileformat: suggested_username  name   <email>
-            confirmation = confirm_action("Are you sure you want to add users to the database? (y/[n]):",
+            confirmation = confirm_action(
+                "Are you sure you want to add users to the database? (y/[n]):",
                 assume_yes=args.yes)
             if confirmation is True:
                 for line in args.users_by_file.readlines():

--- a/tutorials/start_tutorial.sh
+++ b/tutorials/start_tutorial.sh
@@ -41,7 +41,7 @@ trap cleanup EXIT
 
 if [[ "$2" == "./tutorial_mscolab.py" ]]; then
   # ToDo mscolab needs a -Y and a stop
-  python $PYTHONPATH/mslib/mscolab/mscolab.py db --seed
+  python $PYTHONPATH/mslib/mscolab/mscolab.py db --seed --yes
   # sleep(2)
   python $PYTHONPATH/mslib/mscolab/mscolab.py start &
   # sleep(2)


### PR DESCRIPTION
### Summary
adds a `--yes / -y` flag to `mscolab db` commands to allow non-interactive usage.

### details
extends `confirm_action` with an `assume_yes` parameter
preserves existing interactive behavior
enables CI and tutorial workflows

Closes #2376
