### PR TITLE
Refactor MSColab away from a bunch of global variables

### DIFF
--- a/docs/mscolab.rst
+++ b/docs/mscolab.rst
@@ -121,9 +121,11 @@ address and using the token that the system sent along with the email.
 Instructions to use mscolab wsgi
 ................................
 
-Create a file called :code:`server.py` having this line::
+Create a file called :code:`server.py` having these lines::
 
-  from mslib.mscolab.server import _app as app
+  from mslib.mscolab.server import create_server_app
+
+  app = create_server_app()
 
 Then install gunicorn by pixi::
 

--- a/mslib/mscolab/CLAUDE.md
+++ b/mslib/mscolab/CLAUDE.md
@@ -6,8 +6,10 @@ Global map: ../../ARCHITECTURE.md
 
 ## Layout
 
-- `server.py` — thin assembly: HTTP basic auth hooks, blueprint registration
-- `app/__init__.py` — Flask app factory (config, db, socketio bindings)
+- `server.py` — thin assembly: `create_server_app()` adds db migration, CORS,
+  HTTP basic auth and the socket.io managers to the app
+- `app/__init__.py` — `create_app()` factory (config, extensions, blueprints)
+  and `initialise_db()`; there is no module level app instance
 - `blueprints/{operation,auth,chat,user,docs}/` — all ~50 REST routes; keep
   handlers thin, business logic belongs in the managers
 - `file_manager.py` — operations/permissions/versioning (git-backed) — core

--- a/mslib/mscolab/app/__init__.py
+++ b/mslib/mscolab/app/__init__.py
@@ -34,11 +34,10 @@ import sqlalchemy
 from flask_mail import Mail
 
 from flask_migrate import Migrate
-from flask import Flask
+from flask import Flask, current_app, url_for
 
 import mslib
 
-from flask import url_for
 from flask_sqlalchemy import SQLAlchemy
 
 from mslib.mscolab.conf import mscolab_settings
@@ -64,15 +63,20 @@ if update:
     logging.warning(message)
 
 
-# in memory database for testing
-# app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
-APP = Flask(__name__, template_folder=os.path.join(DOCS_TEMPLATES_DIR))
-APP.jinja_env.globals.setdefault("imprint", "")
-APP.jinja_env.globals.setdefault("gdpr", "")
-APP.config.from_object(mscolab_settings)
-# Expose docs path for callers/tests and make it part of Flask config for consistency.
-APP.config['DOCS_SERVER_PATH'] = DOCS_SERVER_PATH
-APP.route = prefix_route(APP.route, SCRIPT_NAME)
+db = SQLAlchemy(
+    metadata=sqlalchemy.MetaData(
+        naming_convention={
+            # For reference: https://alembic.sqlalchemy.org/en/latest/naming.html#the-importance-of-naming-constraints
+            "ix": "ix_%(column_0_label)s",
+            "uq": "uq_%(table_name)s_%(column_0_name)s",
+            "ck": "ck_%(table_name)s_`%(constraint_name)s`",
+            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "pk": "pk_%(table_name)s",
+        },
+    ),
+)
+mail = Mail()
+migrate = Migrate(render_as_batch=True, user_module_prefix="cu.")
 
 
 def _xstatic(name):
@@ -93,17 +97,21 @@ def _xstatic(name):
         return None
 
 
-# Keep backward compatibility with callers/tests expecting an app attribute.
-APP.xstatic = _xstatic
-
-
 def create_files():
-    Path(APP.config['OPERATIONS_DATA']).mkdir(parents=True, exist_ok=True)
-    Path(APP.config['UPLOAD_FOLDER']).mkdir(parents=True, exist_ok=True)
-    Path(APP.config['SSO_DIR']).mkdir(parents=True, exist_ok=True)
+    Path(current_app.config['OPERATIONS_DATA']).mkdir(parents=True, exist_ok=True)
+    Path(current_app.config['UPLOAD_FOLDER']).mkdir(parents=True, exist_ok=True)
+    Path(current_app.config['SSO_DIR']).mkdir(parents=True, exist_ok=True)
 
 
-def _handle_db_upgrade():
+def initialise_db():
+    """Create the data directories and bring the database up to the latest revision.
+
+    Must be called in an application context. This is not part of
+    :func:`create_app`, so that creating an app has no side effects on the
+    database (the CLI e.g. creates an app to then reset the database).
+    """
+    # imported here because mslib.mscolab.models imports db from this module; the
+    # import also registers the models on the metadata, which the migrations need
     from mslib.mscolab.models import db
 
     # Remove any stale session state before inspecting the schema; a lingering
@@ -130,9 +138,9 @@ your database MSColab will abort. Please follow the documentation for a manual d
         and db.session.execute(sqlalchemy.text("SELECT * FROM alembic_version")).first() is None
     )
     # If a database connection to migrate from is set and the target database is empty, then migrate the existing data
-    if is_empty_database and APP.config['SQLALCHEMY_DATABASE_URI_TO_MIGRATE_FROM'] is not None:
+    if is_empty_database and current_app.config['SQLALCHEMY_DATABASE_URI_TO_MIGRATE_FROM'] is not None:
         logging.info("The target database is empty and a database to migrate from is set, starting the data migration")
-        source_engine = sqlalchemy.create_engine(APP.config['SQLALCHEMY_DATABASE_URI_TO_MIGRATE_FROM'])
+        source_engine = sqlalchemy.create_engine(current_app.config['SQLALCHEMY_DATABASE_URI_TO_MIGRATE_FROM'])
         source_metadata = sqlalchemy.MetaData()
         source_metadata.reflect(bind=source_engine)
         # Determine the previous MSColab version based on the database content and upgrade to the corresponding revision
@@ -144,7 +152,7 @@ your database MSColab will abort. Please follow the documentation for a manual d
             flask_migrate.upgrade(directory=migrations.__path__[0], revision="92eaba86a92e")
         # Copy over the existing data.
         # Use db.engine.url (the resolved absolute URL) rather than
-        # APP.config['SQLALCHEMY_DATABASE_URI'], which may be a relative SQLite
+        # current_app.config['SQLALCHEMY_DATABASE_URI'], which may be a relative SQLite
         # path that Flask-SQLAlchemy expands via instance_path — plain
         # sqlalchemy.create_engine would resolve it against CWD instead.
         target_engine = sqlalchemy.create_engine(str(db.engine.url))
@@ -194,7 +202,7 @@ ORDER BY sequence_namespace.nspname, class_sequence.relname;
                 target_connection.commit()
         logging.info("Data migration finished")
         # Dispose the temporary copy engine so it doesn't hold SQLite
-        # connections across subsequent _handle_db_upgrade() iterations.
+        # connections across subsequent initialise_db() iterations.
         target_engine.dispose()
         source_engine.dispose()
 
@@ -204,18 +212,34 @@ ORDER BY sequence_namespace.nspname, class_sequence.relname;
     logging.info("Database initialised successfully!")
 
 
-def create_app(imprint=None, gdpr=None):
-    imprint_file = imprint
-    gdpr_file = gdpr
-    APP.mail = Mail(APP)
+def create_app(config_object=mscolab_settings):
+    """Create and configure an MSColab Flask application.
 
-    with APP.app_context():
-        _handle_db_upgrade()
+    :param config_object: the object the configuration is read from, by default the
+        :class:`mslib.mscolab.conf.DefaultSettings` instance updated with the
+        settings of the users ``mscolab_settings`` module.
 
-    APP.jinja_env.globals.update(file_exists=file_exists)
-    APP.jinja_env.globals["imprint"] = imprint_file or ""
-    APP.jinja_env.globals["gdpr"] = gdpr_file or ""
-    APP.jinja_env.globals.update(get_topmenu=get_topmenu)
+    The returned app is not connected to a database schema yet, call
+    :func:`initialise_db` within an application context of it to do so.
+    """
+    app = Flask(__name__, template_folder=DOCS_TEMPLATES_DIR)
+    app.config.from_object(config_object)
+    # Expose docs path for callers/tests and make it part of Flask config for consistency.
+    app.config['DOCS_SERVER_PATH'] = DOCS_SERVER_PATH
+    app.route = prefix_route(app.route, SCRIPT_NAME)
+    # Keep backward compatibility with callers/tests expecting an app attribute.
+    app.xstatic = _xstatic
+
+    db.init_app(app)
+    migrate.init_app(app, db)
+    mail.init_app(app)
+    # mslib.utils.auth.send_email sends its messages via current_app.mail
+    app.mail = mail
+
+    app.jinja_env.globals.update(file_exists=file_exists)
+    app.jinja_env.globals["imprint"] = app.config['IMPRINT'] or ""
+    app.jinja_env.globals["gdpr"] = app.config['GDPR'] or ""
+    app.jinja_env.globals.update(get_topmenu=get_topmenu)
 
     from mslib.mscolab.blueprints.auth import AUTH_BP
     from mslib.mscolab.blueprints.chat import CHAT_BP
@@ -223,36 +247,10 @@ def create_app(imprint=None, gdpr=None):
     from mslib.mscolab.blueprints.user import USER_BP
     from mslib.mscolab.blueprints.docs import DOCS_BP
 
-    if AUTH_BP.name not in APP.blueprints:
-        APP.register_blueprint(AUTH_BP)
-    if CHAT_BP.name not in APP.blueprints:
-        APP.register_blueprint(CHAT_BP)
-    if USER_BP.name not in APP.blueprints:
-        APP.register_blueprint(USER_BP)
-    if OPERATION_BP.name not in APP.blueprints:
-        APP.register_blueprint(OPERATION_BP)
-    if DOCS_BP.name not in APP.blueprints:
-        APP.register_blueprint(DOCS_BP)
+    for bp in (AUTH_BP, CHAT_BP, OPERATION_BP, USER_BP, DOCS_BP):
+        app.register_blueprint(bp)
 
-    return APP
-
-
-db = SQLAlchemy(
-    metadata=sqlalchemy.MetaData(
-        naming_convention={
-            # For reference: https://alembic.sqlalchemy.org/en/latest/naming.html#the-importance-of-naming-constraints
-            "ix": "ix_%(column_0_label)s",
-            "uq": "uq_%(table_name)s_%(column_0_name)s",
-            "ck": "ck_%(table_name)s_`%(constraint_name)s`",
-            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
-            "pk": "pk_%(table_name)s",
-        },
-    ),
-)
-db.init_app(APP)
-
-migrate = Migrate(render_as_batch=True, user_module_prefix="cu.")
-migrate.init_app(APP, db)
+    return app
 
 
 def get_topmenu():

--- a/mslib/mscolab/chat_manager.py
+++ b/mslib/mscolab/chat_manager.py
@@ -27,7 +27,8 @@
 import datetime
 from pathlib import Path
 
-from mslib.mscolab.app import APP
+from flask import current_app
+
 from mslib.mscolab.models import db, Message, MessageType
 from mslib.mscolab.utils import get_message_dict
 
@@ -88,7 +89,7 @@ class ChatManager:
         message = Message.query.filter(Message.id == message_id).first()
         if message.message_type == MessageType.IMAGE or message.message_type == MessageType.DOCUMENT:
             file_name = Path(message.text).name
