### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'COLOR' for Py…

### DIFF
--- a/mslib/msui/editor.py
+++ b/mslib/msui/editor.py
@@ -613,7 +613,7 @@ class ConfigurationEditorWindow(QtWidgets.QMainWindow, ui_conf.Ui_ConfigurationE
         key = "predefined_map_sections"
         source_model = self.json_model
         # set default color
-        color = QtCore.Qt.black
+        color = QtGui.QColor("black")
         self.set_key_color(source_model, key, color)
 
         data = source_model.serialize()

--- a/mslib/support/qt_json_view/datatypes.py
+++ b/mslib/support/qt_json_view/datatypes.py
@@ -13,7 +13,7 @@ class DataType:
     """Base class for data types."""
 
     # (mss)
-    COLOR = QtCore.Qt.black
+    COLOR = QtGui.QColor("black")
 
     def matches(self, data):
         """Logic to define whether the given data matches this type."""
@@ -54,9 +54,13 @@ class DataType:
         """Create an item for the key column for this data type."""
         key_item = QtGui.QStandardItem(key)
         key_item.setData(datatype, TypeRole)
-        key_item.setData(datatype.__class__.__name__, QtCore.Qt.ToolTipRole)
-        key_item.setData(
-            QtGui.QBrush(datatype.COLOR), QtCore.Qt.ForegroundRole)
+        if datatype:
+            key_item.setData(datatype.__class__.__name__, QtCore.Qt.ToolTipRole)
+            color = datatype.COLOR
+        else:
+            key_item.setData("None", QtCore.Qt.ToolTipRole)
+            color = QtGui.QColor("black")
+        key_item.setData(QtGui.QBrush(color), QtCore.Qt.ForegroundRole)
         key_item.setFlags(
             QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
         if editable and model.editable_keys:


### PR DESCRIPTION
…thon 3.13/3.14

- Change QtCore.Qt.black to QtGui.QColor('black') in DataType.COLOR and editor.py
- Handle None datatype in key_item method

**Purpose of PR?**:

Fixes #

**Does this PR introduce a breaking change?**

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests

<!--

The PR title message must follow convention:
`<type>: <subject>`.

Where: <br />
- `type` is to define what type of PR is this.
  Most common types are:
    - `feat`      - for new features, not a new feature for build script
    - `fix`       - for bug fixes or improvements, not a fix for build script
    - `chore`     - changes not related to production code
    - `docs`      - changes related to documentation
    - `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    - `test`      - adding missing tests, refactoring tests; no production code change
    - `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

- `subject` is a single line brief description of the changes made in the pull request.

-->