### PR TITLE
fix: make is_roundtrip_possible return a boolean

### DIFF
--- a/mslib/msui/tableview.py
+++ b/mslib/msui/tableview.py
@@ -260,7 +260,7 @@ class MSUITableViewWindow(MSUIViewWindow, ui.Ui_TableViewWindow):
             condition = first_waypoint.lat != last_waypoint.lat or first_waypoint.lon != last_waypoint.lon or \
                 first_waypoint.flightlevel != last_waypoint.flightlevel
 
-        return condition
+        return bool(condition)
 
     def update_roundtrip_enabled(self):
         self.btRoundtrip.setEnabled(self.is_roundtrip_possible())


### PR DESCRIPTION
**Purpose of PR?**:
This PR updates the function `is_roundtrip_possible` to ensure it returns a boolean value.
Fixes #2879 

**Does this PR introduce a breaking change?**
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Verified that the function now always returns True/False.
- Verified that `update_roundtrip_enabled()` correctly enables/disables the button.

**Additional information for reviewer?** :
This PR is a small fix requested to ensure correct return type. No other logic was modified.

**Does this PR results in some Documentation changes?**
No.

**Checklist:**
- [ ✅] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [✅ ] PR Title follows the convention of  `<type>: <subject>`
- [ ] Commit has unit tests