-            upload_path = Path(APP.config['UPLOAD_FOLDER']) / str(message.op_id) / file_name
+            upload_path = Path(current_app.config['UPLOAD_FOLDER']) / str(message.op_id) / file_name
             upload_path.unlink()
         db.session.delete(message)
         db.session.commit()

--- a/mslib/mscolab/file_manager.py
+++ b/mslib/mscolab/file_manager.py
@@ -35,11 +35,11 @@ import git
 import threading
 import mimetypes
 from pathlib import Path, PurePosixPath
+from flask import current_app
 from werkzeug.utils import secure_filename
 from sqlalchemy.exc import IntegrityError
 from mslib.utils.verify_waypoint_data import verify_waypoint_data
 from mslib.mscolab.models import db, Operation, Permission, User, Change, Message
-from mslib.mscolab.app import APP
 from mslib.mscolab.utils import ATTACHMENTS_URL_PREFIX
 
 
@@ -97,8 +97,8 @@ class FileManager:
             db.session.add(perm)
             db.session.commit()
             # here we can import the permissions from Group file
-            if not path.endswith(APP.config['GROUP_POSTFIX']):
-                import_op = Operation.query.filter_by(path=f"{category}{APP.config['GROUP_POSTFIX']}").first()
+            if not path.endswith(current_app.config['GROUP_POSTFIX']):
+                import_op = Operation.query.filter_by(path=f"{category}{current_app.config['GROUP_POSTFIX']}").first()
                 if import_op is not None:
                     self.import_permissions(import_op.id, operation_id, user.id)
             data_dir = Path(self.data_dir)
@@ -267,7 +267,7 @@ class FileManager:
         """
         This function is called when deleting account or updating the profile picture
         """
-        upload_folder = APP.config['UPLOAD_FOLDER']
+        upload_folder = current_app.config['UPLOAD_FOLDER']
         if sys.platform.startswith('win'):
             upload_folder = upload_folder.replace('\\', '/')
 
@@ -289,7 +289,7 @@ class FileManager:
         Generic function to save files securely in any specified directory with unique filename
         and return the relative file path.
         """
-        upload_folder = APP.config['UPLOAD_FOLDER']
+        upload_folder = current_app.config['UPLOAD_FOLDER']
         if sys.platform.startswith('win'):
             upload_folder = upload_folder.replace('\\', '/')
 
@@ -392,9 +392,9 @@ class FileManager:
             except OSError:
                 shutil.move(str(old_path), str(new_path))
 
-            if value.endswith(APP.config['GROUP_POSTFIX']):
+            if value.endswith(current_app.config['GROUP_POSTFIX']):
                 # getting the category
-                category = value.split(APP.config['GROUP_POSTFIX'])[0]
+                category = value.split(current_app.config['GROUP_POSTFIX'])[0]
                 # all operation with that category
                 ops_category = Operation.query.filter_by(category=category)
                 for ops in ops_category:
@@ -648,14 +648,14 @@ class FileManager:
                 new_permissions.append(Permission(u_id, op_id, access_level))
         db.session.add_all(new_permissions)
         operation = Operation.query.filter_by(id=op_id).first()
-        if operation.path.endswith(APP.config['GROUP_POSTFIX']):
+        if operation.path.endswith(current_app.config['GROUP_POSTFIX']):
             # the members of this gets added to all others of same category
-            category = operation.path.split(APP.config['GROUP_POSTFIX'])[0]
+            category = operation.path.split(current_app.config['GROUP_POSTFIX'])[0]
             # all operation with that category
             ops_category = Operation.query.filter_by(category=category)
             new_permissions = []
             for ops in ops_category:
-                if not ops.path.endswith(APP.config['GROUP_POSTFIX']):
+                if not ops.path.endswith(current_app.config['GROUP_POSTFIX']):
                     new_permissions.append(Permission(u_id, ops.id, access_level))
                 db.session.add_all(new_permissions)
         try:
@@ -676,9 +676,9 @@ class FileManager:
             .update({Permission.access_level: new_access_level}, synchronize_session='fetch')
 
         operation = Operation.query.filter_by(id=op_id).first()
-        if operation.path.endswith(APP.config['GROUP_POSTFIX']):
+        if operation.path.endswith(current_app.config['GROUP_POSTFIX']):
             # the members of this gets added to all others of same category
-            category = operation.path.split(APP.config['GROUP_POSTFIX'])[0]
+            category = operation.path.split(current_app.config['GROUP_POSTFIX'])[0]
             # all operation with that category
             ops_category = Operation.query.filter_by(category=category)
             for ops in ops_category:
@@ -717,9 +717,9 @@ class FileManager:
             .delete(synchronize_session='fetch')
 
         operation = Operation.query.filter_by(id=op_id).first()
-        if operation.path.endswith(APP.config['GROUP_POSTFIX']):
+        if operation.path.endswith(current_app.config['GROUP_POSTFIX']):
             # the members of this gets added to all others of same category
-            category = operation.path.split(APP.config['GROUP_POSTFIX'])[0]
+            category = operation.path.split(current_app.config['GROUP_POSTFIX'])[0]
             # all operation with that category
             ops_category = Operation.query.filter_by(category=category)
             for ops in ops_category:

--- a/mslib/mscolab/models.py
+++ b/mslib/mscolab/models.py
@@ -103,19 +103,18 @@ class User(db.Model):
 
     def generate_auth_token(self, expiration=None):
         # Importing conf here to avoid loading settings on opening chat window
-        from mslib.mscolab.app import APP
-        expiration = APP.__dict__.get('EXPIRATION', expiration)
+        from mslib.mscolab.conf import mscolab_settings
         if expiration is None:
-            expiration = 864000
-            token = jwt.encode(
-                {
-                    "id": self.id,
-                    "exp": datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=expiration)
-                },
-                APP.config['SECRET_KEY'],
-                algorithm="HS256"
-            )
-            return token
+            expiration = getattr(mscolab_settings, 'EXPIRATION', 864000)
+        token = jwt.encode(
+            {
+                "id": self.id,
+                "exp": datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(seconds=expiration)
+            },
+            mscolab_settings.SECRET_KEY,
+            algorithm="HS256"
+        )
+        return token
 
     @staticmethod
     def verify_auth_token(token):

--- a/mslib/mscolab/mscolab.py
+++ b/mslib/mscolab/mscolab.py
@@ -37,23 +37,26 @@ import git
 import flask_migrate
 from pathlib import Path
 
+from flask import current_app
+
 from mslib import __version__
 from mslib.mscolab import migrations
-from mslib.mscolab.app import APP, create_files
+from mslib.mscolab.app import create_app, create_files
 from mslib.mscolab.seed import seed_data, add_user, add_all_users_default_operation, \
     add_all_users_to_all_operations, delete_user
 from mslib.utils import setup_logging
 
 
 def handle_start(args=None):
-    from mslib.mscolab.server import APP, sockio, cm, fm, start_server
+    from mslib.mscolab.server import create_server_app, start_server
     if args is not None:
         setup_logging(args)
     logging.info("MSS Version: %s", __version__)
     logging.info("Python Version: %s", sys.version)
     logging.info("Platform: %s (%s)", platform.platform(), platform.architecture())
     logging.info("Launching MSColab Server")
-    start_server(APP, sockio, cm, fm)
+    app = create_server_app()
+    start_server(app, app.extensions['sockio'], app.extensions['cm'], app.extensions['fm'])
 
 
 def confirm_action(confirmation_prompt, assume_yes=False):
@@ -90,12 +93,12 @@ def handle_db_reset(verbose=True):
         previous_levels = [logger.level for logger in alembic_loggers]
         for logger in alembic_loggers:
             logger.setLevel(logging.WARNING)
-    if APP.config['SQLALCHEMY_DATABASE_URI'].startswith("sqlite:///") and (
-        db_path := Path(APP.config['SQLALCHEMY_DATABASE_URI'].removeprefix("sqlite:///"))
-    ).is_relative_to(APP.config['DATA_DIR']):
+    if current_app.config['SQLALCHEMY_DATABASE_URI'].startswith("sqlite:///") and (
+        db_path := Path(current_app.config['SQLALCHEMY_DATABASE_URI'].removeprefix("sqlite:///"))
+    ).is_relative_to(current_app.config['DATA_DIR']):
         # Don't remove the database file
         # This would be easier if the database wasn't stored in DATA_DIR...
-        p = Path(APP.config['DATA_DIR'])
+        p = Path(current_app.config['DATA_DIR'])
         for root, dirs, files in os.walk(p, topdown=False):
             for name in files:
                 full_file_path = Path(root) / name
@@ -110,8 +113,8 @@ def handle_db_reset(verbose=True):
 
                     # Directory might not be empty or already removed
                     pass
-    elif Path(APP.config['DATA_DIR']).exists():
-        shutil.rmtree(APP.config['DATA_DIR'])
+    elif Path(current_app.config['DATA_DIR']).exists():
+        shutil.rmtree(current_app.config['DATA_DIR'])
     create_files()
     try:
         flask_migrate.downgrade(directory=migrations.__path__[0], revision="base")
@@ -147,9 +150,9 @@ def handle_mscolab_certificate_init():
 
     try:
         cmd = ["openssl", "req", "-newkey", "rsa:4096", "-keyout",
-               os.path.join(APP.config['SSO_DIR'], "key_mscolab.key"),
+               os.path.join(current_app.config['SSO_DIR'], "key_mscolab.key"),
                "-nodes", "-x509", "-days", "365", "-batch", "-subj",
-               "/CN=localhost", "-out", os.path.join(APP.config['SSO_DIR'],
+               "/CN=localhost", "-out", os.path.join(current_app.config['SSO_DIR'],
                                                      "crt_mscolab.crt")]
         subprocess.run(cmd, check=True)
         logging.info("generated CRTs for the mscolab server.")
@@ -164,9 +167,9 @@ def handle_local_idp_certificate_init():
 
     try:
         cmd = ["openssl", "req", "-newkey", "rsa:4096", "-keyout",
-               os.path.join(APP.config['SSO_DIR'], "key_local_idp.key"),
+               os.path.join(current_app.config['SSO_DIR'], "key_local_idp.key"),
                "-nodes", "-x509", "-days", "365", "-batch", "-subj",
-               "/CN=localhost", "-out", os.path.join(APP.config['SSO_DIR'], "crt_local_idp.crt")]
+               "/CN=localhost", "-out", os.path.join(current_app.config['SSO_DIR'], "crt_local_idp.crt")]
         subprocess.run(cmd, check=True)
         logging.info("generated CRTs for the local identity provider")
         return True
@@ -297,7 +300,7 @@ config:
   #       name_id_format_allow_create: true
 """
     try:
-        file_path = os.path.join(APP.config['SSO_DIR'], "mss_saml2_backend.yaml")
+        file_path = os.path.join(current_app.config['SSO_DIR'], "mss_saml2_backend.yaml")
         with open(file_path, "w", encoding="utf-8") as file:
             file.write(saml_2_backend_yaml_content)
         return True
