### PR TITLE
Use osascript on apple and clip on windows for entering into path dialogs

### DIFF
--- a/tutorials/tutorial_kml.py
+++ b/tutorials/tutorial_kml.py
@@ -53,7 +53,7 @@ def _switch_to_europe_map():
 
 
 def _create_and_load_kml_files():
-    parent_path = os.path.normpath(os.path.join(os.getcwd(), os.pardir))
+    parent_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     kml_folder_path = os.path.join(parent_path, 'docs/samples/kml')
     _load_kml_files(kml_folder_path)
     pag.sleep(1)
@@ -106,4 +106,4 @@ def _change_linewidth(img_name, actions):
 
 
 if __name__ == '__main__':
-    start(target=automate_kml, duration=130)
+    start(target=automate_kml, duration=130, dry_run=True)

--- a/tutorials/tutorial_mscolab.py
+++ b/tutorials/tutorial_mscolab.py
@@ -26,7 +26,7 @@ import os
 import pyautogui as pag
 
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view, create_tutorial_images,
-                             select_listelement, find_and_click_picture, type_and_key)
+                             select_listelement, find_and_click_picture, type_path, type_and_key)
 
 from tutorials.utils.platform_keys import platform_keys
 from tutorials.utils.picture import picture
@@ -41,7 +41,7 @@ OPERATION_NAME = 'operation_of_john_doe'
 OPERATION_DESCRIPTION = """This is John Doe's operation. He wants his colleagues and friends \
 to collaborate on this operation with him in the network. Mscolab, here, \
 will be very helpful for Joe with various features to use!"""
-PATH = os.path.normpath(os.getcwd() + os.sep + os.pardir)
+PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 EXMPLE_IMAGE_PATH = os.path.join(os.path.join(PATH, 'docs', 'mss-logo.png'))
 MSCOLAB_URL = 'http://localhost:8083/'
 
@@ -457,9 +457,7 @@ def _chatting():
     pag.moveTo(x, y + 40, duration=2)
     pag.click(x, y + 40, duration=2)
     pag.sleep(1)
-    pag.typewrite(EXMPLE_IMAGE_PATH, interval=0.2)
-    pag.sleep(1)
-    pag.press(ENTER)
+    type_path(EXMPLE_IMAGE_PATH, clear=True)
     pag.sleep(1)
     pag.moveTo(x, y, duration=2)
     pag.click(x, y, duration=2)

--- a/tutorials/tutorial_performancesettings.py
+++ b/tutorials/tutorial_performancesettings.py
@@ -28,7 +28,8 @@ import shutil
 import tempfile
 
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view,
-                             create_tutorial_images, select_listelement, find_and_click_picture, type_and_key)
+                             create_tutorial_images, select_listelement, find_and_click_picture,
+                             type_path, type_and_key)
 from tutorials.utils.platform_keys import platform_keys
 
 CTRL, ENTER, WIN, ALT = platform_keys()
@@ -43,11 +44,12 @@ def automate_performance():
     pag.sleep(5)
 
     # Performance file path
-    path = os.path.normpath(os.getcwd() + os.sep + os.pardir)
-    ps_file_path = os.path.join(path, 'docs/samples/config/msui/performance_simple.json.sample')
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ps_file_path = os.path.join(repo_root, 'docs', 'samples', 'config', 'msui',
+                                'performance_simple.json.sample')
     dirpath = tempfile.mkdtemp()
-    sample = os.path.join(dirpath, 'example.json')
-    shutil.copy(ps_file_path, sample)
+    sample_path = os.path.join(dirpath, 'example.json')
+    shutil.copy(ps_file_path, sample_path)
 
     msui_full_screen_and_open_first_view(view_cmd='t')
     # Opening Performance Settings dockwidget
@@ -62,7 +64,7 @@ def automate_performance():
 
     # Exploring through the file system and loading the performance settings json file for a dummy aircraft.
     find_and_click_picture('tableviewwindow-select.png', 'Select button not found')
-    type_and_key(sample)
+    type_path(sample_path, clear=True)
 
     # Checking the Show Performance checkbox to display the settings file in the table view
     find_and_click_picture('tableviewwindow-show-performance.png',

--- a/tutorials/tutorial_satellitetrack.py
+++ b/tutorials/tutorial_satellitetrack.py
@@ -24,12 +24,12 @@
 import os.path
 import pyautogui as pag
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view,
-                             create_tutorial_images, select_listelement, find_and_click_picture, type_and_key, zoom_in)
+                             create_tutorial_images, select_listelement, find_and_click_picture, type_path, zoom_in)
 from tutorials.utils.platform_keys import platform_keys
 
 
 CTRL, ENTER, WIN, ALT = platform_keys()
