### PR TITLE
fix: handle missing selected user ids in bulk permissions

### DIFF
--- a/mslib/mscolab/blueprints/operation/__init__.py
+++ b/mslib/mscolab/blueprints/operation/__init__.py
@@ -252,7 +252,7 @@ def get_users_with_permission():
 def add_bulk_permissions():
     fm = current_app.extensions['fm']
     op_id = int(request.form.get('op_id'))
-    new_u_ids = json.loads(request.form.get('selected_userids', []))
+    new_u_ids = json.loads(request.form.get('selected_userids', "[]"))
     access_level = request.form.get('selected_access_level')
     user = g.user
     success = fm.add_bulk_permission(op_id, user, new_u_ids, access_level)
@@ -271,7 +271,7 @@ def add_bulk_permissions():
 def modify_bulk_permissions():
     fm = current_app.extensions['fm']
     op_id = int(request.form.get('op_id'))
-    u_ids = json.loads(request.form.get('selected_userids', []))
+    u_ids = json.loads(request.form.get('selected_userids', "[]"))
     new_access_level = request.form.get('selected_access_level')
     user = g.user
     success = fm.modify_bulk_permission(op_id, user, u_ids, new_access_level)
@@ -290,7 +290,7 @@ def modify_bulk_permissions():
 def delete_bulk_permissions():
     fm = current_app.extensions['fm']
     op_id = int(request.form.get('op_id'))
-    u_ids = json.loads(request.form.get('selected_userids', []))
+    u_ids = json.loads(request.form.get('selected_userids', "[]"))
     user = g.user
     success = fm.delete_bulk_permission(op_id, user, u_ids)
     if success:


### PR DESCRIPTION
## Description

Fixes the default value used when parsing `selected_userids` in bulk permission routes.

## Changes

- Updated `add_bulk_permissions` to default missing `selected_userids` to `"[]"`
- Updated `modify_bulk_permissions` to default missing `selected_userids` to `"[]"`
- Updated `delete_bulk_permissions` to default missing `selected_userids` to `"[]"`

## Why

`json.loads()` expects a string, bytes, or bytearray. The previous default value was a Python list (`[]`), which can raise a `TypeError` if `selected_userids` is missing from the submitted form data.

Using `"[]"` keeps the intended empty-list behavior while passing a valid JSON string to `json.loads()`.

## Testing

- Ran `python -m py_compile mslib/mscolab/blueprints/operation/__init__.py`
- Reviewed the three bulk permission routes locally