@@ -323,7 +326,7 @@ def handle_mscolab_metadata_init(repo_exists):
         process = subprocess.Popen(command)
         cmd_curl = ["curl", "--retry", "5", "--retry-connrefused", "--retry-delay", "3",
                     "http://localhost:8083/metadata/localhost_test_idp",
-                    "-o", os.path.join(APP.config['SSO_DIR'], "metadata_sp.xml")]
+                    "-o", os.path.join(current_app.config['SSO_DIR'], "metadata_sp.xml")]
         subprocess.run(cmd_curl, check=True)
         process.terminate()
         logging.info('mscolab metadata file generated succesfully')
@@ -338,8 +341,8 @@ def handle_local_idp_metadata_init(repo_exists):
     print('generating metadata for localhost identity provider')
 
     try:
-        if os.path.exists(os.path.join(APP.config['SSO_DIR'], "idp.xml")):
-            os.remove(os.path.join(APP.config['SSO_DIR'], "idp.xml"))
+        if os.path.exists(os.path.join(current_app.config['SSO_DIR'], "idp.xml")):
+            os.remove(os.path.join(current_app.config['SSO_DIR'], "idp.xml"))
 
         idp_conf_path = os.path.join("mslib", "msidp", "idp_conf.py")
 
@@ -350,15 +353,15 @@ def handle_local_idp_metadata_init(repo_exists):
 
         cmd = ["make_metadata", idp_conf_path]
 
