### PR TITLE
show revision id in view and plot titles

### DIFF
--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -62,11 +62,13 @@ xml.dom.minidom.Element.writexml = writexml  # nosec, we take care of writing co
 LOCATION, LAT, LON, FLIGHTLEVEL, PRESSURE = list(range(5))
 TIME_UTC = 9
 
+
 class Revision:
     """
     Represents a revision of a flight track.
     ID is mandatory, name is optional.
     """
+
     def __init__(self, revision_id, name=None):
         self.id = revision_id
         self.name = name
@@ -193,7 +195,7 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
 
     def __init__(self, name="", filename=None, waypoints=None, mscolab_mode=False,
                  data_dir=config_loader(dataset="mss_dir"),
-                 xml_content=None): 
+                 xml_content=None):
         super().__init__()
         self.revision = None
         self.name = name  # a name for this flight track
@@ -218,12 +220,12 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
 
         if waypoints:
             self.replace_waypoints(waypoints)
-            
+
         if self.revision is None:
             self.revision = Revision(
                 revision_id=int(datetime.datetime.utcnow().timestamp()),
                 name=None
-            )    
+            )
 
     def load_settings(self):
         """
@@ -686,7 +688,6 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
 
         return doc
 
-
     def get_xml_content(self):
         doc = self.get_xml_doc()
         return doc.toprettyxml(indent="  ", newl="\n")
@@ -729,7 +730,6 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
             self.replace_waypoints(_waypoints_list)
         else:
             raise SyntaxError(f"Invalid flight track filename: {name}")
-
 
 
 #

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -733,7 +733,7 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
 
     def get_filename(self):
         return self.filename
-    
+
 #
 # CLASS  WaypointDelegate
 #

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -142,12 +142,17 @@ class Waypoint:
 
     def __init__(self, lat=0., lon=0., flightlevel=0., location="", comments=""):
         self.location = location
-        locations = config_loader(dataset='locations')
-        if location in locations:
-            self.lat, self.lon = locations[location]
-        else:
-            self.lat = lat
-            self.lon = lon
+
+        # Always trust explicitly provided coordinates first
+        self.lat = lat
+        self.lon = lon
+
+        # Only resolve location name if coordinates are not provided
+        if (lat == 0.0 and lon == 0.0) and location:
+            locations = config_loader(dataset='locations')
+            if location in locations:
+                self.lat, self.lon = locations[location]
+
         self.flightlevel = flightlevel
         self.pressure = thermolib.flightlevel2pressure(flightlevel * units.hft).magnitude
         self.distance_to_prev = 0.

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -661,8 +661,9 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
         ft_el = doc.createElement("FlightTrack")
         ft_el.setAttribute("version", __version__)
         doc.appendChild(ft_el)
+        # The list of waypoint elements.
 
-        # --- NEW: write revision information ---
+        # Write revision information
         if self.revision is not None:
             rev_el = doc.createElement("Revision")
             rev_el.setAttribute("id", str(self.revision.id))
@@ -670,7 +671,7 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
                 rev_el.setAttribute("name", self.revision.name)
             ft_el.appendChild(rev_el)
 
-        # --- existing: list of waypoints ---
+        # List of waypoints
         wp_el = doc.createElement("ListOfWaypoints")
         ft_el.appendChild(wp_el)
 

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -731,7 +731,9 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
         else:
             raise SyntaxError(f"Invalid flight track filename: {name}")
 
-
+    def get_filename(self):
+        return self.filename
+    
 #
 # CLASS  WaypointDelegate
 #

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -62,6 +62,15 @@ xml.dom.minidom.Element.writexml = writexml  # nosec, we take care of writing co
 LOCATION, LAT, LON, FLIGHTLEVEL, PRESSURE = list(range(5))
 TIME_UTC = 9
 
+class Revision:
+    """
+    Represents a revision of a flight track.
+    ID is mandatory, name is optional.
+    """
+    def __init__(self, revision_id, name=None):
+        self.id = revision_id
+        self.name = name
+
 
 def seconds_to_string(seconds):
     """
@@ -184,8 +193,9 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
 
     def __init__(self, name="", filename=None, waypoints=None, mscolab_mode=False,
                  data_dir=config_loader(dataset="mss_dir"),
-                 xml_content=None):
+                 xml_content=None): 
         super().__init__()
+        self.revision = None
         self.name = name  # a name for this flight track
         self.filename = filename  # filename for store/load
         self.data_dir = data_dir