-PATH = os.path.normpath(os.getcwd() + os.sep + os.pardir)
+PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SATELLITE_PATH = os.path.join(PATH, 'docs/samples/satellite_tracks/satellite_predictor.txt')
 
 
@@ -62,7 +62,7 @@ def automate_rs():
     # Todo find and use QLineEdit leFile instead of Load button
     # Loading the file
     find_and_click_picture('topviewwindow-load.png', 'Load button not found', xoffset=-150)
-    type_and_key(SATELLITE_PATH, interval=0.1)
+    type_path(SATELLITE_PATH, clear=True)
     find_and_click_picture('topviewwindow-load.png', 'Load button not found')
 
     # Switching between different date and time of satellite overpass.

--- a/tutorials/utils/__init__.py
+++ b/tutorials/utils/__init__.py
@@ -26,6 +26,7 @@
     limitations under the License.
 """
 import os
+import subprocess
 import platform
 import sys
 import multiprocessing
@@ -323,12 +324,84 @@ def load_kml_file(pic_name, file_path, exception_message):
     """
     try:
         find_and_click_picture(pic_name, exception_message)
-        pag.typewrite(file_path, interval=0.1)
-        pag.sleep(1)
-        pag.press(ENTER)
+        type_path(file_path, key=ENTER, clear=True)
     except (ImageNotFoundException, OSError, Exception):
         print(exception_message)
         raise
+
+
+def type_path(file_path, key=ENTER, clear=False):
+    if sys.platform == 'darwin':
+        macos_enter_path_in_dialog(file_path)
+    elif sys.platform == 'win32':
+        win32_enter_path_in_dialog(file_path, key=key, clear=clear)
+    else:
+        pag.typewrite(file_path, interval=0.1)
+        pag.sleep(1)
+        pag.press(key)
+
+
+def macos_enter_path_in_dialog(file_path):
+    """
+    Enter ``file_path`` into the macOS native file-open dialog.
+
+    pag.typewrite() sends US key codes, so it mangles paths on non-US keyboards,
+    and the Cmd+V paste shortcut is not reliably delivered to the panel's text
+    field (it beeps instead of pasting). AppleScript ``keystroke`` honours the
+    active keyboard layout and needs neither the clipboard nor Cmd+V.
+
+    Requires Accessibility permission for the app that launches the tutorial
+    (System Settings > Privacy & Security > Accessibility); without it macOS
+    rejects the keystrokes with osascript.
+
+    Requires Automation permission for the app that launches the tutorial
+    (System Settings > Privacy & Security > Automation); without it macOS
+    rejects the keystrokes with osascript.
+    """
+    import subprocess
+
+    def osa(applescript):
+        subprocess.run(['osascript', '-e', applescript], check=True)
+
+    escaped = file_path.replace('\\', '\\\\').replace('"', '\\"')
+    # open the "Go to Folder" sheet, type the path, then confirm twice
+    # (first Return accepts "Go to Folder", second accepts the open panel).
+    osa('tell application "System Events" to keystroke "g" using {command down, shift down}')
+    pag.sleep(2.5)  # wait for sheet to fully open
+    osa(f'tell application "System Events" to keystroke "{escaped}"')
+    pag.sleep(0.8)
+    osa('tell application "System Events" to keystroke return')
+    pag.sleep(0.8)
+    osa('tell application "System Events" to keystroke return')
+    pag.sleep(1)
+
+
+def win32_enter_path_in_dialog(path, key=ENTER, clear=False):
+    """
+    Enter a filesystem path into the focused field or file dialog.
+
+    On Windows the path is pasted via the clipboard instead of typed: native
+    open/save dialogs reject forward-slash paths and require backslashes, but
+    pyautogui cannot type a backslash on non-US keyboard layouts (it is an AltGr
+    combination), so pasting is the only layout-independent option.
+
+    :param path: The filesystem path to enter.
+    :param key: Key to press afterwards (default ENTER); pass None to skip.
+    :param clear: Select existing content (Ctrl+A) before entering the path.
+    """
+    # Normalise to the OS separator: paths built with os.path.join(root, 'a/b/c')
+    # mix backslashes and forward slashes on Windows (e.g. ...MSS\docs/samples/kml\
+    # folder.kml), which the native dialog cannot resolve, so it never closes.
+    path = os.path.normpath(path)
+    if clear:
+        pag.hotkey(CTRL, 'a')
+        pag.sleep(1)
+        subprocess.run('clip', input=path, text=True, shell=True, check=False)
+        pag.sleep(1)
+        pag.hotkey(CTRL, 'v')
+    pag.sleep(1)
+    if key is not None:
+        pag.press(key)
 
 
 def change_color(pic_name, exception_message, actions, interval=2, sleep_time=2):


### PR DESCRIPTION

**Purpose of PR?**:

This works for file pathes on windows and Mac with non-US keyboard layout.
The linux and windows dialogs are also different to the Mac's one


Fixes #3087 