-        with open(os.path.join(APP.config['SSO_DIR'], "idp.xml"),
+        with open(os.path.join(current_app.config['SSO_DIR'], "idp.xml"),
                   "w", encoding="utf-8") as output_file:
             subprocess.run(cmd, stdout=output_file, check=True)
         logging.info("idp metadata file generated successfully")
         return True
     except subprocess.CalledProcessError as error:
         # Delete the idp.xml file when the subprocess fails
-        if os.path.exists(os.path.join(APP.config['SSO_DIR'], "idp.xml")):
-            os.remove(os.path.join(APP.config['SSO_DIR'], "idp.xml"))
+        if os.path.exists(os.path.join(current_app.config['SSO_DIR'], "idp.xml")):
+            os.remove(os.path.join(current_app.config['SSO_DIR'], "idp.xml"))
         print(f"Error while generating metadata for localhost identity provider: {error}")
         return False
 
@@ -368,8 +371,8 @@ def handle_sso_crts_init():
         This will generate necessary CRTs files for sso in mscolab through localhost idp
     """
     print("\n\nmscolab sso conf initiating......")
-    if os.path.exists(APP.config['SSO_DIR']):
-        shutil.rmtree(APP.config['SSO_DIR'])
+    if os.path.exists(current_app.config['SSO_DIR']):
+        shutil.rmtree(current_app.config['SSO_DIR'])
     create_files()
     if not handle_mscolab_certificate_init():
         print('Error while handling mscolab certificate.')
@@ -464,83 +467,83 @@ def main():
         handle_start(args)
 
     elif args.action == "db":
-        if args.reset:
-            confirmation = confirm_action(
-                "Are you sure you want to reset the database? This would delete "
-                "all your data! (y/[n]):",
-                assume_yes=args.yes)
-            if confirmation is True:
-                with APP.app_context():
+        with create_app().app_context():
+            if args.reset:
+                confirmation = confirm_action(
+                    "Are you sure you want to reset the database? This would delete "
+                    "all your data! (y/[n]):",
+                    assume_yes=args.yes)
+                if confirmation is True:
                     handle_db_reset()
-        elif args.seed:
-            confirmation = confirm_action(
-                "Are you sure you want to seed the database? Seeding will delete all your "
-                "existing data and replace it with seed data (y/[n]):",
-                assume_yes=args.yes)
-            if confirmation is True:
-                with APP.app_context():
+            elif args.seed:
+                confirmation = confirm_action(
+                    "Are you sure you want to seed the database? Seeding will delete all your "
+                    "existing data and replace it with seed data (y/[n]):",
+                    assume_yes=args.yes)
+                if confirmation is True:
                     handle_db_seed()
-        elif args.users_by_file is not None:
-            # fileformat: suggested_username  name   <email>
-            confirmation = confirm_action(
-                "Are you sure you want to add users to the database? (y/[n]):",
-                assume_yes=args.yes)
-            if confirmation is True:
-                for line in args.users_by_file.readlines():
-                    info = line.split()
-                    username = info[0]
-                    fullname = info[1]
-                    emailid = info[-1][1:-1]
-                    password = secrets.token_hex(8)
-                    add_user(emailid, username, password, fullname)
-        elif args.default_operation:
-            confirmation = confirm_action(
-                "Are you sure you want to add users to the default TEMPLATE operation? (y/[n]):",
-                assume_yes=args.yes)
-            if confirmation is True:
-                # adds all users as collaborator on the operation TEMPLATE if not added, command can be repeated
-                add_all_users_default_operation(access_level='admin')
-        elif args.add_all_to_all_operation:
-            confirmation = confirm_action(
-                "Are you sure you want to add users to the ALL operations? (y/[n]):",
-                assume_yes=args.yes)
-            if confirmation is True:
-                # adds all users to all Operations
-                add_all_users_to_all_operations()
-        elif args.delete_users_by_file:
-            confirmation = confirm_action(
-                "Are you sure you want to delete a user? (y/[n]):",
-                assume_yes=args.yes)
-            if confirmation is True:
-                # deletes users from the db
-                for email in args.delete_users_by_file.readlines():
-                    delete_user(email.strip())
+            elif args.users_by_file is not None:
+                # fileformat: suggested_username  name   <email>
+                confirmation = confirm_action(
+                    "Are you sure you want to add users to the database? (y/[n]):",
+                    assume_yes=args.yes)
+                if confirmation is True:
+                    for line in args.users_by_file.readlines():
+                        info = line.split()
+                        username = info[0]
+                        fullname = info[1]
+                        emailid = info[-1][1:-1]
+                        password = secrets.token_hex(8)
+                        add_user(emailid, username, password, fullname)
+            elif args.default_operation:
+                confirmation = confirm_action(
+                    "Are you sure you want to add users to the default TEMPLATE operation? (y/[n]):",
+                    assume_yes=args.yes)
+                if confirmation is True:
+                    # adds all users as collaborator on the operation TEMPLATE if not added, command can be repeated
+                    add_all_users_default_operation(access_level='admin')
+            elif args.add_all_to_all_operation:
+                confirmation = confirm_action(
+                    "Are you sure you want to add users to the ALL operations? (y/[n]):",
+                    assume_yes=args.yes)
+                if confirmation is True:
+                    # adds all users to all Operations
+                    add_all_users_to_all_operations()
+            elif args.delete_users_by_file:
+                confirmation = confirm_action(
+                    "Are you sure you want to delete a user? (y/[n]):",
+                    assume_yes=args.yes)
+                if confirmation is True:
+                    # deletes users from the db
+                    for email in args.delete_users_by_file.readlines():
+                        delete_user(email.strip())
 
     elif args.action == "sso_conf":
-        if args.init_sso_crts:
-            confirmation = confirm_action(
-                "This will reset and initiation all CRTs and SAML yaml file as default. "
-                "Are you sure to continue? (y/[n]):")
-            if confirmation is True:
-                handle_sso_crts_init()
-        if args.init_sso_metadata:
-            confirmation = confirm_action(
-                "Are you sure you executed --init_sso_crts before running this? (y/[n]):")
-            if confirmation is True:
+        with create_app().app_context():
+            if args.init_sso_crts:
                 confirmation = confirm_action(
-                    """
-                    This will generate necessary metada data file for sso in mscolab through localhost idp
-
-                    Before running this function:
-                    - Ensure that USE_SAML2 is set to True.
-                    - Generate the necessary keys and certificates and configure them in the .yaml
-                    file for the local IDP.
-
-                    Are you sure you set all correctly as per the documentation? (y/[n]):
-                    """
-                )
+                    "This will reset and initiation all CRTs and SAML yaml file as default. "
+                    "Are you sure to continue? (y/[n]):")
                 if confirmation is True:
-                    handle_sso_metadata_init(repo_exists)
+                    handle_sso_crts_init()
+            if args.init_sso_metadata:
+                confirmation = confirm_action(
+                    "Are you sure you executed --init_sso_crts before running this? (y/[n]):")
+                if confirmation is True:
+                    confirmation = confirm_action(
+                        """
+                        This will generate necessary metada data file for sso in mscolab through localhost idp
+
+                        Before running this function:
+                        - Ensure that USE_SAML2 is set to True.
+                        - Generate the necessary keys and certificates and configure them in the .yaml
+                        file for the local IDP.
+
+                        Are you sure you set all correctly as per the documentation? (y/[n]):
+                        """
+                    )
+                    if confirmation is True:
+                        handle_sso_metadata_init(repo_exists)
 
 
 if __name__ == '__main__':

--- a/mslib/mscolab/seed.py
+++ b/mslib/mscolab/seed.py
@@ -6,6 +6,9 @@
 
     Seeder utility for database
 
+    All functions of this module access the database and the app configuration, so
+    they have to be called within an application context.
+
     This file is part of MSS.
 
     :copyright: Copyright 2019 Shivashis Padhi
@@ -29,7 +32,7 @@ import git
 from pathlib import Path
 from sqlalchemy.exc import IntegrityError
 
-from mslib.mscolab.app import APP
+from flask import current_app
 from mslib.mscolab.models import User, db, Permission, Operation
 
 
@@ -50,12 +53,8 @@ XML_CONTENT_INIT = """<?xml version="1.0" encoding="utf-8"?>
 # Todo: refactor move to mscolab.utils
 def add_all_users_to_all_operations(access_level='collaborator'):
     """ on db level we add all users as collaborator to all operations """
-    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    APP.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    with APP.app_context():
-        all_operations = Operation.query.all()
-        all_path = [operation.path for operation in all_operations]
-        db.session.close()
+    all_operations = Operation.query.all()
+    all_path = [operation.path for operation in all_operations]
     for path in all_path:
         if path == "TEMPLATE":
             access_level = 'admin'
@@ -64,163 +63,134 @@ def add_all_users_to_all_operations(access_level='collaborator'):
 
 def add_all_users_default_operation(path='TEMPLATE', description="Operation to keep all users", access_level='admin'):
     """ on db level we add all users to the operation TEMPLATE for user handling"""
-    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    APP.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    operation_available = Operation.query.filter_by(path=path).first()
+    if not operation_available:
+        operation = Operation(path, description)
+        db.session.add(operation)
+        db.session.commit()
+        operation_file_name = Path(current_app.config['OPERATIONS_DATA']) / path
+        if not operation_file_name.exists():
+            operation_file_name.mkdir(parents=True, exist_ok=True)
+            operation_file_path = operation_file_name / "main.ftml"
+            xml_content = '''<?xml version="1.0" encoding="UTF-8"?>
+            <waypoints>
+            </waypoints>'''
+            operation_file_path.write_text(xml_content, encoding='utf-8')
+            git_repo_path = Path(current_app.config['OPERATIONS_DATA']) / path
+            git_repo_path.mkdir(parents=True, exist_ok=True)
+            r = git.Repo.init(str(git_repo_path))
+            r.git.clear_cache()
+            main_file_git = git_repo_path / "main.ftml"
+            main_file_git.write_text(XML_CONTENT_INIT, encoding='utf-8')
+            r.index.add(['main.ftml'])
+            r.index.commit("initial commit")
 
-    with APP.app_context():
-        operation_available = Operation.query.filter_by(path=path).first()
-        if not operation_available:
-            operation = Operation(path, description)
-            db.session.add(operation)
-            db.session.commit()
-            operation_file_name = Path(APP.config['OPERATIONS_DATA']) / path
-            if not operation_file_name.exists():
-                operation_file_name.mkdir(parents=True, exist_ok=True)
-                operation_file_path = operation_file_name / "main.ftml"
-                xml_content = '''<?xml version="1.0" encoding="UTF-8"?>
-                <waypoints>
-                </waypoints>'''
-                operation_file_path.write_text(xml_content, encoding='utf-8')
-                git_repo_path = Path(APP.config['OPERATIONS_DATA']) / path
-                git_repo_path.mkdir(parents=True, exist_ok=True)
-                r = git.Repo.init(str(git_repo_path))
-                r.git.clear_cache()
-                main_file_git = git_repo_path / "main.ftml"
-                main_file_git.write_text(XML_CONTENT_INIT, encoding='utf-8')
-                r.index.add(['main.ftml'])
-                r.index.commit("initial commit")
+    operation = Operation.query.filter_by(path=path).first()
+    op_id = operation.id
+    user_list = User.query \
+        .join(Permission, (User.id == Permission.u_id) & (Permission.op_id == op_id), isouter=True) \
+        .add_columns(User.id, User.username) \
+        .filter(Permission.u_id.is_(None))
 
-        operation = Operation.query.filter_by(path=path).first()
-        op_id = operation.id
-        user_list = User.query \
-            .join(Permission, (User.id == Permission.u_id) & (Permission.op_id == op_id), isouter=True) \
-            .add_columns(User.id, User.username) \
-            .filter(Permission.u_id.is_(None))
-
-        new_u_ids = [user.id for user in user_list]
-        new_permissions = []
-        for u_id in new_u_ids:
-            if Permission.query.filter_by(u_id=u_id, op_id=op_id).first() is None:
-                new_permissions.append(Permission(u_id, operation.id, access_level))
-        db.session.add_all(new_permissions)
-        try:
-            db.session.commit()
-            return True
-        except IntegrityError as err:
-            db.session.rollback()
-            logging.debug("Error writing to db: %s", err)
-        db.session.close()
+    new_u_ids = [user.id for user in user_list]
+    new_permissions = []
+    for u_id in new_u_ids:
+        if Permission.query.filter_by(u_id=u_id, op_id=op_id).first() is None:
+            new_permissions.append(Permission(u_id, operation.id, access_level))
+    db.session.add_all(new_permissions)
+    try:
+        db.session.commit()
+        return True
+    except IntegrityError as err:
+        db.session.rollback()
+        logging.debug("Error writing to db: %s", err)
 
 
 def delete_user(email):
-    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    APP.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    with APP.app_context():
-        user = User.query.filter_by(emailid=str(email)).first()
-        if user:
-            logging.info("User: %s deleted from db", email)
-            db.session.delete(user)
-            db.session.commit()
-            db.session.close()
-            return True
-        db.session.close()
-        return False
+    user = User.query.filter_by(emailid=str(email)).first()
+    if user:
+        logging.info("User: %s deleted from db", email)
+        db.session.delete(user)
+        db.session.commit()
+        return True
+    return False
 
 
 def add_user(email, username, password, fullname):
     """
     on db level we add a user
     """
-    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    APP.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-
-    with APP.app_context():
-        user_email_exists = User.query.filter_by(emailid=str(email)).first()
-        user_name_exists = User.query.filter_by(username=str(username)).first()
-        if not user_email_exists and not user_name_exists:
-            db_user = User(email, username, password, fullname)
-            db.session.add(db_user)
-            db.session.commit()
-            db.session.close()
-            logging.info("Userdata: %s %s %s %s", email, username, password, fullname)
-            return True
-        else:
-            logging.info("%s already in db", user_name_exists)
+    user_email_exists = User.query.filter_by(emailid=str(email)).first()
+    user_name_exists = User.query.filter_by(username=str(username)).first()
+    if not user_email_exists and not user_name_exists:
+        db_user = User(email, username, password, fullname)
+        db.session.add(db_user)
+        db.session.commit()
+        logging.info("Userdata: %s %s %s %s", email, username, password, fullname)
+        return True
+    else:
+        logging.info("%s already in db", user_name_exists)
     return False
 
 
 def get_user(email):
-    with APP.app_context():
-        return User.query.filter_by(emailid=str(email)).first()
+    return User.query.filter_by(emailid=str(email)).first()
 
 
 def get_operation(operation_name):
-    with APP.app_context():
-        return Operation.query.filter_by(path=operation_name).first()
+    return Operation.query.filter_by(path=operation_name).first()
 
 
 def add_operation(operation_name, description):
-    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    APP.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    with APP.app_context():
-        operation_available = Operation.query.filter_by(path=operation_name).first()
-        if not operation_available:
-            operation = Operation(operation_name, description)
-            db.session.add(operation)
-            db.session.commit()
-            operation_file_name = Path(APP.config['OPERATIONS_DATA']) / operation_name
+    operation_available = Operation.query.filter_by(path=operation_name).first()
+    if not operation_available:
+        operation = Operation(operation_name, description)
+        db.session.add(operation)
+        db.session.commit()
+        operation_file_name = Path(current_app.config['OPERATIONS_DATA']) / operation_name
 
-            if not operation_file_name.exists():
-                operation_file_name.mkdir(parents=True, exist_ok=True)
-                operation_file_path = operation_file_name / "main.ftml"
-                operation_file_path.write_text(XML_CONTENT_INIT, encoding='utf-8')
-                git_repo_path = Path(APP.config['OPERATIONS_DATA']) / operation_name
-                git_repo_path.mkdir(parents=True, exist_ok=True)
-                r = git.Repo.init(str(git_repo_path))
-                r.git.clear_cache()
-                main_file_git = git_repo_path / "main.ftml"
-                main_file_git.write_text(XML_CONTENT_INIT, encoding='utf-8')
-                r.index.add(['main.ftml'])
-                r.index.commit("initial commit")
-            return True
-        else:
-            return False
+        if not operation_file_name.exists():
+            operation_file_name.mkdir(parents=True, exist_ok=True)
+            operation_file_path = operation_file_name / "main.ftml"
+            operation_file_path.write_text(XML_CONTENT_INIT, encoding='utf-8')
+            git_repo_path = Path(current_app.config['OPERATIONS_DATA']) / operation_name
+            git_repo_path.mkdir(parents=True, exist_ok=True)
+            r = git.Repo.init(str(git_repo_path))
+            r.git.clear_cache()
+            main_file_git = git_repo_path / "main.ftml"
+            main_file_git.write_text(XML_CONTENT_INIT, encoding='utf-8')
+            r.index.add(['main.ftml'])
+            r.index.commit("initial commit")
+        return True
+    else:
+        return False
 
 
 def delete_operation(operation_name):
-    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    APP.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    with APP.app_context():
-        operation = Operation.query.filter_by(path=operation_name).first()
-        if operation:
-            db.session.delete(operation)
-            db.session.commit()
-            db.session.close()
-            return True
-        db.session.close()
-        return False
+    operation = Operation.query.filter_by(path=operation_name).first()
+    if operation:
+        db.session.delete(operation)
+        db.session.commit()
+        return True
+    return False
 
 
 def add_user_to_operation(path=None, access_level='admin', emailid=None):
     """ on db level we add all users to the operation TEMPLATE for user handling"""
     if None in (path, emailid):
         return False
-    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    APP.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    with APP.app_context():
-        operation = Operation.query.filter_by(path=path).first()
-        if operation:
-            user = User.query.filter_by(emailid=emailid).first()
-            if user:
-                new_permissions = [Permission(user.id, operation.id, access_level)]
-                db.session.add_all(new_permissions)
-                try:
-                    db.session.commit()
-                    return True
-                except IntegrityError as err:
-                    db.session.rollback()
-                    logging.debug("Error writing to db: %s", err)
-                db.session.close()
+    operation = Operation.query.filter_by(path=path).first()
+    if operation:
+        user = User.query.filter_by(emailid=emailid).first()
+        if user:
+            new_permissions = [Permission(user.id, operation.id, access_level)]
+            db.session.add_all(new_permissions)
+            try:
+                db.session.commit()
+                return True
+            except IntegrityError as err:
+                db.session.rollback()
+                logging.debug("Error writing to db: %s", err)
     return False
 
 
@@ -228,20 +198,17 @@ def archive_operation(path=None, emailid=None):
     """ this archives an existing operation """
     if None in (path, emailid):
         return False
-    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    APP.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    with APP.app_context():
-        operation = Operation.query.filter_by(path=path).first()
-        if operation:
-            user = User.query.filter_by(emailid=emailid).first()
-            if user:
-                perm = Permission.query.filter_by(u_id=user.id, op_id=operation.id).first()
-                if perm is None:
-                    return False
-                elif perm.access_level not in ["admin", "creator"]:
-                    return False
-                operation.active = False
-                db.session.commit()
+    operation = Operation.query.filter_by(path=path).first()
+    if operation:
+        user = User.query.filter_by(emailid=emailid).first()
+        if user:
+            perm = Permission.query.filter_by(u_id=user.id, op_id=operation.id).first()
+            if perm is None:
+                return False
+            elif perm.access_level not in ["admin", "creator"]:
+                return False
+            operation.active = False
+            db.session.commit()
 
 
 def seed_data():
@@ -423,17 +390,16 @@ def seed_data():
         db_perm = Permission(perm['u_id'], perm['op_id'], perm['access_level'])
         db.session.add(db_perm)
     db.session.commit()
-    db.session.close()
 
     file_paths = ['one', 'two', 'three', 'four', 'Admin_Test', 'test_mscolab']
     for file_path in file_paths:
-        operation_dir = Path(APP.config['OPERATIONS_DATA']) / file_path
+        operation_dir = Path(current_app.config['OPERATIONS_DATA']) / file_path
         operation_dir.mkdir(parents=True, exist_ok=True)
         operation_file = operation_dir / 'main.ftml'
         operation_file.write_text(XML_CONTENT_INIT)
 
         # initiate git in the same directory where the file is created
-        git_dir = Path(APP.config['OPERATIONS_DATA']) / file_path
+        git_dir = Path(current_app.config['OPERATIONS_DATA']) / file_path
         git_dir.mkdir(parents=True, exist_ok=True)
 
         # Create the main.ftml file in the git directory as well

--- a/mslib/mscolab/server.py
+++ b/mslib/mscolab/server.py
@@ -25,22 +25,18 @@
     limitations under the License.
 """
 import logging
-import socketio
 import hashlib
 
-from flask import jsonify, request, current_app
+from flask import current_app, jsonify, request
 from flask_cors import CORS
 from flask_httpauth import HTTPBasicAuth
 
-from mslib.mscolab.app import create_app, APP
+from mslib.mscolab.app import create_app, initialise_db
+from mslib.mscolab.conf import mscolab_settings
 from mslib.mscolab.sockets_manager import _setup_managers
 
 
-APP = create_app(imprint=APP.config['IMPRINT'], gdpr=APP.config['GDPR'])
 auth = HTTPBasicAuth()
-with APP.app_context():
-    CORS(APP, origins=current_app.config.get('CORS_ORIGINS', ["*"]))
-    current_app.extensions["basic_auth"] = auth
 
 
 try:
@@ -72,45 +68,58 @@ def verify_pw(username, password):
     return authfunc(username, password)
 
 
-with APP.app_context():
-    if current_app.config.get('ENABLE_BASIC_HTTP_AUTHENTICATION', False):
-        logging.debug("Enabling basic HTTP authentication. Username and "
-                      "password required to access the service.")
-        auth.verify_password(verify_pw)
-
-
 def _initialize_managers(app):
     sockio, cm, fm = _setup_managers(app)
     app.extensions['cm'] = cm
     app.extensions['sockio'] = sockio
     app.extensions['fm'] = fm
-    # initializing socketio and db
-    app.wsgi_app = socketio.Middleware(socketio.server, app.wsgi_app)
-    sockio.init_app(app)
-    # db.init_app(app)
+    # initializing socketio, the configuration dependent options are passed here,
+    # because the SocketIO instance itself is created on import, without an app.
+    sockio.init_app(app,
+                    logger=app.config['SOCKETIO_LOGGER'],
+                    engineio_logger=app.config['ENGINEIO_LOGGER'],
+                    cors_allowed_origins=("*" if "*" in app.config['CORS_ORIGINS']
+                                          else app.config['CORS_ORIGINS']))
     return app, sockio, cm, fm
 
 
-_app, sockio, cm, fm = _initialize_managers(APP)
-
-
 # 413: Payload Too Large
-@APP.errorhandler(413)
 def error413(error):
-    upload_limit = APP.config['MAX_CONTENT_LENGTH'] / 1024 / 1024
+    upload_limit = current_app.config['MAX_CONTENT_LENGTH'] / 1024 / 1024
     return jsonify({"success": False, "message": f"File size too large. Upload limit is {upload_limit}MB"}), 413
 
 
+def create_server_app(config_object=mscolab_settings):
+    """Create the MSColab application ready to be served.
+
+    In addition to :func:`mslib.mscolab.app.create_app` this migrates the database
+    to the latest revision and sets up everything only a served app needs: CORS,
+    basic HTTP authentication and the socket.io managers. The managers are
+    available as ``app.extensions['sockio' | 'cm' | 'fm']``.
+    """
+    app = create_app(config_object)
+    with app.app_context():
+        initialise_db()
+
+    CORS(app, origins=app.config.get('CORS_ORIGINS', ["*"]))
+    app.extensions["basic_auth"] = auth
+    if app.config.get('ENABLE_BASIC_HTTP_AUTHENTICATION', False):
+        logging.debug("Enabling basic HTTP authentication. Username and "
+                      "password required to access the service.")
+        auth.verify_password(verify_pw)
+    app.register_error_handler(413, error413)
+
+    _initialize_managers(app)
+    return app
+
+
 def start_server(app, sockio, cm, fm, port=8083):
-    sockio.run(app, port=port, debug=APP.config['DEBUG'])
+    sockio.run(app, port=port, debug=app.config['DEBUG'])
 
 
 def main():
-    start_server(_app, sockio, cm, fm)
-
-
-# for wsgi
-application = socketio.WSGIApp(sockio)
+    app = create_server_app()
+    start_server(app, app.extensions['sockio'], app.extensions['cm'], app.extensions['fm'])
 
 
 if __name__ == '__main__':

--- a/mslib/mscolab/sockets_manager.py
+++ b/mslib/mscolab/sockets_manager.py
@@ -35,16 +35,15 @@ from mslib.mscolab.file_manager import FileManager
 from mslib.mscolab.models import MessageType, Permission, User
 from mslib.mscolab.utils import get_message_dict
 from mslib.mscolab.utils import get_user_id
-from mslib.mscolab.app import APP
 
+# The instance is bound to an app by SocketIO.init_app, which is also where the
+# options depending on the app configuration are passed, see
+# mslib.mscolab.server._initialize_managers.
 # async_handlers=False handles each client's events in the order they were received. With
 # the default (async_handlers=True) every event runs in its own thread, so two rapid
 # file-save events can give a wrong final document data.
-socketio = SocketIO(logger=APP.config['SOCKETIO_LOGGER'], engineio_logger=APP.config['ENGINEIO_LOGGER'],
-                    async_mode='threading',
-                    async_handlers=False,
-                    cors_allowed_origins=("*" if not hasattr(APP, "CORS_ORIGINS") or
-                    "*" in APP.config['CORS_ORIGINS'] else APP.config['CORS_ORIGINS']))
+socketio = SocketIO(async_mode='threading',
+                    async_handlers=False)
 
 
 class SocketsManager:

--- a/tests/_test_mscolab/test_chat_manager.py
+++ b/tests/_test_mscolab/test_chat_manager.py
@@ -38,12 +38,12 @@ class Test_Chat_Manager:
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'User UV'
         self.anotheruserdata = 'UV20@uv20', 'UV20', 'uv20', 'User UVs'
         self.operation_name = "europe"
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        assert add_operation(self.operation_name, "test europe")
-        assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
-        self.user = get_user(self.userdata[0])
-        self.operation = get_operation(self.operation_name)
         with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            assert add_operation(self.operation_name, "test europe")
+            assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
+            self.user = get_user(self.userdata[0])
+            self.operation = get_operation(self.operation_name)
             yield
 
     def test_add_message(self):

--- a/tests/_test_mscolab/test_file_manager.py
+++ b/tests/_test_mscolab/test_file_manager.py
@@ -33,43 +33,44 @@ from werkzeug.datastructures import FileStorage
 
 from mslib.mscolab.models import Operation, User
 from mslib.mscolab.seed import add_user, get_user, add_operation
-from mslib.mscolab.app import APP
 from mslib.mscolab.utils import ATTACHMENTS_URL_PREFIX
 from mslib.mscolab.seed import XML_CONTENT_INIT
+
+from flask import current_app
 
 
 class Test_FileManager:
     @pytest.fixture(autouse=True)
     def setup(self, mscolab_app, mscolab_managers):
-        self.APP = mscolab_app
+        self.app = mscolab_app
         _, _, self.fm = mscolab_managers
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'User UV'
         self.anotheruserdata = 'UV20@uv20', 'UV20', 'uv20', 'User UVs'
 
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        self.user = get_user(self.userdata[0])
-        assert self.user is not None
-        assert add_user(self.anotheruserdata[0], self.anotheruserdata[1], self.anotheruserdata[2],
-                        self.anotheruserdata[3])
-        self.anotheruser = get_user(self.anotheruserdata[0])
-        assert add_user('UV30@uv30', 'UV30', 'uv30', 'User 30')
-        self.vieweruser = get_user('UV30@uv30')
-        assert add_user('UV40@uv40', 'UV40', 'uv40', 'User 40')
-        self.collaboratoruser = get_user('UV40@uv40')
-        assert add_user('UV50@uv50', 'UV50', 'uv50', 'User 50')
-        self.op2user = get_user('UV50@uv50')
-        assert add_user('UV60@uv60', 'UV60', 'uv60', 'User 60')
-        self.op2vieweruser = get_user('UV60@uv60')
-        assert add_user('UV70@uv70', 'UV70', 'uv70', 'User 70')
-        self.user1 = get_user('UV70@uv70')
-        assert add_user('UV80@uv80', 'UV80', 'uv80', 'User 80')
-        self.adminuser = get_user('UV80@uv80')
-        self._example_data()
-        with self.APP.app_context():
+        with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            self.user = get_user(self.userdata[0])
+            assert self.user is not None
+            assert add_user(self.anotheruserdata[0], self.anotheruserdata[1], self.anotheruserdata[2],
+                            self.anotheruserdata[3])
+            self.anotheruser = get_user(self.anotheruserdata[0])
+            assert add_user('UV30@uv30', 'UV30', 'uv30', 'User 30')
+            self.vieweruser = get_user('UV30@uv30')
+            assert add_user('UV40@uv40', 'UV40', 'uv40', 'User 40')
+            self.collaboratoruser = get_user('UV40@uv40')
+            assert add_user('UV50@uv50', 'UV50', 'uv50', 'User 50')
+            self.op2user = get_user('UV50@uv50')
+            assert add_user('UV60@uv60', 'UV60', 'uv60', 'User 60')
+            self.op2vieweruser = get_user('UV60@uv60')
+            assert add_user('UV70@uv70', 'UV70', 'uv70', 'User 70')
+            self.user1 = get_user('UV70@uv70')
+            assert add_user('UV80@uv80', 'UV80', 'uv80', 'User 80')
+            self.adminuser = get_user('UV80@uv80')
+            self._example_data()
             yield
 
     def test_modify_user(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             user = User("user@example.com", "user", "password")
             assert user.id is None
             assert User.query.filter_by(emailid=user.emailid).first() is None
@@ -103,7 +104,7 @@ class Test_FileManager:
         assert self.fm.modify_user(user_query1, "emailid", user2.emailid) is False
 
     def test_fetch_operation_creator(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="more_than_one")
             self.fm.add_bulk_permission(operation.id, self.user, [self.collaboratoruser.id], "collaborator")
             self.fm.add_bulk_permission(operation.id, self.user, [self.vieweruser.id], "viewer")
@@ -119,7 +120,7 @@ class Test_FileManager:
             assert self.fm.fetch_operation_creator(operation.id, self.op2user.id) is False
 
     def test_create_operation(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="famous")
             assert operation.path == flight_path
             assert self.fm.create_operation(flight_path, "something to know", self.user,
@@ -128,7 +129,7 @@ class Test_FileManager:
             assert operation.path == flight_path
 
     def test_get_operation_details(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path='operation2')
             pd = self.fm.get_operation_details(operation.id, self.user)
             assert pd['description'] == operation.description
@@ -136,7 +137,7 @@ class Test_FileManager:
             assert pd['id'] == operation.id
 
     def test_list_operations(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             self.fm.create_operation("first", "info about first", self.user, content=XML_CONTENT_INIT)
             self.fm.create_operation("second", "info about second", self.user, content=XML_CONTENT_INIT)
             expected_result = [{'access_level': 'creator',
@@ -154,7 +155,7 @@ class Test_FileManager:
             assert self.fm.list_operations(self.user) == expected_result
 
     def test_list_operations_skip_archived(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             self.fm.create_operation("first", "info about first", self.user, content=XML_CONTENT_INIT, active=False)
             self.fm.create_operation("second", "info about second", self.user, content=XML_CONTENT_INIT)
             expected_result_all = [{'access_level': 'creator',
@@ -179,19 +180,19 @@ class Test_FileManager:
             assert self.fm.list_operations(self.user, skip_archived=True) == expected_result_skipped_true
 
     def test_is_creator(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path='third')
             assert self.fm.is_creator(self.user.id, operation.id)
 
     def test_is_collaborator(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path='fourth')
             assert self.anotheruser.id is not None
             self.fm.add_bulk_permission(operation.id, self.user, [self.anotheruser.id], "collaborator")
             assert self.fm.is_collaborator(self.anotheruser.id, operation.id)
 
     def test_is_non_admin_member(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path='fifth')
             assert self.anotheruser.id is not None
             self.fm.add_bulk_permission(operation.id, self.user, [self.vieweruser.id], "viewer")
@@ -199,7 +200,7 @@ class Test_FileManager:
             assert self.fm.is_admin(self.vieweruser.id, operation.id) is False
 
     def test_is_viewer(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="test_flight")
             assert operation.path == flight_path
             self.fm.add_bulk_permission(operation.id, self.user, [self.vieweruser.id], "viewer")
@@ -215,20 +216,20 @@ class Test_FileManager:
             assert self.fm.is_viewer(self.user.id, operation.id) is False
 
     def test_is_member(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="sunset")
             assert operation.path == flight_path
             assert self.fm.is_member(82322, operation.id) is False
             assert self.fm.is_member(self.user.id, operation.id) is True
 
     def test_auth_type(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="aa")
             assert self.fm.auth_type(self.user.id, operation.id) != "collaborator"
             assert self.fm.auth_type(self.user.id, operation.id) == "creator"
 
     def test_update_operation(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path='operation3')
             rename_to = "operation03"
             self.fm.update_operation(operation.id, "path", rename_to, self.user)
@@ -237,19 +238,19 @@ class Test_FileManager:
             assert ren_operation.path == rename_to
 
     def test_delete_operation(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path='operation4')
             assert self.fm.delete_operation(operation.id, self.user)
             assert Operation.query.filter_by(path=flight_path).first() is None
 
     def test_get_authorized_users(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path='operation5')
             assert self.fm.get_authorized_users(operation.id) == [{'access_level': 'creator',
                                                                    'username': self.userdata[1], 'id': 1}]
 
     def test_save_file(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="operation6", content=self.content1)
             # nothing changed
             assert self.fm.save_file(operation.id, self.content1, self.user) is False
@@ -286,7 +287,7 @@ class Test_FileManager:
 
         upload_folder = tmp_path / "uploadshaha"
         sample_path = os.path.join(os.path.dirname(__file__), "..", "data")
-        with mock.patch.dict(APP.config, {'UPLOAD_FOLDER': str(upload_folder)}):
+        with mock.patch.dict(current_app.config, {'UPLOAD_FOLDER': str(upload_folder)}):
             with open(os.path.join(sample_path, "example.csv"), 'rb') as fp:
                 file = FileStorage(fp, filename="example.csv", content_type="text/csv")
                 static_path = self.fm.upload_file(file, subfolder=str(operation.id), include_prefix=True)
@@ -308,7 +309,7 @@ class Test_FileManager:
             subfolder = 'test_subfolder'
             identifier = 'unique_identifier'
             relative_path = self.fm.upload_file(file, subfolder=subfolder, identifier=identifier)
-            full_path = os.path.join(APP.config['UPLOAD_FOLDER'], relative_path)
+            full_path = os.path.join(current_app.config['UPLOAD_FOLDER'], relative_path)
 
             assert os.path.isfile(full_path)
             assert identifier in relative_path
@@ -320,12 +321,12 @@ class Test_FileManager:
                 assert uploaded_file_content == file_content
 
     def test_get_file(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="operation7")
             assert self.fm.get_file(operation.id, self.user).startswith('<?xml version="1.0" encoding="utf-8"?>')
 
     def test_get_all_changes(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="operation8")
             assert self.fm.get_all_changes(operation.id, self.user) == []
             assert self.fm.save_file(operation.id, self.content1, self.user)
@@ -334,7 +335,7 @@ class Test_FileManager:
             assert len(changes) == 2
 
     def test_get_change_content(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="operation8")
             assert self.fm.get_all_changes(operation.id, self.user) == []
             assert self.fm.save_file(operation.id, self.content1, self.user)
@@ -343,7 +344,7 @@ class Test_FileManager:
             assert self.fm.get_change_content(all_changes[1]["id"], self.user) == self.content1
 
     def test_set_version_name(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="operation8")
             assert self.fm.get_all_changes(operation.id, self.user) == []
             assert self.fm.save_file(operation.id, self.content1, self.user)
@@ -361,7 +362,7 @@ class Test_FileManager:
             assert self.fm.set_version_name(all_changes[1]["id"], operation.id, self.vieweruser.id, "THIS") is False
 
     def test_undo(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="operation8")
             assert self.fm.get_all_changes(operation.id, self.user) == []
             assert self.fm.save_file(operation.id, self.content1, self.user)
@@ -379,17 +380,17 @@ class Test_FileManager:
             assert self.fm.undo_changes(all_changes[1]["id"], self.vieweruser) is False
 
     def test_fetch_users_without_permission(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="operation9")
             assert len(self.fm.fetch_users_without_permission(operation.id, self.user.id)) == 7
 
     def test_fetch_users_with_permission(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="operation9")
             assert self.fm.fetch_users_with_permission(operation.id, self.user.id) == []
 
     def test_delete_bulk_permission_for_creators(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation1 = self._create_operation(flight_path="testflight", user=self.user)
             assert self.fm.is_creator(self.user.id, operation1.id)
             assert self.user.id is not None
@@ -410,7 +411,7 @@ class Test_FileManager:
             assert self.fm.delete_bulk_permission(operation2.id, self.op2user, [self.anotheruser.id]) is False
 
     def test_delete_bulk_permission_for_members(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation1 = self._create_operation(flight_path="testflight", user=self.user)
             assert self.fm.is_creator(self.user.id, operation1.id)
             assert self.user.id is not None
@@ -440,7 +441,7 @@ class Test_FileManager:
             ) is False
 
     def test_delete_bulk_permission_for_non_members(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation1 = self._create_operation(flight_path="testflight", user=self.user)
             assert self.fm.is_creator(self.user.id, operation1.id)
             assert self.user.id is not None
@@ -456,7 +457,7 @@ class Test_FileManager:
         # admin is a role to add users.
         # the creator has also this role. But there could be more admins
         # admins have the right to remove themselves
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path, operation = self._create_operation(flight_path="saturn")
             assert operation.path == flight_path
             self.fm.add_bulk_permission(operation.id, self.user, [self.adminuser.id], "admin")
@@ -465,7 +466,7 @@ class Test_FileManager:
             assert self.fm.delete_bulk_permission(operation.id, self.adminuser, [self.adminuser.id]) is True
 
     def test_group_permissions(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path_oslo, operation_oslo = self._create_operation(flight_path="flightoslo", category="oslo")
 
             flight_path_no1, operation_no_1 = self._create_operation(flight_path="flightno1", category="bergen")
@@ -490,7 +491,7 @@ class Test_FileManager:
             assert self.fm.is_member(self.collaboratoruser.id, operation_group.id) is False
 
     def test_existing_operation_renaming_to_a_group(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             _, operation_b1 = self._create_operation(flight_path="flightb1", category="morning")
             self.fm.add_bulk_permission(operation_b1.id, self.user, [self.collaboratoruser.id], "collaborator")
             assert self.fm.is_collaborator(self.collaboratoruser.id, operation_b1.id)
@@ -513,7 +514,7 @@ class Test_FileManager:
             assert self.fm.is_collaborator(self.collaboratoruser.id, operation_b2.id) is False
 
     def test_import_permission(self):
-        with self.APP.test_client():
+        with self.app.test_client():
             flight_path10, operation10 = self._create_operation(flight_path="operation10")
             flight_path11, operation11 = self._create_operation(flight_path="operation11")
             flight_path12, operation12 = self._create_operation(flight_path="operation12", user=self.anotheruser)

--- a/tests/_test_mscolab/test_files.py
+++ b/tests/_test_mscolab/test_files.py
@@ -28,7 +28,7 @@
 import os
 import pytest
 
-from mslib.mscolab.app import APP
+from flask import current_app
 from mslib.mscolab.models import User, Operation, Permission, Change, Message
 from mslib.mscolab.seed import add_user, get_user
 from mslib.mscolab.utils import get_recent_op_id
@@ -45,15 +45,15 @@ class Test_Files:
         self.userdata = 'UV11@uv11', 'UV11', 'uv11', 'User UV'
         self.userdata2 = 'UV12@uv12', 'UV12', 'uv12', 'User UVs'
 
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        assert add_user(self.userdata2[0], self.userdata2[1], self.userdata2[2], self.userdata2[3])
-
-        self.user = get_user(self.userdata[0])
-        self.user2 = get_user(self.userdata2[0])
-        assert self.user is not None
-        self.file_message_counter = [0] * 2
-        self._example_data()
         with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            assert add_user(self.userdata2[0], self.userdata2[1], self.userdata2[2], self.userdata2[3])
+
+            self.user = get_user(self.userdata[0])
+            self.user2 = get_user(self.userdata2[0])
+            assert self.user is not None
+            self.file_message_counter = [0] * 2
+            self._example_data()
             yield
 
     def test_create_operation(self):
@@ -65,7 +65,7 @@ class Test_Files:
             # test for '/' in path
             assert self.fm.create_operation('test/path', 'sth', self.user, content=XML_CONTENT_INIT) is False
             # check file existence
-            assert os.path.exists(os.path.join(APP.config['OPERATIONS_DATA'], 'test_path')) is True
+            assert os.path.exists(os.path.join(current_app.config['OPERATIONS_DATA'], 'test_path')) is True
             # check creation in db
             p = Operation.query.filter_by(path="test_path").first()
             assert p is not None
@@ -167,7 +167,7 @@ class Test_Files:
             assert self.fm.update_operation(op_id, 'path', 'dummy wrong', self.user) is False
             assert self.fm.update_operation(op_id, 'path', 'dummy/wrong', self.user) is False
             assert self.fm.update_operation(op_id, 'path', 'dummy', self.user) is True
-            assert os.path.exists(os.path.join(APP.config['OPERATIONS_DATA'], 'dummy'))
+            assert os.path.exists(os.path.join(current_app.config['OPERATIONS_DATA'], 'dummy'))
             assert self.fm.update_operation(op_id, 'description', 'dummy', self.user) is True
 
     def test_delete_operation(self):

--- a/tests/_test_mscolab/test_files_api.py
+++ b/tests/_test_mscolab/test_files_api.py
@@ -39,12 +39,12 @@ class Test_Files:
         self.app = mscolab_app
         _, _, self.fm = mscolab_managers
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'User UV'
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        self.user = get_user(self.userdata[0])
-        assert self.user is not None
-        assert add_user('UV20@uv20', 'UV20', 'uv20', 'UserUV20')
-        self.user_2 = get_user('UV20@uv20')
         with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            self.user = get_user(self.userdata[0])
+            assert self.user is not None
+            assert add_user('UV20@uv20', 'UV20', 'uv20', 'UserUV20')
+            self.user_2 = get_user('UV20@uv20')
             yield
 
     def test_create_operation(self):

--- a/tests/_test_mscolab/test_migrations.py
+++ b/tests/_test_mscolab/test_migrations.py
@@ -24,14 +24,14 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import copy
 import pytest
 import itertools
-import flask
 import flask_migrate
 import sqlalchemy
 import mslib.mscolab.migrations
-from mslib.mscolab.app import db, migrate
-from mslib.mscolab.app import APP
+from mslib.mscolab.app import create_app, db
+from mslib.mscolab.conf import mscolab_settings
 
 
 def test_migrations(mscolab_app):
@@ -74,15 +74,11 @@ _cases = list(
 def test_upgrade_from(revision, iterations, mscolab_app, tmp_path):
     """Test upgrading from a pre-v10 database that wasn't yet automatically managed with flask-migrate."""
     migrations_path = mslib.mscolab.migrations.__path__[0]
-    # Construct a dummy flask app to create a separate database to migrate from
-    # TODO: this would be easier if it was possible to create multiple canonical MSColab Flask app instances,
-    # i.e. if there was a factory function instead of one global instance. This test could then check the correct
-    # functioning of the data migration while creating such an app instance, instead of having to call a private method.
-    app = flask.Flask("whatever")
+    # Construct a second app instance to create a separate database to migrate from
     # TODO: make this somehow configurable to use something other than sqlite as the source database
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///" + str(tmp_path.absolute() / "mscolab.db")
-    db.init_app(app)
-    migrate.init_app(app, db)
+    source_settings = copy.copy(mscolab_settings)
+    source_settings.SQLALCHEMY_DATABASE_URI = "sqlite:///" + str(tmp_path.absolute() / "mscolab.db")
+    app = create_app(source_settings)
     with app.app_context():
         # Seed the database and downgrade to the supplied revision
         mslib.mscolab.mscolab.handle_db_seed()
@@ -97,7 +93,7 @@ def test_upgrade_from(revision, iterations, mscolab_app, tmp_path):
         del expected_data["alembic_version"]  # the alembic_version table will be different, but that is expected
 
     try:
-        APP.config['SQLALCHEMY_DATABASE_URI_TO_MIGRATE_FROM'] = app.config["SQLALCHEMY_DATABASE_URI"]
+        mscolab_app.config['SQLALCHEMY_DATABASE_URI_TO_MIGRATE_FROM'] = app.config["SQLALCHEMY_DATABASE_URI"]
         with mscolab_app.app_context():
             db.drop_all()
             db.session.execute(sqlalchemy.text("DROP TABLE alembic_version"))
@@ -108,7 +104,7 @@ def test_upgrade_from(revision, iterations, mscolab_app, tmp_path):
 
             # Also try multiple applications of the db upgrade to ensure idempotence of the operation
             for _ in range(iterations):
-                mslib.mscolab.app._handle_db_upgrade()
+                mslib.mscolab.app.initialise_db()
 
             # Check that no further migration is required
             flask_migrate.check(directory=migrations_path)
@@ -134,4 +130,4 @@ def test_upgrade_from(revision, iterations, mscolab_app, tmp_path):
             flask_migrate.upgrade(directory=migrations_path)
             assert mslib.mscolab.seed.add_user('test123@test456', 'test123', 'test456', 'User test789')
     finally:
-        APP.config['SQLALCHEMY_DATABASE_URI_TO_MIGRATE_FROM'] = None
+        mscolab_app.config['SQLALCHEMY_DATABASE_URI_TO_MIGRATE_FROM'] = None

--- a/tests/_test_mscolab/test_mscolab.py
+++ b/tests/_test_mscolab/test_mscolab.py
@@ -29,7 +29,7 @@ import mock
 import argparse
 from pathlib import Path
 
-from mslib.mscolab.app import APP
+from flask import current_app
 from mslib.mscolab.models import Operation, User, Permission
 from mslib.mscolab.mscolab import handle_db_reset, handle_db_seed, confirm_action, main
 from mslib.mscolab.seed import add_operation
@@ -72,22 +72,22 @@ class Test_Mscolab:
         assert Permission.query.all() == []
 
     def test_handle_db_reset(self):
-        assert Path(APP.config['UPLOAD_FOLDER']).exists()
-        assert Path(APP.config['OPERATIONS_DATA']).exists()
+        assert Path(current_app.config['UPLOAD_FOLDER']).exists()
+        assert Path(current_app.config['OPERATIONS_DATA']).exists()
         all_operations = Operation.query.all()
         assert all_operations == []
         operation_name = "Example"
         assert add_operation(operation_name, "Test_Example")
-        assert (Path(APP.config['OPERATIONS_DATA']) / operation_name).exists()
+        assert (Path(current_app.config['OPERATIONS_DATA']) / operation_name).exists()
         operation = Operation.query.filter_by(path=operation_name).first()
         assert operation.description == "Test_Example"
         all_operations = Operation.query.all()
         assert len(all_operations) == 1
         handle_db_reset()
         # check operation dir name removed
-        assert (Path(APP.config['OPERATIONS_DATA']) / operation_name).exists() is False
-        assert Path(APP.config['OPERATIONS_DATA']).exists()
-        assert Path(APP.config['UPLOAD_FOLDER']).exists()
+        assert (Path(current_app.config['OPERATIONS_DATA']) / operation_name).exists() is False
+        assert Path(current_app.config['OPERATIONS_DATA']).exists()
+        assert Path(current_app.config['UPLOAD_FOLDER']).exists()
         # query db for operation_name
         operation = Operation.query.filter_by(path=operation_name).first()
         assert operation is None

--- a/tests/_test_mscolab/test_seed.py
+++ b/tests/_test_mscolab/test_seed.py
@@ -42,11 +42,11 @@ class Test_Seed:
         self.userdata_1 = "UV1@uv1", "UV1", "UV1", "Userb UV"
         self.userdata_2 = "UV2@v2", "V2", "v2", "Userc UV"
 
-        assert add_user(self.userdata_0[0], self.userdata_0[1], self.userdata_0[2], self.userdata_0[3])
-        assert add_operation(self.operation_name, self.description)
-        assert add_user_to_operation(path=self.operation_name, emailid=self.userdata_0[0])
-        self.user = User(self.userdata_0[0], self.userdata_0[1], self.userdata_0[2])
         with self.app.app_context():
+            assert add_user(self.userdata_0[0], self.userdata_0[1], self.userdata_0[2], self.userdata_0[3])
+            assert add_operation(self.operation_name, self.description)
+            assert add_user_to_operation(path=self.operation_name, emailid=self.userdata_0[0])
+            self.user = User(self.userdata_0[0], self.userdata_0[1], self.userdata_0[2])
             yield
 
     def test_add_operation(self):

--- a/tests/_test_mscolab/test_sockets_manager.py
+++ b/tests/_test_mscolab/test_sockets_manager.py
@@ -29,7 +29,6 @@ import pytest
 import datetime
 
 from mslib.msui.icons import icons
-from mslib.mscolab.app import APP
 from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_operation, get_operation
 from mslib.mscolab.models import Permission, User, Message, MessageType
 
@@ -44,15 +43,16 @@ class Test_Socket_Manager:
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'User UV'
         self.anotheruserdata = 'UV20@uv20', 'UV20', 'uv20', 'User UVs'
         self.operation_name = "europe"
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        assert add_operation(self.operation_name, "test europe")
-        assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
-        self.user = get_user(self.userdata[0])
-        assert add_user(self.anotheruserdata[0], self.anotheruserdata[1], self.anotheruserdata[2],
-                        self.anotheruserdata[3])
-        self.anotheruser = get_user(self.anotheruserdata[0])
-        self.token = self.user.generate_auth_token()
-        self.operation = get_operation(self.operation_name)
+        with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            assert add_operation(self.operation_name, "test europe")
+            assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
+            self.user = get_user(self.userdata[0])
+            assert add_user(self.anotheruserdata[0], self.anotheruserdata[1], self.anotheruserdata[2],
+                            self.anotheruserdata[3])
+            self.anotheruser = get_user(self.anotheruserdata[0])
+            self.token = self.user.generate_auth_token()
+            self.operation = get_operation(self.operation_name)
         yield
         for sock in self.sockets:
             sock.disconnect()
@@ -64,8 +64,9 @@ class Test_Socket_Manager:
         return sio
 
     def _new_operation(self, operation_name, description):
-        assert add_operation(operation_name, description)
-        operation = get_operation(operation_name)
+        with self.app.app_context():
+            assert add_operation(operation_name, description)
+            operation = get_operation(operation_name)
         return operation
 
     def test_handle_connect(self):
@@ -112,7 +113,8 @@ class Test_Socket_Manager:
         assert received_message_args["count"] == 1
 
         # Testing with multiple users
-        add_user_to_operation(path=self.operation_name, emailid=self.anotheruserdata[0])
+        with self.app.app_context():
+            add_user_to_operation(path=self.operation_name, emailid=self.anotheruserdata[0])
         another_sio = self._connect()
         another_sio.emit("operation-selected",
                          {"token": self.anotheruser.generate_auth_token(), "op_id": self.operation.id})
@@ -277,7 +279,7 @@ class Test_Socket_Manager:
         }
         with self.app.test_client() as c:
             c.post("message_attachment", data=data, content_type="multipart/form-data")