@@ -208,6 +218,12 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
 
         if waypoints:
             self.replace_waypoints(waypoints)
+            
+        if self.revision is None:
+            self.revision = Revision(
+                revision_id=int(datetime.datetime.utcnow().timestamp()),
+                name=None
+            )    
 
     def load_settings(self):
         """
@@ -639,12 +655,23 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
 
     def get_xml_doc(self):
         doc = xml.dom.minidom.Document()  # nosec, we take care of writing correct XML
+
         ft_el = doc.createElement("FlightTrack")
         ft_el.setAttribute("version", __version__)
         doc.appendChild(ft_el)
-        # The list of waypoint elements.
+
+        # --- NEW: write revision information ---
+        if self.revision is not None:
+            rev_el = doc.createElement("Revision")
+            rev_el.setAttribute("id", str(self.revision.id))
+            if self.revision.name:
+                rev_el.setAttribute("name", self.revision.name)
+            ft_el.appendChild(rev_el)
+
+        # --- existing: list of waypoints ---
         wp_el = doc.createElement("ListOfWaypoints")
         ft_el.appendChild(wp_el)
+
         for wp in self.waypoints:
             element = doc.createElement("Waypoint")
             wp_el.appendChild(element)
@@ -652,10 +679,13 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
             element.setAttribute("lat", str(wp.lat))
             element.setAttribute("lon", str(wp.lon))
             element.setAttribute("flightlevel", str(wp.flightlevel))
+
             comments = doc.createElement("Comments")
             comments.appendChild(doc.createTextNode(str(wp.comments)))
             element.appendChild(comments)
+
         return doc
+
 
     def get_xml_content(self):
         doc = self.get_xml_doc()
@@ -671,14 +701,35 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
 
     def load_from_xml_data(self, xml_content, name="Flight track"):
         self.name = name
+
+        try:
+            doc = defusedxml.minidom.parseString(xml_content)
+        except DefusedXmlException as ex:
+            raise SyntaxError(str(ex))
+
+        ft_el = doc.getElementsByTagName("FlightTrack")[0]
+
+        # Load revision
+        revision_nodes = ft_el.getElementsByTagName("Revision")
+        if revision_nodes:
+            rev_el = revision_nodes[0]
+            revision_id = int(rev_el.getAttribute("id"))
+            revision_name = rev_el.getAttribute("name") or None
+            self.revision = Revision(revision_id, revision_name)
+        else:
+            # Backward compatibility
+            self.revision = Revision(
+                revision_id=int(datetime.datetime.utcnow().timestamp()),
+                name=None
+            )
+
+        # Existing waypoint loading
         if verify_waypoint_data(xml_content):
             _waypoints_list = load_from_xml_data(xml_content, name)
             self.replace_waypoints(_waypoints_list)
         else:
             raise SyntaxError(f"Invalid flight track filename: {name}")
 
-    def get_filename(self):
-        return self.filename
 
 
 #

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -225,7 +225,6 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
         if waypoints:
             self.replace_waypoints(waypoints)
 
-
     def load_settings(self):
         """
         Load settings from the file self.settingsfile.

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -143,12 +143,14 @@ class Waypoint:
     def __init__(self, lat=0., lon=0., flightlevel=0., location="", comments=""):
         self.location = location
 
+        # Prefer explicitly provided coordinates (e.g. from XML/server)
+        self.lat = lat
+        self.lon = lon
+
+        # Only resolve from configured locations if coordinates were not meaningfully provided
         locations = config_loader(dataset='locations')
-        if location in locations:
+        if location in locations and (lat == 0.0 and lon == 0.0):
             self.lat, self.lon = locations[location]
-        else:
-            self.lat = lat
-            self.lon = lon
 
         self.flightlevel = flightlevel
         self.pressure = thermolib.flightlevel2pressure(flightlevel * units.hft).magnitude

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -50,7 +50,6 @@ from mslib.utils.units import units
 from mslib.utils.coordinate import path_points, get_distance
 from mslib.utils.find_location import find_location
 from mslib.utils import thermolib
-from mslib.utils.verify_waypoint_data import verify_waypoint_data
 from mslib.utils.config import config_loader, save_settings_qsettings, load_settings_qsettings
 from mslib.utils.qt import variant_to_string, variant_to_float
 from mslib.msui.performance_settings import DEFAULT_PERFORMANCE
