### PR TITLE
replaced QColorDialog by CustomColorDialog

### DIFF
--- a/mslib/msui/kmloverlay_dockwidget.py
+++ b/mslib/msui/kmloverlay_dockwidget.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from matplotlib import patheffects
 
 from mslib.utils.qt import get_open_filenames, get_save_filename
+from mslib.utils.colordialog import CustomColorDialog
 from mslib.msui.qt5 import ui_kmloverlay_dockwidget as ui
 from PyQt5 import QtGui, QtWidgets, QtCore
 from mslib.utils.config import save_settings_qsettings, load_settings_qsettings
@@ -370,17 +371,22 @@ class KMLOverlayControlWidget(QtWidgets.QWidget, ui.Ui_KMLOverlayDockWidget):
         Sets the color of the selected KML file when Change Colour button is clicked.
         """
         if self.listWidget.currentItem() is not None:
-            filename = self.listWidget.currentItem().text()
-            clr = self.set_color(filename)
-            colour = QtGui.QColor(int(clr[0] * 255), int(clr[1] * 255), int(clr[2] * 255))
-            self.colour = QtWidgets.QColorDialog.getColor(colour)
-            if self.colour.isValid() and filename in self.dict_files:
-                self.dict_files[filename]["color"] = self.colour.getRgbF()
-                self.flag2 = 1  # sets flag of 0 to 1 when the color changes
-                self.listWidget.currentItem().setIcon(self.show_color_icon(filename, self.set_color(filename)))
-                if self.dict_files[filename]["patch"] is not None:
-                    self.dict_files[filename]["patch"].update(
-                        self.dict_files[filename]["color"], self.dict_files[filename]["linewidth"])
+            dialog = CustomColorDialog(self)
+            dialog.color_selected.connect(self.on_color_selected)
+            dialog.show()
+
+    def on_color_selected(self, colour):
+        if self.listWidget.currentItem() is None:
+            return
+        filename = self.listWidget.currentItem().text()
+        self.colour = colour
+        if self.colour.isValid() and filename in self.dict_files:
+            self.dict_files[filename]["color"] = self.colour.getRgbF()
+            self.flag2 = 1  # sets flag of 0 to 1 when the color changes
+            self.listWidget.currentItem().setIcon(self.show_color_icon(filename, self.set_color(filename)))
+            if self.dict_files[filename]["patch"] is not None:
+                self.dict_files[filename]["patch"].update(
+                    self.dict_files[filename]["color"], self.dict_files[filename]["linewidth"])
 
     def set_color(self, filename):
         """

--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -318,6 +318,15 @@ class MSUI_ShortcutsDialog(QtWidgets.QDialog, ui_sh.Ui_ShortcutsDialog):
             pix_dir.mkdir(exist_ok=True)
 
             for item in actions:
+                # Tutorial-only: capture widgets explicitly marked with a
+                # color_name (e.g. CustomColorDialog swatches, which
+                # have empty text and would otherwise be skipped below).
+                if self.tutorial_mode:
+                    tut_name = item[5].property("color_name") if item[5] is not None else None
+                    if tut_name:
+                        pix_name = slugify(f"{item[0].objectName()}-{tut_name}")
+                        pix_file = pix_dir / f"{pix_name}.png"
+                        item[5].grab().save(str(pix_file.resolve()), 'png')
                 if len(item[2]) > 0:
                     # These are twice defined, but only one can be used for highlighting
                     if (item[2] in ['Pan', 'Home', 'Forward',

--- a/mslib/msui/multilayers.py
+++ b/mslib/msui/multilayers.py
@@ -29,6 +29,7 @@ import logging
 import mslib.msui.wms_control
 from mslib.msui.icons import icons
 from mslib.msui.qt5 import ui_wms_multilayers as ui
+from mslib.utils.colordialog import CustomColorDialog
 from mslib.utils.config import save_settings_qsettings, load_settings_qsettings
 
 
@@ -353,15 +354,20 @@ class Multilayers(QtWidgets.QDialog, ui.Ui_MultilayersDialog):
                 color.setStyleSheet(f"background-color: {widget.color}")
                 self.listLayers.setItemWidget(widget, 3, color)
 
-                def color_changed(layer):
-                    self.multilayer_clicked(layer)
-                    new_color = QtWidgets.QColorDialog.getColor().name()
-                    color.setStyleSheet(f"background-color: {new_color}")
+                def apply_color(layer, button, new_color):
+                    button.setStyleSheet(f"background-color: {new_color}")
                     layer.color_changed(new_color)
                     self.multilayer_clicked(layer)
                     self.dock_widget.auto_update()
 
-                color.clicked.connect(lambda: color_changed(widget))
+                def color_changed(layer, button):
+                    self.multilayer_clicked(layer)
+                    dialog = CustomColorDialog(self)
+                    dialog.color_selected.connect(
+                        lambda colour: apply_color(layer, button, colour.name()))
+                    dialog.show()
+
+                color.clicked.connect(lambda: color_changed(widget, color))
 
             if widget.style:
                 style = QtWidgets.QComboBox()

--- a/mslib/msui/remotesensing_dockwidget.py
+++ b/mslib/msui/remotesensing_dockwidget.py
@@ -34,6 +34,7 @@ import skyfield_data
 
 from PyQt5 import QtGui, QtWidgets
 from mslib.msui.qt5 import ui_remotesensing_dockwidget as ui
+from mslib.utils.colordialog import CustomColorDialog
 from mslib.utils.time import jsec_to_datetime, datetime_to_jsec
 from mslib.utils.coordinate import get_distance, rotate_point, fix_angle, normalize_longitude
 
@@ -130,17 +131,20 @@ class RemoteSensingControlWidget(QtWidgets.QWidget, ui.Ui_RemoteSensingDockWidge
         self.view.set_remote_sensing_appearance(settings)
 
     def set_tangentpoint_colour(self):
-        """Slot for the colour buttons: Opens a QColorDialog and sets the
+        """Slot for the colour buttons: Opens the CustomColorDialog and sets the
            new button face colour.
         """
-        button = self.btTangentsColour
-        palette = QtGui.QPalette(button.palette())
-        colour = palette.color(QtGui.QPalette.Button)
-        colour = QtWidgets.QColorDialog.getColor(colour)
+        dialog = CustomColorDialog(self)
+        dialog.color_selected.connect(self.on_tangentpoint_colour_selected)
+        dialog.show()
+
+    def on_tangentpoint_colour_selected(self, colour):
         if colour.isValid():
+            button = self.btTangentsColour
+            palette = QtGui.QPalette(button.palette())
             palette.setColor(QtGui.QPalette.Button, colour)
             button.setPalette(palette)
-        self.update_settings()
+            self.update_settings()
 
     def compute_tangent_lines(self, bmap, wp_vertices, wp_heights):
         """

--- a/mslib/utils/colordialog.py
+++ b/mslib/utils/colordialog.py
@@ -38,6 +38,7 @@ class CustomColorDialog(QtWidgets.QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Select Color")
+        self.setObjectName("ColorSelectDialog")
         self.setFixedSize(350, 300)
 
         self.colors = [
@@ -46,6 +47,16 @@ class CustomColorDialog(QtWidgets.QDialog):
             "#e6194B", "#d2cf94", "#356e33", "#f58231", "#2c2c2c",
             "#000075", "#9A6324", "#808000", "#000000", "#f8cbdc"
         ]
+        # Used to locate colors by name in tutorials.
+        self.color_names = [
+            "maroon", "raspberry", "apricot", "yellow", "blue",
+            "green", "skyblue", "purple", "magenta", "lightgray",
+            "red", "khaki", "darkgreen", "orange", "darkgrey",
+            "navy", "brown", "olive", "black", "pink"
+        ]
+
+        assert len(self.color_names) == len(self.colors), \
+            "color_names and colors must stay the same length"
 
         layout = QVBoxLayout()
         # Color swatches layout
@@ -56,6 +67,7 @@ class CustomColorDialog(QtWidgets.QDialog):
             button = QtWidgets.QPushButton()
             button.setFixedSize(50, 50)
             button.setStyleSheet(f"background-color: {color}")
+            button.setProperty("color_name", self.color_names[i])
             button.clicked.connect(functools.partial(self.on_color_clicked, color))
             row = i // 5
             col = i % 5

--- a/tests/_test_msui/test_kmloverlay_dockwidget.py
+++ b/tests/_test_msui/test_kmloverlay_dockwidget.py
@@ -28,7 +28,7 @@
 import mock
 import pytest
 from pathlib import Path
-from PyQt5 import QtCore, QtTest, QtGui
+from PyQt5 import QtCore, QtTest, QtGui, QtWidgets
 from tests.constants import ROOT_DIR
 import mslib.msui.kmloverlay_dockwidget as kd
 
@@ -146,8 +146,7 @@ class Test_KmlOverlayDockWidget:
         assert mocksave.call_count == 1
         assert save_kml.exists()
 
-    @mock.patch("PyQt5.QtWidgets.QColorDialog.getColor", return_value=QtGui.QColor())
-    def test_customize_kml(self, mock_colour_button):
+    def test_customize_kml(self):
         """
         Test the pushbutton for color and double spin box for linewidth and checking specific
         file gets desired linewidth and colour
@@ -156,25 +155,25 @@ class Test_KmlOverlayDockWidget:
         assert self.window.listWidget.count() == 1
         item = self.window.listWidget.item(0)
         rect = self.window.listWidget.visualItemRect(item)
-        # in testing, need to add mouseclick and click the listWidget item
         QtTest.QTest.mouseClick(self.window.listWidget.viewport(),
                                 QtCore.Qt.LeftButton,
                                 pos=rect.center())
 
-        # Clicking on Push Button Colour
+        # Clicking on Push Button Colour opens the CustomColorDialog
         QtTest.QTest.mouseClick(self.window.pushButton_color, QtCore.Qt.LeftButton)
-        assert mock_colour_button.call_count == 1
+        color_dialog = self.window.findChild(QtWidgets.QDialog)
+        assert color_dialog is not None
+        # pick the first swatch
+        color_dialog.color_buttons[0].click()
 
         # Testing the Double Spin Box for linewidth
         self.window.dsbx_linewidth.setValue(3)
         assert self.window.dsbx_linewidth.value() == 3
 
         # Testing the dictionary of files for color and linewidth
-        assert self.window.dict_files[str(path)]["color"] == (0, 0, 0, 1)
+        expected = QtGui.QColor(color_dialog.colors[0]).getRgbF()
+        assert self.window.dict_files[str(path)]["color"] == expected
         assert self.window.dict_files[str(path)]["linewidth"] == 3
-
-        self.window.remove_file()
-        assert self.window.listWidget.count() == 0
 
     def test_check_uncheck(self):
         """

--- a/tests/_test_msui/test_remotesensing.py
+++ b/tests/_test_msui/test_remotesensing.py
@@ -190,6 +190,16 @@ class Test_RemoteSensingControlWidget:
         result = [(round(x, 2), round(y, 2)) for x, y in coordinates]
         assert result == self.result_test_tangent_point_coordinates
 
+    def test_set_tangentpoint_colour(self):
+        from PyQt5 import QtWidgets, QtGui
+        self.remote_widget.set_tangentpoint_colour()
+        color_dialog = self.remote_widget.findChild(QtWidgets.QDialog)
+        assert color_dialog is not None
+        color_dialog.color_buttons[0].click()
+        expected = QtGui.QColor(color_dialog.colors[0])
+        button_color = self.remote_widget.btTangentsColour.palette().button().color()
+        assert button_color.getRgbF() == expected.getRgbF()
+
     @pytest.mark.parametrize("obs_azi, obs_ele, sol_azi, sol_ele, expected_rating", [
         (76.00, -1.0, 240.70, 58.33, 175.06),
         (76.11, -1.0, 239.90, 60.03, 174.79),

--- a/tests/_test_utils/test_colordialog.py
+++ b/tests/_test_utils/test_colordialog.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+    tests._test_utils.test_colordialog
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests for mslib.utils.colordialog.
+
+    This file is part of MSS.
+
+    :copyright: Copyright 2026 by Reimar Bauer.
+    :license: APACHE-2.0, see LICENSE for details.
+"""
+import pytest
+from mslib.utils.colordialog import CustomColorDialog
+
+
+@pytest.fixture
+def dialog(qtbot):
+    dlg = CustomColorDialog()
+    qtbot.addWidget(dlg)
+    return dlg
+
+
+def test_dialog_has_object_name(dialog):
+    assert dialog.objectName() == "ColorSelectDialog"
+
+
+def test_every_swatch_has_unique_tutorial_name(dialog):
+    names = [b.property("color_name") for b in dialog.color_buttons]
+    assert all(n for n in names), "every swatch must carry a color_name"
+    assert len(names) == len(dialog.colors)
+    assert len(set(names)) == len(names), "swatch names must be unique"
+
+
+def test_swatch_maps_to_expected_hex(dialog):
+    by_name = {b.property("color_name"): dialog.colors[i]
+               for i, b in enumerate(dialog.color_buttons)}
+    assert by_name["red"] == "#e6194B"
+    assert by_name["blue"] == "#0000ff"
+
+
+def test_marked_swatches_are_captured_in_tutorial_mode(qtbot, tmp_path, monkeypatch):
+    """create_tutorial_images() (get_shortcuts in tutorial_mode) writes a PNG per swatch."""
+    from mslib.msui import constants
+    from mslib.msui.msui_mainwindow import MSUI_ShortcutsDialog
+    monkeypatch.setattr(constants, "MSUI_CONFIG_PATH", tmp_path)
+
+    color_dlg = CustomColorDialog()
+    qtbot.addWidget(color_dlg)
+    color_dlg.show()
+    qtbot.waitExposed(color_dlg)
+
+    shortcuts = MSUI_ShortcutsDialog(tutorial_mode=True)
+    qtbot.addWidget(shortcuts)
+    # The real Ctrl+F search path checks cbNoShortcut so widgets without a
+    # keyboard shortcut (the swatches) are included (msui_mainwindow.py ~line 1176).
+    shortcuts.cbNoShortcut.setCheckState(2)
+    shortcuts.get_shortcuts()
+
+    pix_dir = tmp_path / "tutorial_images"
+    written = {p.name for p in pix_dir.glob("*.png")}
+    assert "colorselectdialog-red.png" in written
+    assert "colorselectdialog-blue.png" in written

--- a/tutorials/tutorial_kml.py
+++ b/tutorials/tutorial_kml.py
@@ -26,8 +26,8 @@
 
 import os
 import pyautogui as pag
-from tutorials.utils import (start, finish,
-                             change_color, create_tutorial_images, find_and_click_picture,
+from tutorials.utils import (start, finish, change_color,
+                             select_color, create_tutorial_images, find_and_click_picture,
                              load_kml_file, select_listelement, type_and_key, msui_full_screen_and_open_first_view
                              )
 from tutorials.utils.platform_keys import platform_keys
@@ -66,11 +66,12 @@ def _load_kml_files(kml_folder_path):
                            "'select to open control' button/option not found on the screen.")
     select_listelement(4)
     create_tutorial_images()
+    # select kml examples for europe
     _load_individual_kml_file('folder.kml', kml_folder_path)
     # cursor is on center of the button, moving it so it can be found on screen
     pag.move(100, 100)
     create_tutorial_images()
-    _load_individual_kml_file('color.kml', kml_folder_path)
+    _load_individual_kml_file('line.kml', kml_folder_path)
     pag.sleep(1)
     create_tutorial_images()
 
@@ -88,17 +89,16 @@ def _change_color_and_linewidth():
     create_tutorial_images()
     pag.move(-200, 0, duration=1)
     pag.click(interval=2)
-    _change_color('topviewwindow-change-color.png',
-                  lambda: (pag.move(-220, -300, duration=1), pag.click(interval=2), pag.press(ENTER)))
+    # locate the "red" swatch image and click it, wherever the dialog opens
+    select_color('topviewwindow-change-color.png', 'red')
+    find_and_click_picture('topviewwindow-change-color.png',
+                           "'Change Color' button not found on the screen.")
+    select_color('topviewwindow-change-color.png', 'yellow')
     create_tutorial_images()
-    _change_linewidth('topviewwindow-2-00.png', lambda: (pag.hotkey(CTRL, 'a'),
+    _change_linewidth('topviewwindow-200.png', lambda: (pag.hotkey(CTRL, 'a'),
                                                          [pag.press('down') for _ in range(8)],
                                                          type_and_key('2.50'), pag.sleep(1),
                                                          type_and_key('5.50')))
-
-
-def _change_color(img_name, actions):
-    change_color(img_name, "'Change Color' button not found on the screen.", actions, interval=2)
 
 
 def _change_linewidth(img_name, actions):

--- a/tutorials/tutorial_kml.py
+++ b/tutorials/tutorial_kml.py
@@ -96,9 +96,9 @@ def _change_color_and_linewidth():
     select_color('topviewwindow-change-color.png', 'yellow')
     create_tutorial_images()
     _change_linewidth('topviewwindow-200.png', lambda: (pag.hotkey(CTRL, 'a'),
-                                                         [pag.press('down') for _ in range(8)],
-                                                         type_and_key('2.50'), pag.sleep(1),
-                                                         type_and_key('5.50')))
+                                                        [pag.press('down') for _ in range(8)],
+                                                        type_and_key('2.50'), pag.sleep(1),
+                                                        type_and_key('5.50')))
 
 
 def _change_linewidth(img_name, actions):

--- a/tutorials/tutorial_remotesensing.py
+++ b/tutorials/tutorial_remotesensing.py
@@ -25,7 +25,7 @@ import pyautogui as pag
 
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view,
                              create_tutorial_images, select_listelement, find_and_click_picture, zoom_in,
-                             add_waypoints_to_topview)
+                             type_path, add_waypoints_to_topview)
 from tutorials.utils.platform_keys import platform_keys
 from mslib.utils.config import load_settings_qsettings
 
@@ -107,10 +107,15 @@ def _draw_tangents_to_the_waypoints(os_screen_region):
                            'Draw tangent points not found',
                            region=os_screen_region)
     x, y = pag.position()
-    # Changing color of tangents
+    # Open the tangent colour dialog (the colour button sits to the right of the checkbox)
     pag.click(x + 160, y, duration=1)
     pag.sleep(1)
-    pag.press(ENTER)
+    # Capture the CustomColorDialog swatches, then click the red swatch by image
+    create_tutorial_images()
+    pag.sleep(1)
+    find_and_click_picture('colorselectdialog-red.png',
+                           "Color 'red' not found in color dialog",
+                           region=os_screen_region)
     pag.sleep(1)
     return x, y
 

--- a/tutorials/tutorial_remotesensing.py
+++ b/tutorials/tutorial_remotesensing.py
@@ -25,7 +25,7 @@ import pyautogui as pag
 
 from tutorials.utils import (start, finish, msui_full_screen_and_open_first_view,
                              create_tutorial_images, select_listelement, find_and_click_picture, zoom_in,
-                             type_path, add_waypoints_to_topview)
+                             add_waypoints_to_topview)
 from tutorials.utils.platform_keys import platform_keys
 from mslib.utils.config import load_settings_qsettings
 

--- a/tutorials/utils/__init__.py
+++ b/tutorials/utils/__init__.py
@@ -344,6 +344,36 @@ def change_color(pic_name, exception_message, actions, interval=2, sleep_time=2)
         raise
 
 
+def select_color(open_pic, color_name, exception_message=None, region=None):
+    """
+    Open the predefined-swatch color dialog (CustomColorDialog) and click the
+    swatch named ``color_name`` by locating its captured image on screen.
+
+    This relies on create_tutorial_images() having captured the swatches as
+    ``colorselectdialog-<color_name>.png`` (see CustomColorDialog), so the cursor
+    goes to e.g. "red" wherever the dialog happens to open.
+
+    :param open_pic: Image of the dock button that opens the color dialog.
+    :param color_name: Friendly swatch name, e.g. "red", "blue", "green".
+    :param exception_message: Optional message if ``open_pic`` is not found.
+    :param region: Optional region applied to BOTH the open-button click and the
+        swatch click (e.g. the view window's screen region). Constraining the
+        swatch search avoids matching a same-colored preview button elsewhere.
+        ``create_tutorial_images()`` always captures globally; ``region`` only
+        bounds the on-screen clicks.
+    """
+    # open the color dialog
+    find_and_click_picture(open_pic,
+                           exception_message or f"{open_pic} not found", region=region)
+    pag.sleep(1)
+    # capture the swatch images now that the dialog is visible
+    create_tutorial_images()
+    pag.sleep(1)
+    # click the named swatch
+    find_and_click_picture(f"colorselectdialog-{color_name}.png",
+                           f"Color '{color_name}' not found in color dialog", region=region)
+
+
 def zoom_in(pic_name, exception_message, move=(379, 205), dragRel=(70, 75), region=None):
     """
     This method locates a given picture on the screen, clicks on it, moves the mouse cursor,


### PR DESCRIPTION


**Purpose of PR?**:

Fixes #3089

**Does this PR introduce a breaking change?**
replaced QColorDialog by CustomColorDialog
added select_color tutorial helper
refactored tutorials

**If the changes in this PR are manually verified, list down the scenarios covered:**:

## LinearView
<img width="831" height="726" alt="image" src="https://github.com/user-attachments/assets/25e1ce89-e89d-4698-9967-f792802d1148" />

## KML Dockingwidget
<img width="950" height="813" alt="image" src="https://github.com/user-attachments/assets/a7ca29e0-9305-4dd8-b8dc-ce2cb408e1d4" />

## RemoteSensing
<img width="945" height="810" alt="image" src="https://github.com/user-attachments/assets/e4a6e927-a2ea-45b6-8d27-259d21b0aa36" />