-        upload_dir = os.path.join(APP.config['UPLOAD_FOLDER'], str(self.user.id))
+        upload_dir = os.path.join(self.app.config['UPLOAD_FOLDER'], str(self.user.id))
         assert os.path.exists(upload_dir)
         file = os.listdir(upload_dir)[0]
         assert 'mss-logo' in file

--- a/tests/_test_mscolab/test_utils.py
+++ b/tests/_test_mscolab/test_utils.py
@@ -28,13 +28,15 @@ import os
 import pytest
 import json
 
-from mslib.mscolab.app import APP, create_files
+from mslib.mscolab.app import create_files
 from mslib.mscolab.models import Operation, Message, MessageType, User
 from mslib.mscolab.seed import add_user, get_user
 from mslib.mscolab.utils import (get_recent_op_id, get_session_id,
                                  get_message_dict,
                                  get_user_id)
 from mslib.mscolab.seed import XML_CONTENT_INIT
+
+from flask import current_app
 
 
 class Test_Utils:
@@ -77,8 +79,8 @@ class Test_Utils:
 
     def test_create_file(self):
         create_files()
-        assert os.path.exists(APP.config['OPERATIONS_DATA'])
-        assert os.path.exists(APP.config['UPLOAD_FOLDER'])
+        assert os.path.exists(current_app.config['OPERATIONS_DATA'])
+        assert os.path.exists(current_app.config['UPLOAD_FOLDER'])
 
     def _create_operation(self, test_client, userdata=None, path="firstflight",
                           description="simple test", content=XML_CONTENT_INIT):

