### PR TITLE
set dry-run as the default for tutorials

### DIFF
--- a/docs/gentutorials.rst
+++ b/docs/gentutorials.rst
@@ -126,8 +126,8 @@ For all the tutorials, you can do the same, example ::
 The `MSS/tutorials/textfiles` contain descriptions of the tutorial videos in text format, these later can be
 converted to audio files by `audio.py` script after adding certain #ToDOs there.
 
-When you want to run the tutorial by your IDE you can disable the screenrecording by `dry_run=True`
-in the `start` function. Development on a 4K display is then possible too.
+The tutorial runs in dry-run mode (no recording) by default. You can enable screen recording by setting dry_run=False
+Development on a 4K display is then possible too.
 
 For running the `tutorial_mscolab.py` you must provide a cleaned database and a mcolab server running on default port.
 

--- a/tutorials/tutorial_hexagoncontrol.py
+++ b/tutorials/tutorial_hexagoncontrol.py
@@ -23,7 +23,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-
+import argparse
 import pyautogui as pag
 
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view, create_tutorial_images, move_window,
@@ -150,4 +150,10 @@ def _arrange_open_app_windows():
 
 
 if __name__ == '__main__':
-    start(target=automate_hexagoncontrol, duration=170)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=170,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    args = parser.parse_args()
+    start(target=automate_hexagoncontrol, duration=args.duration, dry_run=args.dry_run)

--- a/tutorials/tutorial_kml.py
+++ b/tutorials/tutorial_kml.py
@@ -24,6 +24,7 @@
     limitations under the License.
 """
 
+import argparse
 import os
 import pyautogui as pag
 from tutorials.utils import (start, finish,
@@ -106,4 +107,10 @@ def _change_linewidth(img_name, actions):
 
 
 if __name__ == '__main__':
-    start(target=automate_kml, duration=130)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=130,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    args = parser.parse_args()
+    start(target=automate_kml, duration=args.duration, dry_run=args.dry_run)

--- a/tutorials/tutorial_mscolab.py
+++ b/tutorials/tutorial_mscolab.py
@@ -23,6 +23,8 @@
     limitations under the License.
 """
 import os
+import argparse
+
 import pyautogui as pag
 
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view, create_tutorial_images,
@@ -554,4 +556,12 @@ def _connect_to_mscolab_url():
 
 
 if __name__ == '__main__':
-    start(target=automate_mscolab, duration=640, mscolab=True, dry_run=False)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=640,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    parser.add_argument("--mscolab", action=argparse.BooleanOptionalAction, default=True,
+                        help="default: use a local mscolab server")
+    args = parser.parse_args()
+    start(target=automate_mscolab, duration=args.duration, mscolab=args.mscolab, dry_run=args.dry_run)

--- a/tutorials/tutorial_performancesettings.py
+++ b/tutorials/tutorial_performancesettings.py
@@ -22,6 +22,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import argparse
 import os.path
 import pyautogui as pag
 import shutil
@@ -113,4 +114,10 @@ def automate_performance():
 
 
 if __name__ == '__main__':
-    start(target=automate_performance, duration=114)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=114,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    args = parser.parse_args()
+    start(target=automate_performance, duration=args.duration, dry_run=args.dry_run)

--- a/tutorials/tutorial_remotesensing.py
+++ b/tutorials/tutorial_remotesensing.py
@@ -21,6 +21,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import argparse
 import pyautogui as pag
 
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view,
@@ -183,4 +184,10 @@ def _show_solar_angle(os_screen_region):
 
 
 if __name__ == '__main__':
-    start(target=automate_rs, duration=198)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=198,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    args = parser.parse_args()
+    start(target=automate_rs, duration=args.duration, dry_run=args.dry_run)

--- a/tutorials/tutorial_satellitetrack.py
+++ b/tutorials/tutorial_satellitetrack.py
@@ -22,6 +22,7 @@
     limitations under the License.
 """
 import os.path
+import argparse
 import pyautogui as pag
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view,
                              create_tutorial_images, select_listelement, find_and_click_picture, type_and_key, zoom_in)
@@ -33,9 +34,9 @@ PATH = os.path.normpath(os.getcwd() + os.sep + os.pardir)
 SATELLITE_PATH = os.path.join(PATH, 'docs/samples/satellite_tracks/satellite_predictor.txt')
 
 
-def automate_rs():
+def automate_st():
     """
