### PR TITLE
for tutorials enable waypoint manipulations over coordinates (ftml file)

### DIFF
--- a/mslib/msui/msui_mainwindow.py
+++ b/mslib/msui/msui_mainwindow.py
@@ -1150,6 +1150,11 @@ class MSUIMainWindow(QtWidgets.QMainWindow, ui.Ui_MSUIMainWindow):
                 view_window.mpl.setFixedSize(layout['linearview'][0], layout['linearview'][1])
 
         if view_window is not None:
+            if self.tutorial_mode:
+                # Views receive their model via the constructor, which bypasses
+                # setFlightTrackModel; wire the tutorial-mode flight-track mirroring
+                # here once tutorial_mode and the model are both set on the window.
+                view_window.enable_tutorial_flighttrack_save()
             # Set view type to window
             view_window.view_type = view_window.name
             # Make sure view window will be deleted after being closed, not

--- a/mslib/msui/viewwindows.py
+++ b/mslib/msui/viewwindows.py
@@ -27,10 +27,12 @@
     limitations under the License.
 """
 import logging
+import os
 
 from abc import abstractmethod
 
 from PyQt5 import QtCore, QtWidgets
+from mslib.msui import constants
 from mslib.utils.config import save_settings_qsettings
 
 
@@ -112,6 +114,63 @@ class MSUIViewWindow(QtWidgets.QMainWindow):
             self.setWindowTitle(self.windowTitle().replace(self.waypoints_model.name, model.name))
 
         self.waypoints_model = model
+
+        if getattr(self, "tutorial_mode", False):
+            self._track_tutorial_flighttrack(model)
+
+    def enable_tutorial_flighttrack_save(self):
+        """
+        Start mirroring the displayed flight track to the tutorial FTML.
+
+        Views receive their model through the constructor, which bypasses
+        setFlightTrackModel (where the mirroring is normally wired). The view
+        creator calls this once after construction, in tutorial mode, so the
+        initial track is written and later edits are tracked.
+        """
+        self._track_tutorial_flighttrack(self.waypoints_model)
+
+    def _track_tutorial_flighttrack(self, model):
+        """
+        In tutorial mode, keep a silent FTML copy of the displayed flight track
+        current, so coordinate-based tutorials can resolve waypoint names and
+        entry order before a delete/move.
+
+        Connects to the model's change signals so edits made in *any* view (the
+        model object is shared across Top/Side/Table/Linear views) and
+        collaborative mscolab updates -- which also arrive through
+        setFlightTrackModel -- trigger a rewrite. The previously tracked model
+        is disconnected when the displayed model is swapped.
+        """
+        signals = ("dataChanged", "rowsInserted", "rowsRemoved", "layoutChanged", "modelReset")
+        previous = getattr(self, "_tutorial_ft_model", None)
+        if previous is not None and previous is not model:
+            for sig in signals:
+                try:
+                    getattr(previous, sig).disconnect(self._save_tutorial_flighttrack)
+                except (TypeError, RuntimeError):
+                    pass
+        if model is not None and model is not previous:
+            for sig in signals:
+                getattr(model, sig).connect(self._save_tutorial_flighttrack)
+        self._tutorial_ft_model = model
+        self._save_tutorial_flighttrack()
+
+    def _save_tutorial_flighttrack(self, *args):
+        """
+        Write the current flight track to a fixed FTML path for the tutorials.
+
+        Uses get_xml_content() rather than save_to_ftml() so the model's own
+        name/filename are not overwritten.
+        """
+        model = self.waypoints_model
+        if model is None:
+            return
+        path = os.path.join(constants.MSUI_CONFIG_PATH, "tutorial_flighttrack.ftml")
+        try:
+            with open(path, "w") as file_object:
+                file_object.write(model.get_xml_content())
+        except OSError as ex:
+            logging.warning("Could not write tutorial flight track (%s: %s)", type(ex), ex)
 
     def controlToBeCreated(self, index):
         """

--- a/tests/_test_msui/test_sideview.py
+++ b/tests/_test_msui/test_sideview.py
@@ -147,6 +147,49 @@ class Test_MSSSideViewWindow:
         yield
         self.window.hide()
 
+    def test_tutorial_mode_mirrors_flighttrack_to_ftml(self):
+        """
+        In tutorial mode the displayed flight track is silently written to a
+        fixed FTML, and the file is rewritten when the model changes.
+        """
+        from mslib.msui import constants
+        ftml = os.path.join(constants.MSUI_CONFIG_PATH, "tutorial_flighttrack.ftml")
+        if os.path.exists(ftml):
+            os.remove(ftml)
+        self.window.tutorial_mode = True
+        model = self.window.waypoints_model
+        # setting the model connects the change signals and writes the file
+        self.window.setFlightTrackModel(model)
+        assert os.path.exists(ftml)
+        content = open(ftml).read()
+        assert "<FlightTrack" in content
+        assert content.count("<Waypoint") == len(model.waypoints)
+        # a model change triggers a rewrite
+        os.remove(ftml)
+        model.insertRows(0, rows=1, waypoints=[ft.Waypoint(10.0, 20.0, 400)])
+        assert os.path.exists(ftml)
+        with open(ftml) as f:
+            data = f.read()
+            assert data.count("<Waypoint") == len(model.waypoints)
+            assert '    <Waypoint location="" lat="10.0" lon="20.0" flightlevel="400">' in data.split('\n')
+
+    def test_tutorial_mode_enable_save_writes_initial_ftml(self):
+        """
+        Views get their model via the constructor (bypassing setFlightTrackModel),
+        so the creator calls enable_tutorial_flighttrack_save to write the initial
+        FTML and start tracking (mscolab).
+        """
+        from mslib.msui import constants
+        ftml = os.path.join(constants.MSUI_CONFIG_PATH, "tutorial_flighttrack.ftml")
+        if os.path.exists(ftml):
+            os.remove(ftml)
+        self.window.tutorial_mode = True
+        self.window.enable_tutorial_flighttrack_save()
+        assert os.path.exists(ftml)
+        with open(ftml) as f:
+            data = f.read()
+            assert data.count("<Waypoint") == len(self.window.waypoints_model.waypoints)
+
     def test_open_wms(self):
         self.window.cbTools.currentIndexChanged.emit(1)
 