--- a/tests/_test_msui/test_mscolab.py
+++ b/tests/_test_msui/test_mscolab.py
@@ -49,14 +49,16 @@ from mslib.mscolab.seed import add_user, get_user, add_operation, add_user_to_op
 
 class Test_Mscolab_connect_window:
     @pytest.fixture(autouse=True)
-    def setup(self, qtbot, mscolab_server):
+    def setup(self, qtbot, mscolab_app, mscolab_server):
+        self.app = mscolab_app
         self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'User UV'
         self.operation_name = "europe"
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        assert add_operation(self.operation_name, "test europe")
-        assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
-        self.user = get_user(self.userdata[0])
+        with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            assert add_operation(self.operation_name, "test europe")
+            assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
+            self.user = get_user(self.userdata[0])
 
         self.main_window = msui.MSUIMainWindow(local_operations_data=ROOT_DIR)
         self.main_window.create_new_flight_track()
@@ -266,20 +268,22 @@ class Test_Mscolab:
         self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'UserUV10'
         self.operation_name = "europe"
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        assert add_operation(self.operation_name, "test europe")
-        assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
-        self.user = get_user(self.userdata[0])
-
         self.userdata2 = 'sree@sree.org', 'sree', 'sree', 'Sree'
         self.operation_name3 = "kerala"