@@ -725,12 +724,9 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
                 name=None
             )
 
-        # Existing waypoint loading
-        if verify_waypoint_data(xml_content):
-            _waypoints_list = load_from_xml_data(xml_content, name)
-            self.replace_waypoints(_waypoints_list)
-        else:
-            raise SyntaxError(f"Invalid flight track filename: {name}")
+        # Validate only waypoint structure, revision is optional metadata
+        _waypoints_list = load_from_xml_data(xml_content, name)
+        self.replace_waypoints(_waypoints_list)
 
     def get_filename(self):
         return self.filename

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -143,15 +143,12 @@ class Waypoint:
     def __init__(self, lat=0., lon=0., flightlevel=0., location="", comments=""):
         self.location = location
 
-        # Always trust explicitly provided coordinates first
-        self.lat = lat
-        self.lon = lon
-
-        # Only resolve location name if coordinates are truly missing
-        if (lat is None or lon is None) and location:
-            locations = config_loader(dataset='locations')
-            if location in locations:
-                self.lat, self.lon = locations[location]
+        locations = config_loader(dataset='locations')
+        if location in locations:
+            self.lat, self.lon = locations[location]
+        else:
+            self.lat = lat
+            self.lon = lon
 
         self.flightlevel = flightlevel
         self.pressure = thermolib.flightlevel2pressure(flightlevel * units.hft).magnitude
@@ -717,7 +714,11 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
             revision_name = rev_el.getAttribute("name") or None
             self.revision = Revision(revision_id, revision_name)
         else:
-            self.revision = None
+            # Backward compatibility: create deterministic default revision
+            self.revision = Revision(
+                revision_id=0,
+                name=None
+            )
 
         # Validate only waypoint structure, revision is optional metadata
         _waypoints_list = load_from_xml_data(xml_content, name)

--- a/mslib/msui/flighttrack.py
+++ b/mslib/msui/flighttrack.py
@@ -147,8 +147,8 @@ class Waypoint:
         self.lat = lat
         self.lon = lon
 
-        # Only resolve location name if coordinates are not provided
-        if (lat == 0.0 and lon == 0.0) and location:
+        # Only resolve location name if coordinates are truly missing
+        if (lat is None or lon is None) and location:
             locations = config_loader(dataset='locations')
             if location in locations:
                 self.lat, self.lon = locations[location]
@@ -225,11 +225,6 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
         if waypoints:
             self.replace_waypoints(waypoints)
 
-        if self.revision is None:
-            self.revision = Revision(
-                revision_id=int(datetime.datetime.utcnow().timestamp()),
-                name=None
-            )
 
     def load_settings(self):
         """
@@ -723,11 +718,7 @@ class WaypointsTableModel(QtCore.QAbstractTableModel):
             revision_name = rev_el.getAttribute("name") or None
             self.revision = Revision(revision_id, revision_name)
         else:
-            # Backward compatibility
-            self.revision = Revision(
-                revision_id=int(datetime.datetime.utcnow().timestamp()),
-                name=None
-            )
+            self.revision = None
 
         # Validate only waypoint structure, revision is optional metadata
         _waypoints_list = load_from_xml_data(xml_content, name)

--- a/mslib/msui/viewwindows.py
+++ b/mslib/msui/viewwindows.py
@@ -33,6 +33,7 @@ from abc import abstractmethod
 from PyQt5 import QtCore, QtWidgets
 from mslib.utils.config import save_settings_qsettings
 
+
 def format_operation_with_revision(model):
     """
     Return operation name including revision id and optional revision name.
@@ -48,6 +49,7 @@ def format_operation_with_revision(model):
     if getattr(rev, "name", None):
         label += f" ({rev.name})"
     return label
+
 
 class MSUIViewWindow(QtWidgets.QMainWindow):
     """
@@ -127,7 +129,6 @@ class MSUIViewWindow(QtWidgets.QMainWindow):
             old_label = format_operation_with_revision(self.waypoints_model)
             new_label = format_operation_with_revision(model)
             self.setWindowTitle(self.windowTitle().replace(old_label, new_label))
-
 
         self.waypoints_model = model
 

--- a/mslib/msui/viewwindows.py
+++ b/mslib/msui/viewwindows.py
@@ -33,6 +33,21 @@ from abc import abstractmethod
 from PyQt5 import QtCore, QtWidgets
 from mslib.utils.config import save_settings_qsettings
 
+def format_operation_with_revision(model):
+    """
+    Return operation name including revision id and optional revision name.
+    """
+    if model is None:
+        return ""
+
+    rev = getattr(model, "revision", None)
+    if rev is None:
+        return model.name
+
+    label = f"{model.name} [rev: {rev.id}]"
+    if getattr(rev, "name", None):
+        label += f" ({rev.name})"
+    return label
 
 class MSUIViewWindow(QtWidgets.QMainWindow):
     """