--- a/tests/_test_msui/test_tableview.py
+++ b/tests/_test_msui/test_tableview.py
@@ -56,6 +56,49 @@ class Test_TableView:
         yield
         self.window.hide()
 
+    def test_tutorial_mode_mirrors_flighttrack_to_ftml(self):
+        """
+        In tutorial mode the displayed flight track is silently written to a
+        fixed FTML, and the file is rewritten when the model changes.
+        """
+        from mslib.msui import constants
+        ftml = os.path.join(constants.MSUI_CONFIG_PATH, "tutorial_flighttrack.ftml")
+        if os.path.exists(ftml):
+            os.remove(ftml)
+        self.window.tutorial_mode = True
+        model = self.window.waypoints_model
+        # setting the model connects the change signals and writes the file
+        self.window.setFlightTrackModel(model)
+        assert os.path.exists(ftml)
+        content = open(ftml).read()
+        assert "<FlightTrack" in content
+        assert content.count("<Waypoint") == len(model.waypoints)
+        # a model change triggers a rewrite
+        os.remove(ftml)
+        model.insertRows(0, rows=1, waypoints=[ft.Waypoint(10.0, 20.0, 200)])
+        assert os.path.exists(ftml)
+        with open(ftml) as f:
+            data = f.read()
+            assert data.count("<Waypoint") == len(model.waypoints)
+            assert '    <Waypoint location="" lat="10.0" lon="20.0" flightlevel="200">' in data.split('\n')
+
+    def test_tutorial_mode_enable_save_writes_initial_ftml(self):
+        """
+        Views get their model via the constructor (bypassing setFlightTrackModel),
+        so the creator calls enable_tutorial_flighttrack_save to write the initial
+        FTML and start tracking (mscolab).
+        """
+        from mslib.msui import constants
+        ftml = os.path.join(constants.MSUI_CONFIG_PATH, "tutorial_flighttrack.ftml")
+        if os.path.exists(ftml):
+            os.remove(ftml)
+        self.window.tutorial_mode = True
+        self.window.enable_tutorial_flighttrack_save()
+        assert os.path.exists(ftml)
+        with open(ftml) as f:
+            data = f.read()
+            assert data.count("<Waypoint") == len(self.window.waypoints_model.waypoints)
+
     def test_open_hex(self):
         """
         Tests opening the hexagon dock widget.

--- a/tests/_test_msui/test_topview.py
+++ b/tests/_test_msui/test_topview.py
@@ -131,6 +131,49 @@ class Test_MSSTopViewWindow:
         yield
         self.window.hide()
 
+    def test_tutorial_mode_mirrors_flighttrack_to_ftml(self):
+        """
+        In tutorial mode the displayed flight track is silently written to a
+        fixed FTML, and the file is rewritten when the model changes.
+        """
+        from mslib.msui import constants
+        ftml = os.path.join(constants.MSUI_CONFIG_PATH, "tutorial_flighttrack.ftml")
+        if os.path.exists(ftml):
+            os.remove(ftml)
+        self.window.tutorial_mode = True
+        model = self.window.waypoints_model
+        # setting the model connects the change signals and writes the file
+        self.window.setFlightTrackModel(model)
+        assert os.path.exists(ftml)
+        content = open(ftml).read()
+        assert "<FlightTrack" in content
+        assert content.count("<Waypoint") == len(model.waypoints)
+        # a model change triggers a rewrite
+        os.remove(ftml)
+        model.insertRows(0, rows=1, waypoints=[ft.Waypoint(10.0, 20.0, 0)])
+        assert os.path.exists(ftml)
+        with open(ftml) as f:
+            data = f.read()
+            assert data.count("<Waypoint") == len(model.waypoints)
+            assert '    <Waypoint location="" lat="10.0" lon="20.0" flightlevel="0">' in data.split('\n')
+
+    def test_tutorial_mode_enable_save_writes_initial_ftml(self):
+        """
+        Views get their model via the constructor (bypassing setFlightTrackModel),
+        so the creator calls enable_tutorial_flighttrack_save to write the initial
+        FTML and start tracking (mscolab).
+        """
+        from mslib.msui import constants
+        ftml = os.path.join(constants.MSUI_CONFIG_PATH, "tutorial_flighttrack.ftml")
+        if os.path.exists(ftml):
+            os.remove(ftml)
+        self.window.tutorial_mode = True
+        self.window.enable_tutorial_flighttrack_save()
+        assert os.path.exists(ftml)
+        with open(ftml) as f:
+            data = f.read()
+            assert data.count("<Waypoint") == len(self.window.waypoints_model.waypoints)
+
     def test_open_wms(self):
         self.window.cbTools.currentIndexChanged.emit(1)
 


### PR DESCRIPTION

**Purpose of PR?**:

Fixes #3098

In tutorial mode we store now the flightpath data independent from a user. 
This enables location of waypoints by coordinates for move and delete "clicks" 
refactoring delete waypoints by the tutorials (graphical) is a follow up.