-        assert add_user(self.userdata2[0], self.userdata2[1], self.userdata2[2], self.userdata2[3])
-        assert add_operation(self.operation_name3, "test kerala")
-        assert add_user_to_operation(path=self.operation_name3, emailid=self.userdata2[0])
-
         self.userdata3 = 'anand@anand.org', 'anand', 'anand', 'Anand Kumar'
-        assert add_user(self.userdata3[0], self.userdata3[1], self.userdata3[2], self.userdata3[3])
-        assert add_user_to_operation(path=self.operation_name3, access_level="collaborator", emailid=self.userdata3[0])
+        with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            assert add_operation(self.operation_name, "test europe")
+            assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
+            self.user = get_user(self.userdata[0])
+
+            assert add_user(self.userdata2[0], self.userdata2[1], self.userdata2[2], self.userdata2[3])
+            assert add_operation(self.operation_name3, "test kerala")
+            assert add_user_to_operation(path=self.operation_name3, emailid=self.userdata2[0])
+
+            assert add_user(self.userdata3[0], self.userdata3[1], self.userdata3[2], self.userdata3[3])
+            assert add_user_to_operation(path=self.operation_name3, access_level="collaborator",
+                                         emailid=self.userdata3[0])
 
         self.window = msui.MSUIMainWindow(local_operations_data=ROOT_DIR)
         self.window.create_new_flight_track()