@@ -109,7 +124,10 @@ class MSUIViewWindow(QtWidgets.QMainWindow):
         """
         # Update title flighttrack name
         if self.waypoints_model:
-            self.setWindowTitle(self.windowTitle().replace(self.waypoints_model.name, model.name))
+            old_label = format_operation_with_revision(self.waypoints_model)
+            new_label = format_operation_with_revision(model)
+            self.setWindowTitle(self.windowTitle().replace(old_label, new_label))
+
 
         self.waypoints_model = model
 
@@ -274,11 +292,15 @@ class MSUIMplViewWindow(MSUIViewWindow):
 
             # Update Top View flighttrack name
             if hasattr(self.mpl.canvas, "map"):
-                self.mpl.canvas.map.ax.figure.suptitle(f"{model.name}", x=0.95, ha='right')
+                title = format_operation_with_revision(model)
+                self.mpl.canvas.map.ax.figure.suptitle(title, x=0.95, ha='right')
+
                 self.mpl.canvas.map.ax.figure.canvas.draw()
 
             elif hasattr(self.mpl.canvas, 'plotter'):
-                self.mpl.canvas.plotter.fig.suptitle(f"{model.name}", x=0.95, ha='right')
+                title = format_operation_with_revision(model)
+                self.mpl.canvas.plotter.fig.suptitle(title, x=0.95, ha='right')
+
                 self.mpl.canvas.plotter.fig.canvas.draw()
 
     def getView(self):

--- a/tests/_test_msui/test_flighttrack.py
+++ b/tests/_test_msui/test_flighttrack.py
@@ -114,7 +114,7 @@ class Test_WaypointsTableModel_CorruptedSettings:
             "Dict should pass isinstance dict check"
         assert isinstance({}, dict), \
             "Empty dict should pass isinstance dict check"
-           
+
     def test_load_ftml_with_revision(self):
         xml_content = """
         <FlightTrack version="test">
@@ -131,7 +131,7 @@ class Test_WaypointsTableModel_CorruptedSettings:
 
         assert model.revision is not None
         assert model.revision.id == 42
-        assert model.revision.name == "draft"        
+        assert model.revision.name == "draft"
 
     def test_load_ftml_without_revision_creates_default_revision(self):
         xml_content = """

--- a/tests/_test_msui/test_flighttrack.py
+++ b/tests/_test_msui/test_flighttrack.py
@@ -114,3 +114,38 @@ class Test_WaypointsTableModel_CorruptedSettings:
             "Dict should pass isinstance dict check"
         assert isinstance({}, dict), \
             "Empty dict should pass isinstance dict check"
+           
+    def test_load_ftml_with_revision(self):
+        xml_content = """
+        <FlightTrack version="test">
+            <Revision id="42" name="draft"/>
+            <ListOfWaypoints>
+                <Waypoint location="" lat="0" lon="0" flightlevel="100">
+                    <Comments></Comments>
+                </Waypoint>
+            </ListOfWaypoints>
+        </FlightTrack>
+        """
+
+        model = WaypointsTableModel(xml_content=xml_content, name="test_track")
+
+        assert model.revision is not None
+        assert model.revision.id == 42
+        assert model.revision.name == "draft"        
+
+    def test_load_ftml_without_revision_creates_default_revision(self):
+        xml_content = """
+        <FlightTrack version="test">
+            <ListOfWaypoints>
+                <Waypoint location="" lat="0" lon="0" flightlevel="100">
+                    <Comments></Comments>
+                </Waypoint>
+            </ListOfWaypoints>
+        </FlightTrack>
+        """
+
+        model = WaypointsTableModel(xml_content=xml_content, name="legacy_track")
+
+        assert model.revision is not None
+        assert isinstance(model.revision.id, int)
+        assert model.revision.name is None


### PR DESCRIPTION
### summary
always show the revision ID in view window titles and plot titles.
if a revision name exists, it is appended.

### motivation
improves traceability when switching revisions or comparing views.

Fixes #2026