-    This is the main automating script of the MSS remote sensing tutorial which will be recorded and saved
+    This is the main automating script of the MSS satellitetrack tutorial which will be recorded and saved
     to a file having dateframe nomenclature with a .mp4 extension(codec).
     """
     # Giving time for loading of the MSS GUI.
@@ -111,4 +112,10 @@ def automate_rs():
 
 
 if __name__ == '__main__':
-    start(target=automate_rs, duration=170)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=170,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    args = parser.parse_args()
+    start(target=automate_st, duration=args.duration, dry_run=args.dry_run)

--- a/tutorials/tutorial_views.py
+++ b/tutorials/tutorial_views.py
@@ -23,6 +23,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import argparse
 import pyautogui as pag
 
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view, create_tutorial_images,
@@ -581,4 +582,10 @@ def _tv_add_waypoints(os_screen_region):
 
 
 if __name__ == '__main__':
-    start(target=automate_views, duration=567)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=567,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    args = parser.parse_args()
+    start(target=automate_views, duration=args.duration, dry_run=args.dry_run)

--- a/tutorials/tutorial_waypoints.py
+++ b/tutorials/tutorial_waypoints.py
@@ -23,7 +23,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-
+import argparse
 import pyautogui as pag
 import datetime
 
@@ -133,4 +133,10 @@ def automate_waypoints():
 
 
 if __name__ == '__main__':
-    start(target=automate_waypoints, duration=158)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=158,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    args = parser.parse_args()
+    start(target=automate_waypoints, duration=args.duration, dry_run=args.dry_run)

--- a/tutorials/tutorial_wms.py
+++ b/tutorials/tutorial_wms.py
@@ -23,6 +23,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import argparse
 import pyautogui as pag
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view, create_tutorial_images,
                              find_and_click_picture, move_and_setup_layerchooser, get_region,
@@ -226,4 +227,10 @@ def automate_wms():
 
 
 if __name__ == '__main__':
-    start(target=automate_wms, duration=280)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--duration", type=int, default=280,
+                        help="estimated time for the tutorial in seconds")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run",
+                        help="default: no recording")
+    args = parser.parse_args()
+    start(target=automate_wms, duration=args.duration, dry_run=args.dry_run)

--- a/tutorials/tutorials.batch
+++ b/tutorials/tutorials.batch
@@ -17,7 +17,7 @@ export XDG_CACHE_HOME=$(mktemp -d)
 
 ##########################################################################
 # wms tutorial
-python tutorial_wms.py
+python tutorial_wms.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*
@@ -34,7 +34,7 @@ cd ..
 # kml tutorial
 ~/bin/highlight-pointer -r 10 --key-quit q &
 
-python tutorial_kml.py
+python tutorial_kml.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*
@@ -52,7 +52,7 @@ cd ..
 # hexagoncontrol tutorial
 ~/bin/highlight-pointer -r 10 --key-quit q &
 
-python tutorial_hexagoncontrol.py
+python tutorial_hexagoncontrol.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*
@@ -70,7 +70,7 @@ cd ..
 # performancesettings tutorial
 ~/bin/highlight-pointer -r 10 --key-quit q &
 
-python tutorial_performancesettings.py
+python tutorial_performancesettings.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*
@@ -90,7 +90,7 @@ cd ..
 
 ~/bin/highlight-pointer -r 10 --key-quit q &
 
-python tutorial_remotesensing.py
+python tutorial_remotesensing.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*
@@ -108,7 +108,7 @@ cd ..
 # satellitetrack tutorial
 ~/bin/highlight-pointer -r 10 --key-quit q &
 
-python tutorial_satellitetrack.py
+python tutorial_satellitetrack.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*
@@ -126,7 +126,7 @@ cd ..
 ##################################################
 # tutorial waypoints
 ~/bin/highlight-pointer -r 10 --key-quit q &
-python tutorial_waypoints.py
+python tutorial_waypoints.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*
@@ -144,7 +144,7 @@ cd ..
 ################################################################
 # views tutorial, 4K
 ~/bin/highlight-pointer -r 10 --key-quit q &
-python tutorial_views.py
+python tutorial_views.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*
@@ -172,7 +172,7 @@ mscolab db --seed
 mscolab start &
 
 ~/bin/highlight-pointer -r 10 --key-quit q &
-python tutorial_mscolab.py
+python tutorial_mscolab.py --no-dry-run
 
 # remove config files created for this tutorial
 rm -r /tmp/msui_tutorials/*


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #3081

For debugging of tutorials it is easier not to have recording enabled. The video is the result when we don't need to debug.
