### PR TITLE
test: add standard dimension verification for seed profiles

### DIFF
--- a/tests/_test_mswms/test_seed.py
+++ b/tests/_test_mswms/test_seed.py
@@ -81,3 +81,11 @@ class Testseed:
             assert "unit" in entry
             assert isinstance(entry["unit"], str)
             assert isinstance(entry["data"], np.ndarray)
+
+    def test_standard_profile_dimensions(self):
+        """Added test to verify standard output dimensions for PR requirements."""
+        levels = [100, 200, 500, 1000]
+        mean, std = seed.get_profile("air_pressure", levels, "air_temperature")
+        assert len(mean) == len(levels)
+        assert len(std) == len(levels)
+        assert isinstance(mean, np.ndarray)


### PR DESCRIPTION
The purpose of this PR is to improve the test coverage for the mswms.seed module. I have added a new test case, test_standard_profile_dimensions, to ensure that the profile data (mean and standard deviation) consistently matches the dimensions of the input levels and returns the correct data types.