@@ -382,8 +386,9 @@ class Test_Mscolab:
         """
         # more operations for the user
         for op_name in ["second", "third"]:
-            assert add_operation(op_name, "description")
-            assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+            with self.app.app_context():
+                assert add_operation(op_name, "description")
+                assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
 
         self._connect_to_mscolab(qtbot)
         modify_config_file({"MSS_auth": {self.url: self.userdata[0]}})
@@ -457,8 +462,9 @@ class Test_Mscolab:
         """
         # more operations for the user
         for op_name in ["second", "third"]:
-            assert add_operation(op_name, "description")
-            assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+            with self.app.app_context():
+                assert add_operation(op_name, "description")
+                assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
 
         self._connect_to_mscolab(qtbot)
         modify_config_file({"MSS_auth": {self.url: self.userdata[0]}})
@@ -500,8 +506,9 @@ class Test_Mscolab:
         """
         # more operations for the user
         for op_name in ["second", "third"]:
-            assert add_operation(op_name, "description")
-            assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+            with self.app.app_context():
+                assert add_operation(op_name, "description")
+                assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
 
         self._connect_to_mscolab(qtbot)
         modify_config_file({"MSS_auth": {self.url: self.userdata[0]}})
@@ -529,8 +536,9 @@ class Test_Mscolab:
         """
         # more operations for the user
         for op_name in ["second", "third"]:
-            assert add_operation(op_name, "description")
-            assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
+            with self.app.app_context():
+                assert add_operation(op_name, "description")
+                assert add_user_to_operation(path=op_name, emailid=self.userdata[0])
 
         self._connect_to_mscolab(qtbot)
         modify_config_file({"MSS_auth": {self.url: self.userdata[0]}})

--- a/tests/_test_msui/test_mscolab_admin_window.py
+++ b/tests/_test_msui/test_mscolab_admin_window.py
@@ -37,26 +37,28 @@ from mslib.utils.config import modify_config_file
 
 class Test_MscolabAdminWindow:
     @pytest.fixture(autouse=True)
-    def setup(self, qtbot, mscolab_server):
+    def setup(self, qtbot, mscolab_app, mscolab_server):
+        self.app = mscolab_app
         self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'User UV'
         self.operation_name = "europe"
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        assert add_operation(self.operation_name, "test europe")
-        assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0], access_level="creator")
-        self.user = get_user(self.userdata[0])
-        assert add_user("collaborator@example.de", "example", "example", "Example")
-        assert add_user_to_operation(path=self.operation_name,
-                                     emailid="collaborator@example.de", access_level="collaborator")
-        assert add_user("viewer@example.de", "viewer", "viewer", "Viewer")
-        assert add_user_to_operation(path=self.operation_name, emailid="viewer@example.de", access_level="viewer")
-        assert add_user("name1@example.de", "name1", "name1", "Name1")
-        assert add_user("name2@example.de", "name2", "name2", "Name2")
-        assert add_operation("paris", "test paris")
-        assert add_user_to_operation(path="paris", emailid=self.userdata[0], access_level="creator")
-        assert add_user_to_operation(path="paris", emailid="name1@example.de")
-        assert add_operation("tokyo", "test tokyo")
-        assert add_user_to_operation(path="tokyo", emailid=self.userdata[0], access_level="creator")
+        with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            assert add_operation(self.operation_name, "test europe")
+            assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0], access_level="creator")
+            self.user = get_user(self.userdata[0])
+            assert add_user("collaborator@example.de", "example", "example", "Example")
+            assert add_user_to_operation(path=self.operation_name,
+                                         emailid="collaborator@example.de", access_level="collaborator")
+            assert add_user("viewer@example.de", "viewer", "viewer", "Viewer")
+            assert add_user_to_operation(path=self.operation_name, emailid="viewer@example.de", access_level="viewer")
+            assert add_user("name1@example.de", "name1", "name1", "Name1")
+            assert add_user("name2@example.de", "name2", "name2", "Name2")
+            assert add_operation("paris", "test paris")
+            assert add_user_to_operation(path="paris", emailid=self.userdata[0], access_level="creator")
+            assert add_user_to_operation(path="paris", emailid="name1@example.de")
+            assert add_operation("tokyo", "test tokyo")
+            assert add_user_to_operation(path="tokyo", emailid=self.userdata[0], access_level="creator")
 
         self.window = msui.MSUIMainWindow(local_operations_data=constants.MSCOLAB_DATA_DIR)
         self.window.create_new_flight_track()

--- a/tests/_test_msui/test_mscolab_operation.py
+++ b/tests/_test_msui/test_mscolab_operation.py
@@ -52,10 +52,11 @@ class Test_MscolabOperation:
         self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'User UV'
         self.operation_name = "europe"
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        assert add_operation(self.operation_name, "test europe")
-        assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
-        self.user = get_user(self.userdata[0])
+        with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            assert add_operation(self.operation_name, "test europe")
+            assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
+            self.user = get_user(self.userdata[0])
         self.window = msui.MSUIMainWindow(local_operations_data=ROOT_DIR)
         self.window.create_new_flight_track()
         self.window.show()

--- a/tests/_test_msui/test_mscolab_version_history.py
+++ b/tests/_test_msui/test_mscolab_version_history.py
@@ -37,14 +37,16 @@ from mslib.utils.config import modify_config_file
 
 class Test_MscolabVersionHistory:
     @pytest.fixture(autouse=True)
-    def setup(self, qtbot, mscolab_server):
+    def setup(self, qtbot, mscolab_app, mscolab_server):
+        self.app = mscolab_app
         self.url = mscolab_server
         self.userdata = 'UV10@uv10', 'UV10', 'uv10', 'User UV'
         self.operation_name = "europe"
-        assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
-        assert add_operation(self.operation_name, "test europe")
-        assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
-        self.user = get_user(self.userdata[0])
+        with self.app.app_context():
+            assert add_user(self.userdata[0], self.userdata[1], self.userdata[2], self.userdata[3])
+            assert add_operation(self.operation_name, "test europe")
+            assert add_user_to_operation(path=self.operation_name, emailid=self.userdata[0])
+            self.user = get_user(self.userdata[0])
         self.window = msui.MSUIMainWindow(local_operations_data=ROOT_DIR)
         self.window.create_new_flight_track()
         self.window.show()

--- a/tests/_test_utils/test_index.py
+++ b/tests/_test_utils/test_index.py
@@ -34,8 +34,9 @@ def test_xstatic():
 
 
 def test_app_loader():
-    assert app.APP.config['DOCS_SERVER_PATH'].endswith('mslib')
-    with app.APP.test_client() as c:
+    application = app.create_app()
+    assert application.config['DOCS_SERVER_PATH'].endswith('mslib')
+    with application.test_client() as c:
         response = c.get('/xstatic/bootstrap/css/bootstrap.css')
         assert response.status_code == 200
         response = c.get('mss_theme/img/wise12_overview.png')

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -29,12 +29,13 @@ import multiprocessing
 import time
 import urllib
 import socketio
+
 import mslib.mswms.mswms
 from werkzeug.serving import make_server
 
 from PyQt5 import QtWidgets
 from contextlib import contextmanager
-from mslib.mscolab.server import APP, sockio, cm, fm
+from mslib.mscolab.server import create_server_app
 from mslib.mscolab.mscolab import handle_db_reset
 from mslib.utils.config import modify_config_file
 from tests.utils import is_url_response_ok
@@ -98,11 +99,7 @@ def mscolab_session_app():
     This fixture should not be used in tests. Instead use :func:`mscolab_app`, which
     handles per-test cleanup as well.
     """
-    _app = APP
-    _app.config['SQLALCHEMY_DATABASE_URI'] = APP.config['SQLALCHEMY_DATABASE_URI']
-    _app.config['OPERATIONS_DATA'] = APP.config['OPERATIONS_DATA']
-    _app.config['UPLOAD_FOLDER'] = APP.config['UPLOAD_FOLDER']
-    return _app
+    return create_server_app()
 
 
 @pytest.fixture(scope="session")
@@ -112,7 +109,9 @@ def mscolab_session_managers(mscolab_session_app):
     This fixture should not be used in tests. Instead use :func:`mscolab_managers`,
     which handles per-test cleanup as well.
     """
-    return sockio, cm, fm
+    return (mscolab_session_app.extensions['sockio'],
+            mscolab_session_app.extensions['cm'],
+            mscolab_session_app.extensions['fm'])
 
 
 # TODO: Having this fixture be autouse is a crutch. It seems like if it is not autouse some tests can bring the pytest


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #2442 

**Does this PR introduce a breaking change?**
Commit 6779420 replaced the global APP with an AppFactory. Without a global app, there’s no longer a way to access the config or DB session from anywhere—both are now handled via `current_app` and `db.session`, respectively, and these only work within an application context. As a result, the context shifts from the called functions to the caller.

Previously, virtually every function in `seed.py` had its own mini-context:

def add_user(...):
    APP.config[‘SQLALCHEMY_DATABASE_URI’]=APP.config[‘SQLALCHEMY_DATABASE_URI’] 
    with APP.app_context():
        ...

This only worked because there was exactly one app that the module could pin itself to upon import. With the factory, it is no longer up to the function to decide in which app it runs—only the caller knows that.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
test succeeded, not manually verified 

**Additional information for reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Does this PR results in some Documentation changes?**
_If yes, include the list of Documentation changes_

**Checklist:**
- [ ] Bug fix. Fixes #<issue number>
- [ ] New feature (Non-API breaking changes that adds functionality)
- [ ] PR Title follows the convention of  `<type>: <subject>`
- [x] Commit has unit tests

small corrections by claude